### PR TITLE
Fix docs deploy: drop stale index.html rename

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,18 +32,14 @@ jobs:
             -c Release \
             -o .artifacts/playground
           # Drop the Blazor publish output into VitePress' static asset folder
-          # so it ships as part of the site under /playground/.
+          # so it ships as part of the site under /_playground/.
           rm -rf docs/public/_playground
           mkdir -p docs/public/_playground
           cp -r .artifacts/playground/wwwroot/. docs/public/_playground/
-          # Rename to app.html so it doesn't collide with VitePress's route resolution
-          mv docs/public/_playground/index.html docs/public/_playground/app.htm
           sed -i 's|<base href="/" />|<base href="/ExpressiveSharp/_playground/" />|' docs/public/_playground/app.htm
           # Copy _content/ to docs root so Blazor's dynamic imports resolve
           # when the web component is hosted directly on the VitePress page
           cp -r docs/public/_playground/_content docs/public/_content
-          # Remove BlazorMonaco static assets (no longer used)
-          rm -rf docs/public/_content/BlazorMonaco docs/public/_playground/_content/BlazorMonaco
 
       - name: Pre-render doc samples
         run: |


### PR DESCRIPTION
## Summary
PR #32 got the publish step working but the next step failed:

    mv: cannot stat 'docs/public/_playground/index.html': No such file or directory

The wwwroot already ships \`app.htm\` directly (BlazorMonaco removal moved the entry point off \`index.html\`), so the \`mv\` is obsolete. Also drops the \`rm -rf BlazorMonaco\` line that was cleaning up static assets that no longer exist in the publish output.

Locally verified \`dotnet publish src/Docs/Playground.Wasm -c Release\` emits \`wwwroot/app.htm\` and \`<base href="/" />\` — the remaining \`sed\` step still has the right target.

## Test plan
- [ ] Merge → Deploy Docs workflow goes green → docs appear at https://efnext.github.io/ExpressiveSharp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)