### PR TITLE
Fix Cosmos prerender: single container with $type discriminator

### DIFF
--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/Customer.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/Customer.cs
@@ -5,9 +5,8 @@
 
 namespace ExpressiveSharp.Docs.PlaygroundModel.Webshop;
 
-public class Customer
+public class Customer : WebshopEntity
 {
-    public int Id { get; set; }
     public string Name { get; set; } = "";
     public string? Email { get; set; }
     public string? Country { get; set; }

--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/LineItem.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/LineItem.cs
@@ -1,8 +1,7 @@
 namespace ExpressiveSharp.Docs.PlaygroundModel.Webshop;
 
-public class LineItem
+public class LineItem : WebshopEntity
 {
-    public int Id { get; set; }
     public int OrderId { get; set; }
     public Order Order { get; set; } = null!;
     public int ProductId { get; set; }

--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/Order.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/Order.cs
@@ -1,8 +1,7 @@
 namespace ExpressiveSharp.Docs.PlaygroundModel.Webshop;
 
-public class Order
+public class Order : WebshopEntity
 {
-    public int Id { get; set; }
     public int CustomerId { get; set; }
     public Customer Customer { get; set; } = null!;
     public DateTime PlacedAt { get; set; }

--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/Product.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/Product.cs
@@ -1,8 +1,7 @@
 namespace ExpressiveSharp.Docs.PlaygroundModel.Webshop;
 
-public class Product
+public class Product : WebshopEntity
 {
-    public int Id { get; set; }
     public string Name { get; set; } = "";
     public string Category { get; set; } = "";
     public decimal ListPrice { get; set; }

--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/WebshopEntity.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/WebshopEntity.cs
@@ -1,0 +1,9 @@
+namespace ExpressiveSharp.Docs.PlaygroundModel.Webshop;
+
+// Shared base so Cosmos can host all 4 types in a single container, accessed
+// as `DbSet<WebshopEntity>.OfType<T>()`. `Id` lives here because EF Core's TPH
+// discriminator model requires the key on the root type.
+public abstract class WebshopEntity
+{
+    public int Id { get; set; }
+}

--- a/src/Docs/Prerenderer/SampleRenderer.cs
+++ b/src/Docs/Prerenderer/SampleRenderer.cs
@@ -37,7 +37,7 @@ internal sealed class SampleRenderer : IAsyncDisposable
             .EnableServiceProviderCaching(false)
             .Options);
 
-    private static WebshopDbContext BuildCosmosContext() =>
+    private static WebshopCosmosDbContext BuildCosmosContext() =>
         new(new DbContextOptionsBuilder<WebshopDbContext>()
             .UseCosmos("AccountEndpoint=https://localhost:8081/;AccountKey=dW5pdHRlc3Q=", "playground")
             .UseExpressives()
@@ -62,6 +62,19 @@ internal sealed class SampleRenderer : IAsyncDisposable
         public IExpressiveQueryable<Order> Orders => _ctx.Orders;
         public IExpressiveQueryable<Product> Products => _ctx.Products;
         public IExpressiveQueryable<LineItem> LineItems => _ctx.LineItems;
+    }
+
+    // Cosmos roots: every entity lives in the same container and is filtered
+    // via OfType<T>() on the single DbSet<WebshopEntity>, keeping the query
+    // tree rooted at one entity type.
+    private sealed class CosmosDbContextRoots : IWebshopQueryRoots
+    {
+        private readonly WebshopCosmosDbContext _ctx;
+        public CosmosDbContextRoots(WebshopCosmosDbContext ctx) { _ctx = ctx; }
+        public IExpressiveQueryable<Customer> Customers => _ctx.Entities.AsExpressive().OfType<WebshopEntity, Customer>();
+        public IExpressiveQueryable<Order> Orders => _ctx.Entities.AsExpressive().OfType<WebshopEntity, Order>();
+        public IExpressiveQueryable<Product> Products => _ctx.Entities.AsExpressive().OfType<WebshopEntity, Product>();
+        public IExpressiveQueryable<LineItem> LineItems => _ctx.Entities.AsExpressive().OfType<WebshopEntity, LineItem>();
     }
 
     private sealed class MongoRootsImpl : IWebshopQueryRoots
@@ -156,7 +169,7 @@ internal sealed class SampleRenderer : IAsyncDisposable
             RenderPrerendererTarget(targets, invoke, "sqlserver", "EF Core + SQL Server", "sql",
                 new DbContextRoots(sqlServer), static (q, _) => q.ToQueryString());
             RenderPrerendererTarget(targets, invoke, "cosmos", "EF Core + Cosmos DB", "sql",
-                new DbContextRoots(cosmos), static (q, _) => q.ToQueryString());
+                new CosmosDbContextRoots(cosmos), static (q, _) => q.ToQueryString());
             RenderPrerendererTarget(targets, invoke, "mongodb", "MongoDB", "javascript",
                 BuildMongoRoots(), static (q, _) => FormatMongoOutput(q.ToString()!));
         }

--- a/src/Docs/Prerenderer/WebshopCosmosDbContext.cs
+++ b/src/Docs/Prerenderer/WebshopCosmosDbContext.cs
@@ -1,0 +1,42 @@
+using ExpressiveSharp.Docs.PlaygroundModel.Webshop;
+using Microsoft.EntityFrameworkCore;
+
+namespace ExpressiveSharp.Docs.Prerenderer;
+
+// Single shared Cosmos container; every entity lives in it and is
+// discriminated by $type. Samples access each concrete type via
+// `DbSet<WebshopEntity>.OfType<T>()`, so every query stays rooted at
+// one entity type from Cosmos's perspective — sidestepping the
+// "Root entity X already being referenced" failure.
+internal sealed class WebshopCosmosDbContext : WebshopDbContext
+{
+    public WebshopCosmosDbContext(DbContextOptions<WebshopDbContext> options) : base(options) { }
+
+    public DbSet<WebshopEntity> Entities => Set<WebshopEntity>();
+
+    protected override void OnModelCreating(ModelBuilder b)
+    {
+        b.Entity<WebshopEntity>(e =>
+        {
+            e.ToContainer("webshop");
+            e.HasKey(x => x.Id);
+            e.HasPartitionKey(x => x.Id);
+            e.HasDiscriminator<string>("$type")
+                .HasValue<Customer>("Customer")
+                .HasValue<Order>("Order")
+                .HasValue<Product>("Product")
+                .HasValue<LineItem>("LineItem");
+        });
+
+        b.Entity<Order>(e => e.Ignore(o => o.Customer));
+
+        b.Entity<LineItem>(e =>
+        {
+            e.Ignore(i => i.Order);
+            e.Ignore(i => i.Product);
+            e.Property(i => i.UnitPrice).HasPrecision(18, 2);
+        });
+
+        b.Entity<Product>(e => e.Property(p => p.ListPrice).HasPrecision(18, 2));
+    }
+}

--- a/src/ExpressiveSharp/Extensions/ExpressiveQueryableLinqExtensions.cs
+++ b/src/ExpressiveSharp/Extensions/ExpressiveQueryableLinqExtensions.cs
@@ -399,6 +399,11 @@ namespace ExpressiveSharp
             => Queryable.Index(source).AsExpressive();
 #endif
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IExpressiveQueryable<TResult> OfType<T, TResult>(
+            this IExpressiveQueryable<T> source)
+            => Queryable.OfType<TResult>(source).AsExpressive();
+
         // ── Non-lambda-first intercepted methods ─────────────────────────────
 
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
## Summary

Cosmos DB rejects queries that reference more than one root entity type:

> Root entity type 'Customer' is referenced by the query, but 'Order' is already being referenced. A query can only reference a single root entity type.

Every sample that navigated across entities or used \`SelectMany\` into a sibling \`DbSet\` tripped this. Cosmos was at 42% prerender success (50/117).

Fix: host all 4 webshop types in a single Cosmos container with EF Core's TPH discriminator. Samples access each concrete type through \`DbSet<WebshopEntity>.OfType<T>()\`, keeping every query rooted at the same entity from Cosmos's perspective.

**Approach:**
- Add empty base \`WebshopEntity\` with shared \`Id\` (TPH requires the key on the root).
- Customer / Order / Product / LineItem now inherit from it — no other changes to the POCOs.
- \`WebshopCosmosDbContext\` (prerenderer-only) configures the hierarchy with \`HasContainer\`/\`HasDiscriminator\` and ignores cross-root navigations Cosmos can't resolve.
- \`CosmosDbContextRoots\` exposes each concrete type via \`_ctx.Entities.OfType<WebshopEntity, T>()\`.
- \`OfType<T, TResult>()\` added as a passthrough extension on \`IExpressiveQueryable<T>\`.

**SQL providers are untouched.** The base class is never referenced in \`WebshopDbContext.OnModelCreating\`, so SQLite/Postgres/SqlServer still map each entity to its own table.

## Result

| Cosmos | Before | After |
|---|---|---|
| Passing | 50/117 (42%) | 61/117 (52%) |
| \"Root entity already referenced\" errors | 29 | 0 |

Sample MQL output now emits:
\`\`\`sql
SELECT VALUE { \"Id\" : c[\"Id\"], \"Category\" : \"Regular\" }
FROM root c
WHERE (c[\"\$type\"] IN (\"Customer\", \"LineItem\", \"Order\", \"Product\") AND (c[\"\$type\"] = \"Order\"))
\`\`\`

Remaining 56 failures are genuine Cosmos limits (uncorrelated subqueries, cross-document navigation, specific method translation) surfaced as yellow \"cannot be translated\" banners — honest provider behavior for readers evaluating Cosmos.

## Test plan
- [x] \`dotnet build -c Release\` — clean
- [x] \`dotnet run --project src/Docs/Prerenderer -c Release\` — 117/117 samples prerendered
- [x] Cosmos success rate rechecked: 52%
- [ ] SQL targets (SQLite/Postgres/SqlServer) produce byte-identical output to main for unchanged samples
- [ ] Merge → Deploy Docs workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)