### PR TITLE
Fix docs deploy: disable AOT on Playground.Wasm

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,10 +45,6 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-
 
-      # Required by Playground.Wasm's Release AOT compilation.
-      - name: Install wasm-tools workload
-        run: dotnet workload install wasm-tools
-
       - name: Restore
         run: dotnet restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,6 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-
 
-      # Required by Playground.Wasm's Release AOT compilation.
-      - name: Install wasm-tools workload
-        run: dotnet workload install wasm-tools
-
       - name: Restore
         run: dotnet restore
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,10 +26,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # Required by Playground.Wasm's Release AOT compilation.
-      - name: Install wasm-tools workload
-        run: dotnet workload install wasm-tools
-
       - name: Publish ExpressiveSharp Playground (Blazor WASM)
         run: |
           dotnet publish src/Docs/Playground.Wasm/ExpressiveSharp.Docs.Playground.Wasm.csproj \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,6 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
 
-      # Required by Playground.Wasm's Release AOT compilation.
-      - name: Install wasm-tools workload
-        run: dotnet workload install wasm-tools
-
       - name: Restore
         run: dotnet restore
 

--- a/src/Docs/Playground.Wasm/ExpressiveSharp.Docs.Playground.Wasm.csproj
+++ b/src/Docs/Playground.Wasm/ExpressiveSharp.Docs.Playground.Wasm.csproj
@@ -14,15 +14,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
 
-    <!-- Roslyn + EF Core trim incompatibly. -->
+    <!-- Roslyn + EF Core trim incompatibly, so PublishTrimmed stays off. .NET 10
+         wasm-tools requires trimming for AOT, so AOT is disabled too — the
+         playground runs interpreted, which trades Roslyn startup speed for a
+         working build. -->
     <PublishTrimmed>false</PublishTrimmed>
-
-    <!-- AOT compilation via wasm-tools workload — significantly faster Roslyn
-         execution at runtime. Only applied on Release publish. We can't strip
-         IL after AOT because PlaygroundReferences feeds the .dll files back
-         into Roslyn as MetadataReference instances for compile-time type
-         resolution — MetadataReference.CreateFromImage needs real PE bytes. -->
-    <RunAOTCompilation Condition="'$(Configuration)' == 'Release'">true</RunAOTCompilation>
 
     <!-- WebCIL packaging + content-hashed asset names off so SnippetCompiler
          can fetch reference DLLs from /_framework/<name>.dll via HttpClient. -->


### PR DESCRIPTION
## Summary
- PR #30 broke the docs deploy. Publish step fails with: `error : AOT is not supported without IL trimming (PublishTrimmed=true required).`
- Root cause: .NET 10's \`wasm-tools\` workload tightened its check — \`RunAOTCompilation=true\` now requires \`PublishTrimmed=true\`. The playground can't enable trimming (Roslyn + EF Core don't trim cleanly), so AOT has to go.
- Trade-off: the playground runs interpreted instead of AOT'd. Roslyn startup is slower, but the build works. AOT was a nice-to-have, not a correctness requirement.
- Also drops \`dotnet workload install wasm-tools\` from all 4 workflows — without AOT, no emscripten/wasm-opt invocation happens, saving ~30-60s per run.

## Test plan
- [x] \`dotnet publish src/Docs/Playground.Wasm -c Release\` succeeds locally
- [x] No emscripten/wasm-opt/relink steps invoked (verified with \`-v normal\`)
- [ ] After merge, Deploy Docs workflow goes green and publishes to gh-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)