### PR TITLE
Improve polyfill generator by emitting a generated file for each source file, into a partial class

### DIFF
--- a/benchmarks/ExpressiveSharp.Benchmarks/PolyfillGeneratorBenchmarks.cs
+++ b/benchmarks/ExpressiveSharp.Benchmarks/PolyfillGeneratorBenchmarks.cs
@@ -15,15 +15,13 @@ namespace ExpressiveSharp.Benchmarks;
 /// <list type="bullet">
 ///   <item><c>*</c> — uses <c>RunGenerators</c> (generator pipeline only, no compilation update).
 ///     The O(N) overhead here comes from the driver maintaining N cached output entries in its
-///     internal state; this is unavoidable regardless of <c>RegisterSourceOutput</c> vs
-///     <c>RegisterImplementationSourceOutput</c>.</item>
+///     internal state.</item>
 ///   <item><c>*_E2E</c> — uses <c>RunGeneratorsAndUpdateCompilation</c> (full pipeline including
 ///     the Roslyn compilation rebuild).
-///     With <c>RegisterImplementationSourceOutput</c>, the N interceptor files are NOT included
-///     in the declaration-phase compilation (only in the implementation/emit phase). This makes
-///     the E2E compilation update significantly faster for large N — the declaration compilation
-///     does not parse/bind N generated files. This is the correct variant to compare for IDE
-///     performance.</item>
+///     This variant measures end-to-end cost, including applying generated sources to the
+///     compilation, so results reflect both generator work and compilation-update overhead.
+///     Use this variant when comparing overall IDE-like responsiveness rather than isolated
+///     generator-pipeline cost.</item>
 /// </list>
 /// </summary>
 [MemoryDiagnoser]
@@ -270,9 +268,10 @@ public class BenchEntity { public int Id { get; set; } public string Name { get;
         };
 
         // indices 1..fileCount: query files
+        var sb = new StringBuilder();
         for (var f = 0; f < fileCount; f++)
         {
-            var sb = new StringBuilder();
+            sb.Clear();
             sb.AppendLine("using System.Linq; using ExpressiveSharp; namespace PolyfillBench;");
             sb.AppendLine($"public static class Queries{f} {{");
             for (var i = 0; i < sitesPerFile; i++)

--- a/benchmarks/ExpressiveSharp.Benchmarks/PolyfillGeneratorBenchmarks.cs
+++ b/benchmarks/ExpressiveSharp.Benchmarks/PolyfillGeneratorBenchmarks.cs
@@ -7,94 +7,284 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace ExpressiveSharp.Benchmarks;
 
+/// <summary>
+/// Baseline: all call sites in a single source file.
+/// Varies <see cref="CallSiteCount"/> to show how cost scales with site count.
+///
+/// <b>NOTE – two benchmark variants:</b>
+/// <list type="bullet">
+///   <item><c>*</c> — uses <c>RunGenerators</c> (generator pipeline only, no compilation update).
+///     The O(N) overhead here comes from the driver maintaining N cached output entries in its
+///     internal state; this is unavoidable regardless of <c>RegisterSourceOutput</c> vs
+///     <c>RegisterImplementationSourceOutput</c>.</item>
+///   <item><c>*_E2E</c> — uses <c>RunGeneratorsAndUpdateCompilation</c> (full pipeline including
+///     the Roslyn compilation rebuild).
+///     With <c>RegisterImplementationSourceOutput</c>, the N interceptor files are NOT included
+///     in the declaration-phase compilation (only in the implementation/emit phase). This makes
+///     the E2E compilation update significantly faster for large N — the declaration compilation
+///     does not parse/bind N generated files. This is the correct variant to compare for IDE
+///     performance.</item>
+/// </list>
+/// </summary>
 [MemoryDiagnoser]
-public class PolyfillGeneratorBenchmarks
+public class PolyfillSingleFileBenchmarks
 {
-    [Params(1, 100)]
+    [Params(1, 10, 100)]
     public int CallSiteCount { get; set; }
 
     private Compilation _compilation = null!;
     private GeneratorDriver _warmedDriver = null!;
-    private Compilation _modifiedCompilation = null!;
+    // Entity file (Polyfill0.cs) has NO call sites — editing it should trigger zero re-transforms.
+    private Compilation _entityFileModified = null!;
+    // Query file (Polyfill1.cs) contains the call sites — editing it forces all N re-transforms.
+    private Compilation _queryFileModified = null!;
 
     [GlobalSetup]
     public void Setup()
     {
-        var sources = BuildPolyfillSources(CallSiteCount);
-        _compilation = CreatePolyfillCompilation(sources);
+        var sources = BuildSources(CallSiteCount);
+        _compilation = CreateCompilation(sources);
 
         _warmedDriver = CSharpGeneratorDriver
             .Create(new PolyfillInterceptorGenerator())
-            .RunGeneratorsAndUpdateCompilation(_compilation, out _, out _);
+            .RunGenerators(_compilation);
 
-        var firstTree = _compilation.SyntaxTrees.First();
-        _modifiedCompilation = _compilation.ReplaceSyntaxTree(
-            firstTree,
-            firstTree.WithChangedText(SourceText.From(firstTree.GetText() + "\n// bench-edit")));
+        // index 0 = entity (no call sites)
+        var entityTree = _compilation.SyntaxTrees.ElementAt(0);
+        _entityFileModified = _compilation.ReplaceSyntaxTree(
+            entityTree,
+            entityTree.WithChangedText(SourceText.From(entityTree.GetText() + "\n// bench-edit")));
+
+        // index 1 = queries (CallSiteCount call sites)
+        var queryTree = _compilation.SyntaxTrees.ElementAt(1);
+        _queryFileModified = _compilation.ReplaceSyntaxTree(
+            queryTree,
+            queryTree.WithChangedText(SourceText.From(queryTree.GetText() + "\n// bench-edit")));
     }
 
+    // ── Generator-only (no compilation rebuild) ──────────────────────────────
+
+    /// <summary>
+    /// Fresh driver, runs all <see cref="CallSiteCount"/> per-node transforms from scratch.
+    /// </summary>
     [Benchmark(Baseline = true)]
-    public GeneratorDriver RunGenerator()
+    public GeneratorDriver Cold()
+        => CSharpGeneratorDriver
+            .Create(new PolyfillInterceptorGenerator())
+            .RunGenerators(_compilation);
+
+    /// <summary>
+    /// Incremental edit on a file with ZERO call sites.
+    /// Zero transforms should re-run; cost above baseline = pipeline evaluation overhead only.
+    /// </summary>
+    [Benchmark]
+    public GeneratorDriver Incremental_EditEntityFile()
+        => _warmedDriver.RunGenerators(_entityFileModified);
+
+    /// <summary>
+    /// Incremental edit on the file containing all <see cref="CallSiteCount"/> call sites.
+    /// All transforms must re-run; shows the per-site transform cost.
+    /// Should be ≈ <c>Cold</c>.
+    /// </summary>
+    [Benchmark]
+    public GeneratorDriver Incremental_EditQueryFile()
+        => _warmedDriver.RunGenerators(_queryFileModified);
+
+    // ── End-to-end (generator + Roslyn compilation rebuild) ──────────────────
+    // Compilation-rebuild cost dominates at large N; see the generator-only variants above
+    // for a clean measurement of caching savings.
+
+    [Benchmark]
+    public GeneratorDriver Cold_E2E()
         => CSharpGeneratorDriver
             .Create(new PolyfillInterceptorGenerator())
             .RunGeneratorsAndUpdateCompilation(_compilation, out _, out _);
 
     [Benchmark]
-    public GeneratorDriver RunGenerator_Incremental()
-        => _warmedDriver
-            .RunGeneratorsAndUpdateCompilation(_modifiedCompilation, out _, out _);
+    public GeneratorDriver Incremental_EditEntityFile_E2E()
+        => _warmedDriver.RunGeneratorsAndUpdateCompilation(_entityFileModified, out _, out _);
 
-    private static Compilation CreatePolyfillCompilation(IReadOnlyList<string> sources)
+    [Benchmark]
+    public GeneratorDriver Incremental_EditQueryFile_E2E()
+        => _warmedDriver.RunGeneratorsAndUpdateCompilation(_queryFileModified, out _, out _);
+
+    private static Compilation CreateCompilation(IReadOnlyList<string> sources)
     {
-        var references = Basic.Reference.Assemblies.Net100.References.All.ToList();
-        references.Add(MetadataReference.CreateFromFile(typeof(ExpressiveAttribute).Assembly.Location));
-
+        var refs = Basic.Reference.Assemblies.Net100.References.All.ToList();
+        refs.Add(MetadataReference.CreateFromFile(typeof(ExpressiveAttribute).Assembly.Location));
         return CSharpCompilation.Create(
-            "PolyfillBenchmarkInput",
-            sources.Select((s, idx) => CSharpSyntaxTree.ParseText(s, path: $"Polyfill{idx}.cs")),
-            references,
+            "PolyfillSingleFileBench",
+            sources.Select((s, i) => CSharpSyntaxTree.ParseText(s, path: $"Polyfill{i}.cs")),
+            refs,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
     }
 
-    private static IReadOnlyList<string> BuildPolyfillSources(int callSiteCount)
+    private static IReadOnlyList<string> BuildSources(int callSiteCount)
     {
-        var sources = new List<string>();
-
-        // Entity class
-        sources.Add(@"
+        var sources = new List<string>
+        {
+            // index 0: entity — NO call sites
+            @"
 using System;
 using System.Linq;
 using ExpressiveSharp;
+namespace PolyfillBench;
+public class BenchEntity { public int Id { get; set; } public string Name { get; set; } = """"; }
+"
+        };
 
-namespace PolyfillBenchmarkInput;
-
-public class BenchEntity
-{
-    public int Id { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public decimal Amount { get; set; }
-}
-");
-
-        // Call sites — each in its own method to generate distinct interceptors
+        // index 1: queries — all callSiteCount call sites
         var sb = new StringBuilder();
-        sb.AppendLine("using System;");
-        sb.AppendLine("using System.Linq;");
-        sb.AppendLine("using ExpressiveSharp;");
-        sb.AppendLine();
-        sb.AppendLine("namespace PolyfillBenchmarkInput;");
-        sb.AppendLine();
-        sb.AppendLine("public static class Queries");
-        sb.AppendLine("{");
-
+        sb.AppendLine("using System.Linq; using ExpressiveSharp; namespace PolyfillBench;");
+        sb.AppendLine("public static class Queries {");
         for (var i = 0; i < callSiteCount; i++)
-        {
-            sb.AppendLine($"    public static IQueryable<int> Query{i}(IExpressiveQueryable<BenchEntity> q)");
-            sb.AppendLine($"        => q.Select(x => x.Id + {i});");
-        }
-
+            sb.AppendLine($"  public static IQueryable<int> Q{i}(IExpressiveQueryable<BenchEntity> q) => q.Select(x => x.Id + {i});");
         sb.AppendLine("}");
         sources.Add(sb.ToString());
+
+        return sources;
+    }
+}
+
+/// <summary>
+/// Multi-file scenario: call sites spread across <see cref="FileCount"/> source files.
+/// Each file contains a fixed <see cref="CallSitesPerFile"/> call sites.
+/// Demonstrates the key incremental-caching benefit from the no-Collect() pipeline design:
+/// each call site registers its output independently, so only changed files are re-processed.
+///
+/// Key comparisons (generator-only variants):
+/// <list type="bullet">
+///   <item><c>Cold</c>                        — all FileCount × CallSitesPerFile transforms from scratch. Should scale linearly.</item>
+///   <item><c>Incremental_EditCallSiteFile</c> — only 1 file re-processed (CallSitesPerFile transforms). Cost ≈ constant regardless of FileCount.</item>
+///   <item><c>Incremental_EditNoiseFile</c>    — zero transforms re-run; pipeline overhead only. Cost ≈ constant regardless of FileCount.</item>
+/// </list>
+/// Expected: <c>Cold</c> grows linearly; <c>Incremental_EditCallSiteFile</c> and
+/// <c>Incremental_EditNoiseFile</c> stay near-flat as <see cref="FileCount"/> grows.
+/// The difference between them = cost of <see cref="CallSitesPerFile"/> transforms.
+///
+/// <b>Why this works:</b> Instead of <c>snippets.Collect()</c> (which forces O(total_sites)
+/// array re-assembly on every run), each snippet is registered directly via
+/// <c>RegisterSourceOutput</c>. Roslyn's per-output cache means unchanged call sites'
+/// output files are served from cache with zero work.
+///
+/// <b>E2E variants</b> include the Roslyn compilation-rebuild cost which also scales
+/// with file count and can partially mask the generator savings.
+/// </summary>
+[MemoryDiagnoser]
+public class PolyfillMultiFileBenchmarks
+{
+    [Params(1, 5, 10)]
+    public int FileCount { get; set; }
+
+    private const int CallSitesPerFile = 5;
+
+    private Compilation _compilation = null!;
+    private GeneratorDriver _warmedDriver = null!;
+    private Compilation _callSiteFileModified = null!;
+    private Compilation _noiseFileModified = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var sources = BuildSources(FileCount, CallSitesPerFile);
+        _compilation = CreateCompilation(sources);
+
+        _warmedDriver = CSharpGeneratorDriver
+            .Create(new PolyfillInterceptorGenerator())
+            .RunGenerators(_compilation);
+
+        // Index FileCount = last query file (has CallSitesPerFile call sites)
+        var callSiteTree = _compilation.SyntaxTrees.ElementAt(FileCount);
+        _callSiteFileModified = _compilation.ReplaceSyntaxTree(
+            callSiteTree,
+            callSiteTree.WithChangedText(SourceText.From(callSiteTree.GetText() + "\n// bench-edit")));
+
+        // Index FileCount + 1 = noise file (zero call sites)
+        var noiseTree = _compilation.SyntaxTrees.ElementAt(FileCount + 1);
+        _noiseFileModified = _compilation.ReplaceSyntaxTree(
+            noiseTree,
+            noiseTree.WithChangedText(SourceText.From(noiseTree.GetText() + "\n// bench-edit")));
+    }
+
+    // ── Generator-only (no compilation rebuild) ──────────────────────────────
+
+    /// <summary>All FileCount × CallSitesPerFile transforms run from scratch.</summary>
+    [Benchmark(Baseline = true)]
+    public GeneratorDriver Cold()
+        => CSharpGeneratorDriver
+            .Create(new PolyfillInterceptorGenerator())
+            .RunGenerators(_compilation);
+
+    /// <summary>
+    /// Edits a file that contains <see cref="CallSitesPerFile"/> call sites.
+    /// That file's transforms re-run; all other files' transforms come from cache.
+    /// Cost ≈ <see cref="CallSitesPerFile"/> transforms regardless of <see cref="FileCount"/>.
+    /// </summary>
+    [Benchmark]
+    public GeneratorDriver Incremental_EditCallSiteFile()
+        => _warmedDriver.RunGenerators(_callSiteFileModified);
+
+    /// <summary>
+    /// Edits a file with NO call sites.
+    /// Zero transforms should re-run. Expected cost ≈ pipeline overhead only (near-flat vs FileCount).
+    /// The gap vs <c>Incremental_EditCallSiteFile</c> isolates the per-site transform cost.
+    /// </summary>
+    [Benchmark]
+    public GeneratorDriver Incremental_EditNoiseFile()
+        => _warmedDriver.RunGenerators(_noiseFileModified);
+
+    // ── End-to-end (generator + Roslyn compilation rebuild) ──────────────────
+
+    [Benchmark]
+    public GeneratorDriver Cold_E2E()
+        => CSharpGeneratorDriver
+            .Create(new PolyfillInterceptorGenerator())
+            .RunGeneratorsAndUpdateCompilation(_compilation, out _, out _);
+
+    [Benchmark]
+    public GeneratorDriver Incremental_EditCallSiteFile_E2E()
+        => _warmedDriver.RunGeneratorsAndUpdateCompilation(_callSiteFileModified, out _, out _);
+
+    [Benchmark]
+    public GeneratorDriver Incremental_EditNoiseFile_E2E()
+        => _warmedDriver.RunGeneratorsAndUpdateCompilation(_noiseFileModified, out _, out _);
+
+    private static Compilation CreateCompilation(IReadOnlyList<string> sources)
+    {
+        var refs = Basic.Reference.Assemblies.Net100.References.All.ToList();
+        refs.Add(MetadataReference.CreateFromFile(typeof(ExpressiveAttribute).Assembly.Location));
+        return CSharpCompilation.Create(
+            "PolyfillMultiFileBench",
+            sources.Select((s, i) => CSharpSyntaxTree.ParseText(s, path: $"Polyfill{i}.cs")),
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static IReadOnlyList<string> BuildSources(int fileCount, int sitesPerFile)
+    {
+        // index 0: entity
+        var sources = new List<string>
+        {
+            @"using System.Linq; using ExpressiveSharp; namespace PolyfillBench;
+public class BenchEntity { public int Id { get; set; } public string Name { get; set; } = """"; }"
+        };
+
+        // indices 1..fileCount: query files
+        for (var f = 0; f < fileCount; f++)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("using System.Linq; using ExpressiveSharp; namespace PolyfillBench;");
+            sb.AppendLine($"public static class Queries{f} {{");
+            for (var i = 0; i < sitesPerFile; i++)
+                sb.AppendLine($"  public static IQueryable<int> Q{f}_{i}(IExpressiveQueryable<BenchEntity> q) => q.Select(x => x.Id + {f * 100 + i});");
+            sb.AppendLine("}");
+            sources.Add(sb.ToString());
+        }
+
+        // index fileCount + 1: noise — no call sites at all
+        sources.Add(@"namespace PolyfillBench;
+/// <summary>No IExpressiveQueryable here — editing this file should cost zero generator work.</summary>
+public static class BenchHelper { public static string Describe(int id) => $""#{id}""; }");
 
         return sources;
     }

--- a/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
+++ b/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 using ExpressiveSharp.Generator.Infrastructure;
-using ExpressiveSharp.Generator.Models;
-using ExpressiveSharp.Generator.SyntaxRewriters;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -102,73 +96,123 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // Syntactic pre-filter: any member-access invocation with at least one argument
-        // is a candidate. The semantic check in Emit does the real filtering.
-        var candidates = context.SyntaxProvider.CreateSyntaxProvider(
-            predicate: static (node, _) =>
-                node is InvocationExpressionSyntax inv &&
-                inv.Expression is MemberAccessExpressionSyntax &&
-                inv.ArgumentList.Arguments.Count > 0,
-            transform: static (ctx, _) => (InvocationExpressionSyntax)ctx.Node);
+        // One pipeline item per SOURCE FILE (CompilationUnitSyntax = root node of each file).
+        // The syntactic scan filters out files that have no candidate invocations at all.
+        // This gives us one generated file per user source file — clean and predictable.
+        var candidateFiles = context.SyntaxProvider.CreateSyntaxProvider(
+            predicate: static (node, _) => node is CompilationUnitSyntax,
+            transform: static (ctx, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                var unit = (CompilationUnitSyntax)ctx.Node;
+                // Quick syntactic pre-filter: any member-access invocation with ≥1 argument?
+                foreach (var descendant in unit.DescendantNodes())
+                {
+                    if (descendant is InvocationExpressionSyntax inv &&
+                        inv.Expression is MemberAccessExpressionSyntax &&
+                        inv.ArgumentList.Arguments.Count > 0)
+                        return unit;
+                }
+                return null;
+            })
+            .Where(static x => x is not null)
+            .Select(static (x, _) => x!);
 
-        var globalOptions = context.AnalyzerConfigOptionsProvider
-            .Select(static (opts, _) => new ExpressiveGlobalOptions(opts.GlobalOptions));
+        // Combine with the compilation so ProcessFileAndEmit can build a SemanticModel.
+        //
+        // WithComparer uses REFERENCE equality on the CompilationUnitSyntax root node:
+        //   • Roslyn syntax trees are immutable — editing a noise file creates a new
+        //     Compilation but keeps every other file's syntax tree root as the EXACT
+        //     SAME object reference across incremental runs.
+        //   • All untouched source files compare as "equal" → RegisterSourceOutput
+        //     skipped entirely → O(1) incremental cost for noise-file edits.
+        //   • Only files that were actually edited get a new root reference → re-run.
+        var filesWithCompilation = candidateFiles
+            .Combine(context.CompilationProvider)
+            .WithComparer(CompilationUnitAndCompilationComparer.Instance);
 
-        // Combine with the full compilation so we can do semantic analysis in the output step.
-        context.RegisterSourceOutput(
-            candidates.Collect().Combine(context.CompilationProvider).Combine(globalOptions),
-            static (spc, pair) => Emit(pair.Left.Left, pair.Left.Right, pair.Right, spc));
+        // All semantic analysis, code emission, and EXP_EMIT_FAILED diagnostic reporting
+        // happen inside ProcessFileAndEmit. One output file is produced per source file,
+        // containing all interceptors for that file.
+        context.RegisterSourceOutput(filesWithCompilation,
+            static (spc, pair) => ProcessFileAndEmit(pair.Left, pair.Right, spc));
     }
 
-    // ── Emission ─────────────────────────────────────────────────────────────
+    // ── Per-file processing and emission ────────────────────────────────────
 
-    private static void Emit(
-        ImmutableArray<InvocationExpressionSyntax> invocations,
+    /// <summary>
+    /// Processes all candidate call sites in one source file and emits a single
+    /// interceptor file containing all generated methods for that file.
+    /// Called from <c>RegisterSourceOutput</c>; Roslyn replays cached output when
+    /// <see cref="CompilationUnitAndCompilationComparer"/> signals the file is unchanged.
+    /// </summary>
+    private static void ProcessFileAndEmit(
+        CompilationUnitSyntax unit,
         Compilation compilation,
-        ExpressiveGlobalOptions globalOptions,
         SourceProductionContext spc)
     {
-        var methodsBuilder = new StringBuilder();
-        var snippetCount = 0;
+        var ct = spc.CancellationToken;
+        var model = compilation.GetSemanticModel(unit.SyntaxTree);
+        var sourcePath = unit.SyntaxTree.FilePath;
+        var fileTag = GetFileTag(sourcePath);
 
-        foreach (var inv in invocations)
+        var methodCodes = new List<string>();
+        var needsClosureHelper = false;
+
+        foreach (var descendant in unit.DescendantNodes())
         {
-            spc.CancellationToken.ThrowIfCancellationRequested();
+            if (descendant is not InvocationExpressionSyntax inv) continue;
+            if (inv.Expression is not MemberAccessExpressionSyntax) continue;
+            if (inv.ArgumentList.Arguments.Count == 0) continue;
 
+            ct.ThrowIfCancellationRequested();
             try
             {
-                var snippet = TryEmitPolyfill(inv, compilation, spc, snippetCount, globalOptions)
-                           ?? TryEmit(inv, compilation, spc, snippetCount, globalOptions);
-                if (snippet is not null)
-                {
-                    methodsBuilder.Append(snippet);
-                    snippetCount++;
-                }
+                // Use the METHOD NAME token position for stable, unique naming.
+                // Using the invocation's span-start would collide in chained calls
+                // (e.g. query.AsExpressive().Where(…) — both start at 'query').
+                var ma = (MemberAccessExpressionSyntax)inv.Expression;
+                var nameLineSpan = ma.Name.GetLocation().GetLineSpan();
+                var line = nameLineSpan.StartLinePosition.Line;
+                var col  = nameLineSpan.StartLinePosition.Character;
+
+                var methodCode = TryEmitPolyfill(inv, model, line, col, fileTag, ct)
+                              ?? TryEmit(inv, model, line, col, fileTag, ct);
+                if (methodCode is null) continue;
+
+                methodCodes.Add(methodCode);
+                if (methodCode.Contains("__ClosureHelper"))
+                    needsClosureHelper = true;
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
             {
-                // Report the failure so it doesn't hide bugs silently.
-                // The stub body will throw UnreachableException at runtime with a clear message.
+                var lineSpan = inv.GetLocation().GetLineSpan();
                 spc.ReportDiagnostic(Diagnostic.Create(
                     Diagnostics.InterceptorEmissionFailed,
-                    inv.GetLocation(),
+                    Location.Create(
+                        lineSpan.Path,
+                        new TextSpan(0, 0),
+                        new LinePositionSpan(
+                            new LinePosition(lineSpan.StartLinePosition.Line, lineSpan.StartLinePosition.Character),
+                            new LinePosition(lineSpan.StartLinePosition.Line, lineSpan.StartLinePosition.Character))),
                     ex.GetType().Name + ": " + ex.Message));
             }
         }
 
-        if (snippetCount == 0) return;
+        if (methodCodes.Count == 0) return;
 
-        var methods = methodsBuilder.ToString();
-        var closureHelper = methods.Contains("__ClosureHelper") ? ClosureHelperSource : "";
+        var allMethods = string.Concat(methodCodes);
+        var closureHelper = needsClosureHelper ? ClosureHelperSource : "";
         var source = $$"""
             // <auto-generated/>
             #nullable disable
 
             namespace ExpressiveSharp.Generated.Interceptors
             {
-                internal static class PolyfillInterceptors
+                internal static partial class PolyfillInterceptors
                 {
-            {{methods}}    }{{closureHelper}}
+            {{allMethods}}    }{{closureHelper}}
             }
 
             namespace System.Runtime.CompilerServices
@@ -181,9 +225,48 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             }
             """;
 
-        spc.AddSource("PolyfillInterceptors.g.cs",
+        spc.AddSource(ComputeOutputFileName(sourcePath),
             SourceText.From(source, Encoding.UTF8));
     }
+
+    /// <summary>
+    /// Computes a stable output file name for a given source file.
+    /// One interceptor file is generated per source file, keyed by the full 32-bit
+    /// FNV-1a hash of the source path.
+    /// </summary>
+    private static string ComputeOutputFileName(string sourcePath)
+    {
+        unchecked
+        {
+            var hash = 2166136261u;
+            for (var i = 0; i < sourcePath.Length; i++)
+            {
+                hash ^= (uint)sourcePath[i];
+                hash *= 16777619u;
+            }
+            return "PolyfillInterceptors_" + hash.ToString("x8") + ".g.cs";
+        }
+    }
+
+    /// <summary>
+    /// Returns a short (4-char hex) tag derived from the source file path hash.
+    /// Used as a prefix in interceptor method names to prevent collisions between
+    /// files that have call sites at identical line/col positions.
+    /// </summary>
+    private static string GetFileTag(string sourcePath)
+    {
+        unchecked
+        {
+            var hash = 2166136261u;
+            for (var i = 0; i < sourcePath.Length; i++)
+            {
+                hash ^= (uint)sourcePath[i];
+                hash *= 16777619u;
+            }
+            return (hash & 0xFFFFu).ToString("x4");
+        }
+    }
+
 
     // ── ExpressionPolyfill.Create() interception ──────────────────────────
 
@@ -192,15 +275,13 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     /// an interceptor that returns a literal <c>Expression&lt;TDelegate&gt;</c> with the
     /// rewritten lambda body.
     /// </summary>
-    private static string? TryEmitPolyfill(
-        InvocationExpressionSyntax inv,
-        Compilation compilation,
-        SourceProductionContext spc,
-        int index,
-        ExpressiveGlobalOptions globalOptions)
+    private static string? TryEmitPolyfill(InvocationExpressionSyntax inv,
+        SemanticModel model,
+        int line,
+        int col,
+        string fileTag,
+        CancellationToken ct)
     {
-        var model = compilation.GetSemanticModel(inv.SyntaxTree);
-
         if (model.GetSymbolInfo(inv).Symbol is not IMethodSymbol method)
             return null;
 
@@ -219,12 +300,10 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             return null;
         var hasTransformers = method.Parameters.Length == 2;
 
-        var interceptableLocation = Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetInterceptableLocation(
-            model, inv, spc.CancellationToken);
+        var interceptableLocation = model.GetInterceptableLocation(inv, ct);
         if (interceptableLocation is null)
             return null;
-        var interceptAttr = Microsoft.CodeAnalysis.CSharp.CSharpExtensions
-            .GetInterceptsLocationAttributeSyntax(interceptableLocation);
+        var interceptAttr = interceptableLocation.GetInterceptsLocationAttributeSyntax();
 
         // Extract the delegate type — e.g., Func<Order, bool>
         var delegateType = method.TypeArguments[0];
@@ -233,7 +312,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         // Default to Rewrite (the whole point of Polyfill is enabling expression tree features),
         // but allow MSBuild global property to override.
         
-
         // Get the parameter types from the delegate to build Expression<TDelegate>
         // For Func<T1, T2, ..., TResult>, the lambda parameters map to T1..Tn
         if (delegateType is not INamedTypeSymbol delegateNamed || delegateNamed.TypeArguments.IsEmpty)
@@ -245,9 +323,8 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             return null;
 
         // Use ExpressionTreeEmitter to build the expression tree
-        var exprTypeFqn = $"global::System.Linq.Expressions.Expression<{delegateFqn}>";
-        var emitResult = EmitLambdaBody(lam, elemSymbol, model, spc, globalOptions, delegateFqn,
-            varPrefix: $"i{index}_", delegateVarName: "__func");
+        var emitResult = EmitLambdaBody(lam, elemSymbol, model, delegateFqn,
+            varPrefix: $"i{fileTag}{line}c{col}_", delegateVarName: "__func");
         if (emitResult is null)
             return null;
 
@@ -255,7 +332,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         {
             return $$"""
                     {{interceptAttr}}
-                    internal static global::System.Linq.Expressions.Expression<{{delegateFqn}}> {{MethodId("Create", index)}}(
+                    internal static global::System.Linq.Expressions.Expression<{{delegateFqn}}> {{MethodId("Create", fileTag, line, col)}}(
                         {{delegateFqn}} __func,
                         params global::ExpressiveSharp.IExpressionTreeTransformer[] transformers)
                     {
@@ -269,7 +346,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
         return $$"""
                 {{interceptAttr}}
-                internal static global::System.Linq.Expressions.Expression<{{delegateFqn}}> {{MethodId("Create", index)}}(
+                internal static global::System.Linq.Expressions.Expression<{{delegateFqn}}> {{MethodId("Create", fileTag, line, col)}}(
                     {{delegateFqn}} __func)
                 {
         {{emitResult.Body}}            return __lambda;
@@ -280,14 +357,13 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
     // ── Per-invocation dispatch (IExpressiveQueryable) ───────────────────────
 
-    private static string? TryEmit(
-        InvocationExpressionSyntax inv,
-        Compilation compilation,
-        SourceProductionContext spc,
-        int index,
-        ExpressiveGlobalOptions globalOptions)
+    private static string? TryEmit(InvocationExpressionSyntax inv,
+        SemanticModel model,
+        int line,
+        int col,
+        string fileTag,
+        CancellationToken ct)
     {
-        var model = compilation.GetSemanticModel(inv.SyntaxTree);
         var ma = (MemberAccessExpressionSyntax)inv.Expression;
 
         // Receiver must be or implement IExpressiveQueryable<T>.
@@ -321,14 +397,12 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
         // Get the interceptable location using the Roslyn 5.0+ API.
         // This produces the correct [InterceptsLocation(version, data)] attribute text.
-        var interceptableLocation = Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetInterceptableLocation(
-            model, inv, spc.CancellationToken);
+        var interceptableLocation = model.GetInterceptableLocation(inv, ct);
 
         if (interceptableLocation is null)
             return null;
 
-        var interceptAttr = Microsoft.CodeAnalysis.CSharp.CSharpExtensions
-            .GetInterceptsLocationAttributeSyntax(interceptableLocation);
+        var interceptAttr = interceptableLocation.GetInterceptsLocationAttributeSyntax();
 
         // Element type T of IExpressiveQueryable<T>.
         // The receiver may be IExpressiveQueryable<T> directly, or a type that implements it.
@@ -337,7 +411,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             return null;
         var elementType = rewritableInterface.TypeArguments[0];
         if (elementType is not INamedTypeSymbol elementSymbol)
-            return null; // Skip when T is itself a type parameter
+            return null;
         var elementFqn = elementType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var methodName = ma.Name.Identifier.Text;
 
@@ -354,7 +428,8 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             targetTypeFqn = targetType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         }
 
-        return EmitGenericLambda(inv, model, spc, interceptAttr, index, methodName, elementSymbol, elementFqn, method, funcParamIndices, targetTypeFqn, globalOptions);
+        return EmitGenericLambda(inv, model, interceptAttr, line, col, fileTag,
+            methodName, elementSymbol, elementFqn, method, funcParamIndices, targetTypeFqn);
     }
 
     // ── Lambda helpers ───────────────────────────────────────────────────────
@@ -362,14 +437,13 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     /// <summary>
     /// Uses <see cref="Emitter.ExpressionTreeEmitter"/> to build the expression tree for a lambda body.
     /// Returns the emitter result containing imperative Expression.* factory code, or null on failure.
+    /// Note: <c>context: null</c> is passed to <see cref="Emitter.ExpressionTreeEmitter"/>
+    /// intentionally — emitter diagnostics (EXP0008, EXP0018) are suppressed in this path.
     /// </summary>
     private static Emitter.EmitResult? EmitLambdaBody(
         LambdaExpressionSyntax lambda,
         INamedTypeSymbol elementSymbol,
-
         SemanticModel model,
-        SourceProductionContext spc,
-        ExpressiveGlobalOptions globalOptions,
         string delegateTypeFqn,
         string assignToVariable = "__lambda",
         string varPrefix = "",
@@ -381,7 +455,8 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         var bodyNode = lambda.Body is ExpressionSyntax expr ? (SyntaxNode)expr : lambda.Body;
         if (bodyNode is null) return null;
 
-        var emitter = new Emitter.ExpressionTreeEmitter(model, spc, varPrefix: varPrefix, delegateVarName: delegateVarName);
+        // context: null — SourceProductionContext is not available in the per-node transform.
+        var emitter = new Emitter.ExpressionTreeEmitter(model, context: null, varPrefix: varPrefix, delegateVarName: delegateVarName);
 
         if (typeAliases is not null)
         {
@@ -453,7 +528,16 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
     // ── Formatting helpers ───────────────────────────────────────────────────
 
-    private static string MethodId(string op, int index) => $"__Polyfill_{op}_{index}";
+    /// <summary>
+    /// Produces a unique, stable interceptor method name based on the call site's
+    /// source file hash + method-name-token position (line/col).
+    /// The file hash disambiguates call sites across different source files that happen
+    /// to share the same line/col (e.g., two files both have an <c>OrderBy</c> at 44:13).
+    /// The position component disambiguates multiple call sites within the same file.
+    /// Adding/removing methods in other files never shifts these identifiers.
+    /// </summary>
+    private static string MethodId(string op, string fileTag, int line, int col)
+        => $"__Polyfill_{op}_{fileTag}_{line}_{col}";
 
     /// <summary>
     /// Generic lambda emitter for all LINQ operators and user-defined stubs.
@@ -466,10 +550,9 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     /// </summary>
     private static string? EmitGenericLambda(
         InvocationExpressionSyntax inv, SemanticModel model,
-        SourceProductionContext spc, string interceptAttr, int idx,
+        string interceptAttr, int line, int col, string fileTag,
         string methodName, INamedTypeSymbol elemSym, string elemFqn,
-        IMethodSymbol method, List<int> funcParamIndices, string targetTypeFqn,
-        ExpressiveGlobalOptions globalOptions)
+        IMethodSymbol method, List<int> funcParamIndices, string targetTypeFqn)
     {
         // ── Extract all lambda expressions from the Func<> argument positions ──
         var lambdas = new List<LambdaExpressionSyntax>(funcParamIndices.Count);
@@ -583,7 +666,10 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 if (typeAliases.TryGetValue(returnElemType!, out var retParam))
                     returnRef = retParam;
                 else
-                    returnRef = returnElemType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    // Use ResolveTypeFqn so that composite return types like IGrouping<TKey, AnonType>
+                    // are resolved through the type aliases (e.g. IGrouping<T1, T0> instead of the
+                    // compiler-generated anonymous type name which is not valid C#).
+                    returnRef = ResolveTypeFqn(returnElemType!, typeAliases);
             }
             else
             {
@@ -671,11 +757,11 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         for (int j = 0; j < funcParamIndices.Count; j++)
         {
             var lambdaVar = single ? "__lambda" : $"__lambda{j + 1}";
-            var prefix = single ? $"i{idx}_" : $"i{idx}{(char)('a' + j)}_";
+            var prefix = single ? $"i{fileTag}{line}c{col}_" : $"i{fileTag}{line}c{col}{(char)('a' + j)}_";
             var delegateName = single ? "__func" : $"__func{j + 1}";
             var funcType = (INamedTypeSymbol)method.Parameters[funcParamIndices[j]].Type;
             var lambdaElemSym = funcType.TypeArguments[0] as INamedTypeSymbol ?? elemSym;
-            var emitResult = EmitLambdaBody(lambdas[j], lambdaElemSym, model, spc, globalOptions,
+            var emitResult = EmitLambdaBody(lambdas[j], lambdaElemSym, model,
                 delegateFqns[j], lambdaVar, varPrefix: prefix,
                 typeAliases: hasAnyAnon ? typeAliases : null,
                 delegateVarName: delegateName);
@@ -691,7 +777,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             {
                 return $$"""
                         {{interceptAttr}}
-                        internal static global::ExpressiveSharp.IExpressiveQueryable<{{returnRef}}> {{MethodId(methodName, idx)}}(
+                        internal static global::ExpressiveSharp.IExpressiveQueryable<{{returnRef}}> {{MethodId(methodName, fileTag, line, col)}}(
                             this global::ExpressiveSharp.IExpressiveQueryable<{{elemFqn}}> source,
                             {{interceptorParamList}})
                         {
@@ -706,7 +792,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
             return $$"""
                     {{interceptAttr}}
-                    internal static {{returnRef}} {{MethodId(methodName, idx)}}(
+                    internal static {{returnRef}} {{MethodId(methodName, fileTag, line, col)}}(
                         this global::ExpressiveSharp.IExpressiveQueryable<{{elemFqn}}> source,
                         {{interceptorParamList}})
                     {
@@ -722,7 +808,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         {
             return $$"""
                     {{interceptAttr}}
-                    internal static global::ExpressiveSharp.IExpressiveQueryable<{{returnRef}}> {{MethodId(methodName, idx)}}{{typeParams}}(
+                    internal static global::ExpressiveSharp.IExpressiveQueryable<{{returnRef}}> {{MethodId(methodName, fileTag, line, col)}}{{typeParams}}(
                         this global::ExpressiveSharp.IExpressiveQueryable<{{elemRef}}> source,
                         {{interceptorParamList}})
                     {
@@ -738,7 +824,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
         return $$"""
                 {{interceptAttr}}
-                internal static {{returnRef}} {{MethodId(methodName, idx)}}{{typeParams}}(
+                internal static {{returnRef}} {{MethodId(methodName, fileTag, line, col)}}{{typeParams}}(
                     this global::ExpressiveSharp.IExpressiveQueryable<{{elemRef}}> source,
                     {{interceptorParamList}})
                 {
@@ -816,4 +902,39 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         return type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
     }
 
+    // ── CompilationUnitAndCompilationComparer ─────────────────────────────────
+
+    /// <summary>
+    /// Compares <c>(CompilationUnitSyntax, Compilation)</c> pairs using REFERENCE
+    /// equality on the syntax root only, completely ignoring the <c>Compilation</c>.
+    ///
+    /// <para>
+    /// Roslyn's incremental pipeline rebuilds the <see cref="Compilation"/> on every
+    /// file edit — even for files unrelated to our call sites. However, it keeps every
+    /// unchanged file's <see cref="SyntaxTree"/> root as the exact same object reference
+    /// across incremental runs.
+    /// </para>
+    /// <para>
+    /// By using reference equality on the <see cref="CompilationUnitSyntax"/>, editing
+    /// a noise file makes all untouched source-file pairs compare as "equal" → their
+    /// <c>RegisterSourceOutput</c> actions are skipped entirely → O(1) incremental cost
+    /// for noise-file edits, matching the pattern used by EntityFrameworkCore.Projectables.
+    /// </para>
+    /// </summary>
+    private sealed class CompilationUnitAndCompilationComparer
+        : IEqualityComparer<(CompilationUnitSyntax Left, Compilation Right)>
+    {
+        public readonly static CompilationUnitAndCompilationComparer Instance
+            = new CompilationUnitAndCompilationComparer();
+
+        private CompilationUnitAndCompilationComparer() { }
+
+        public bool Equals(
+            (CompilationUnitSyntax Left, Compilation Right) x,
+            (CompilationUnitSyntax Left, Compilation Right) y)
+            => ReferenceEquals(x.Left, y.Left);
+
+        public int GetHashCode((CompilationUnitSyntax Left, Compilation Right) obj)
+            => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj.Left);
+    }
 }

--- a/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
+++ b/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
@@ -176,8 +176,8 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 var line = nameLineSpan.StartLinePosition.Line;
                 var col  = nameLineSpan.StartLinePosition.Character;
 
-                var methodCode = TryEmitPolyfill(inv, model, line, col, fileTag, ct)
-                              ?? TryEmit(inv, model, line, col, fileTag, ct);
+                var methodCode = TryEmitPolyfill(inv, model, line, col, fileTag, spc)
+                              ?? TryEmit(inv, model, line, col, fileTag, spc);
                 if (methodCode is null) continue;
 
                 methodCodes.Add(methodCode);
@@ -187,15 +187,9 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
-                var lineSpan = inv.GetLocation().GetLineSpan();
                 spc.ReportDiagnostic(Diagnostic.Create(
                     Diagnostics.InterceptorEmissionFailed,
-                    Location.Create(
-                        lineSpan.Path,
-                        new TextSpan(0, 0),
-                        new LinePositionSpan(
-                            new LinePosition(lineSpan.StartLinePosition.Line, lineSpan.StartLinePosition.Character),
-                            new LinePosition(lineSpan.StartLinePosition.Line, lineSpan.StartLinePosition.Character))),
+                    inv.GetLocation(),
                     ex.GetType().Name + ": " + ex.Message));
             }
         }
@@ -280,7 +274,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         int line,
         int col,
         string fileTag,
-        CancellationToken ct)
+        SourceProductionContext spc)
     {
         if (model.GetSymbolInfo(inv).Symbol is not IMethodSymbol method)
             return null;
@@ -300,7 +294,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             return null;
         var hasTransformers = method.Parameters.Length == 2;
 
-        var interceptableLocation = model.GetInterceptableLocation(inv, ct);
+        var interceptableLocation = model.GetInterceptableLocation(inv, spc.CancellationToken);
         if (interceptableLocation is null)
             return null;
         var interceptAttr = interceptableLocation.GetInterceptsLocationAttributeSyntax();
@@ -323,7 +317,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             return null;
 
         // Use ExpressionTreeEmitter to build the expression tree
-        var emitResult = EmitLambdaBody(lam, elemSymbol, model, delegateFqn,
+        var emitResult = EmitLambdaBody(lam, elemSymbol, model, spc, delegateFqn,
             varPrefix: $"i{fileTag}{line}c{col}_", delegateVarName: "__func");
         if (emitResult is null)
             return null;
@@ -362,7 +356,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         int line,
         int col,
         string fileTag,
-        CancellationToken ct)
+        SourceProductionContext spc)
     {
         var ma = (MemberAccessExpressionSyntax)inv.Expression;
 
@@ -397,7 +391,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
         // Get the interceptable location using the Roslyn 5.0+ API.
         // This produces the correct [InterceptsLocation(version, data)] attribute text.
-        var interceptableLocation = model.GetInterceptableLocation(inv, ct);
+        var interceptableLocation = model.GetInterceptableLocation(inv, spc.CancellationToken);
 
         if (interceptableLocation is null)
             return null;
@@ -428,7 +422,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             targetTypeFqn = targetType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         }
 
-        return EmitGenericLambda(inv, model, interceptAttr, line, col, fileTag,
+        return EmitGenericLambda(inv, model, spc, interceptAttr, line, col, fileTag,
             methodName, elementSymbol, elementFqn, method, funcParamIndices, targetTypeFqn);
     }
 
@@ -437,13 +431,12 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     /// <summary>
     /// Uses <see cref="Emitter.ExpressionTreeEmitter"/> to build the expression tree for a lambda body.
     /// Returns the emitter result containing imperative Expression.* factory code, or null on failure.
-    /// Note: <c>context: null</c> is passed to <see cref="Emitter.ExpressionTreeEmitter"/>
-    /// intentionally — emitter diagnostics (EXP0008, EXP0018) are suppressed in this path.
     /// </summary>
     private static Emitter.EmitResult? EmitLambdaBody(
         LambdaExpressionSyntax lambda,
         INamedTypeSymbol elementSymbol,
         SemanticModel model,
+        SourceProductionContext spc,
         string delegateTypeFqn,
         string assignToVariable = "__lambda",
         string varPrefix = "",
@@ -455,8 +448,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         var bodyNode = lambda.Body is ExpressionSyntax expr ? (SyntaxNode)expr : lambda.Body;
         if (bodyNode is null) return null;
 
-        // context: null — SourceProductionContext is not available in the per-node transform.
-        var emitter = new Emitter.ExpressionTreeEmitter(model, context: null, varPrefix: varPrefix, delegateVarName: delegateVarName);
+        var emitter = new Emitter.ExpressionTreeEmitter(model, spc, varPrefix: varPrefix, delegateVarName: delegateVarName);
 
         if (typeAliases is not null)
         {
@@ -549,7 +541,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     /// Non-lambda parameters are forwarded directly to the Queryable.* call.
     /// </summary>
     private static string? EmitGenericLambda(
-        InvocationExpressionSyntax inv, SemanticModel model,
+        InvocationExpressionSyntax inv, SemanticModel model, SourceProductionContext spc,
         string interceptAttr, int line, int col, string fileTag,
         string methodName, INamedTypeSymbol elemSym, string elemFqn,
         IMethodSymbol method, List<int> funcParamIndices, string targetTypeFqn)
@@ -761,7 +753,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             var delegateName = single ? "__func" : $"__func{j + 1}";
             var funcType = (INamedTypeSymbol)method.Parameters[funcParamIndices[j]].Type;
             var lambdaElemSym = funcType.TypeArguments[0] as INamedTypeSymbol ?? elemSym;
-            var emitResult = EmitLambdaBody(lambdas[j], lambdaElemSym, model,
+            var emitResult = EmitLambdaBody(lambdas[j], lambdaElemSym, model, spc,
                 delegateFqns[j], lambdaVar, varPrefix: prefix,
                 typeAliases: hasAnyAnon ? typeAliases : null,
                 delegateVarName: delegateName);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AggregateByTests.AggregateBy_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AggregateByTests.AggregateBy_GeneratesInterceptor.verified.txt
@@ -3,25 +3,25 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Collections.Generic.KeyValuePair<string, decimal>> __Polyfill_AggregateBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Collections.Generic.KeyValuePair<string, decimal>> __Polyfill_AggregateBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func1,
                     decimal seed,
                     global::System.Func<decimal, global::TestNs.Order, decimal> __func2)
         {
             // Source: o => o.Tag
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0a_expr_0, i0a_p_o);
+            var i361d10c18a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18a_expr_0, i361d10c18a_p_o);
             // Source: (acc, o) => acc + o.Price
-            var i0b_p_acc = global::System.Linq.Expressions.Expression.Parameter(typeof(decimal), "acc");
-            var i0b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0b_expr_1 = global::System.Linq.Expressions.Expression.Property(i0b_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Add, i0b_p_acc, i0b_expr_1);
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<decimal, global::TestNs.Order, decimal>>(i0b_expr_0, i0b_p_acc, i0b_p_o);
+            var i361d10c18b_p_acc = global::System.Linq.Expressions.Expression.Parameter(typeof(decimal), "acc");
+            var i361d10c18b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18b_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18b_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
+            var i361d10c18b_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Add, i361d10c18b_p_acc, i361d10c18b_expr_1);
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<decimal, global::TestNs.Order, decimal>>(i361d10c18b_expr_0, i361d10c18b_p_acc, i361d10c18b_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.AggregateBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AggregateByTests.AggregateBy_WithSeedSelector_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AggregateByTests.AggregateBy_WithSeedSelector_GeneratesInterceptor.verified.txt
@@ -3,29 +3,29 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Collections.Generic.KeyValuePair<string, decimal>> __Polyfill_AggregateBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Collections.Generic.KeyValuePair<string, decimal>> __Polyfill_AggregateBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func1,
                     global::System.Func<string, decimal> __func2,
                     global::System.Func<decimal, global::TestNs.Order, decimal> __func3)
         {
             // Source: o => o.Tag
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0a_expr_0, i0a_p_o);
+            var i361d10c18a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18a_expr_0, i361d10c18a_p_o);
             // Source: k => 0m
-            var i0b_p_k = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "k");
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Constant(0m, typeof(decimal)); // 0m
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<string, decimal>>(i0b_expr_0, i0b_p_k);
+            var i361d10c18b_p_k = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "k");
+            var i361d10c18b_expr_0 = global::System.Linq.Expressions.Expression.Constant(0m, typeof(decimal)); // 0m
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<string, decimal>>(i361d10c18b_expr_0, i361d10c18b_p_k);
             // Source: (acc, o) => acc + o.Price
-            var i0c_p_acc = global::System.Linq.Expressions.Expression.Parameter(typeof(decimal), "acc");
-            var i0c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0c_expr_1 = global::System.Linq.Expressions.Expression.Property(i0c_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
-            var i0c_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Add, i0c_p_acc, i0c_expr_1);
-            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<decimal, global::TestNs.Order, decimal>>(i0c_expr_0, i0c_p_acc, i0c_p_o);
+            var i361d10c18c_p_acc = global::System.Linq.Expressions.Expression.Parameter(typeof(decimal), "acc");
+            var i361d10c18c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18c_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18c_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
+            var i361d10c18c_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Add, i361d10c18c_p_acc, i361d10c18c_expr_1);
+            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<decimal, global::TestNs.Order, decimal>>(i361d10c18c_expr_0, i361d10c18c_p_acc, i361d10c18c_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.AggregateBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.Count_AfterAnonymousSelect_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.Count_AfterAnonymousSelect_GeneratesScalarInterceptor.verified.txt
@@ -3,35 +3,35 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static int __Polyfill_Count_0<T0>(
+        internal static int __Polyfill_Count_361d_11_25<T0>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, bool> __func)
         {
             // Source: x => x.Total > 0m
-            var i0_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_x, typeof(T0).GetProperty("Total")); // x.Total
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant(0m, typeof(decimal)); // 0m
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, bool>>(i0_expr_0, i0_p_x);
+            var i361d11c25_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
+            var i361d11c25_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c25_p_x, typeof(T0).GetProperty("Total")); // x.Total
+            var i361d11c25_expr_2 = global::System.Linq.Expressions.Expression.Constant(0m, typeof(decimal)); // 0m
+            var i361d11c25_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d11c25_expr_1, i361d11c25_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, bool>>(i361d11c25_expr_0, i361d11c25_p_x);
             return global::System.Linq.Queryable.Count(
                     (global::System.Linq.IQueryable<T0>)(object)source,
                     __lambda);
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_1<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_10_25<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, o.Total }
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i1_expr_1 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i1_expr_2 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Total")); // o.Total
-            var i1_expr_3 = typeof(T1).GetConstructors()[0];
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.New(i1_expr_3, new global::System.Linq.Expressions.Expression[] { i1_expr_1, i1_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Total") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i1_expr_0, i1_p_o);
+            var i361d10c25_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d10c25_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c25_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d10c25_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d10c25_p_o, typeof(T0).GetProperty("Total")); // o.Total
+            var i361d10c25_expr_3 = typeof(T1).GetConstructors()[0];
+            var i361d10c25_expr_0 = global::System.Linq.Expressions.Expression.New(i361d10c25_expr_3, new global::System.Linq.Expressions.Expression[] { i361d10c25_expr_1, i361d10c25_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Total") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d10c25_expr_0, i361d10c25_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.DistinctBy_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.DistinctBy_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T0> __Polyfill_DistinctBy_0<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T0> __Polyfill_DistinctBy_361d_11_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: x => x.Category
-            var i0_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_x, typeof(T0).GetProperty("Category")); // x.Category
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i0_expr_0, i0_p_x);
+            var i361d11c18_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_x, typeof(T0).GetProperty("Category")); // x.Category
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d11c18_expr_0, i361d11c18_p_x);
             return (global::ExpressiveSharp.IExpressiveQueryable<T0>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.DistinctBy(
@@ -21,17 +21,17 @@ namespace ExpressiveSharp.Generated.Interceptors
                         __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_1<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_10_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, o.Category }
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i1_expr_1 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i1_expr_2 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Category")); // o.Category
-            var i1_expr_3 = typeof(T1).GetConstructors()[0];
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.New(i1_expr_3, new global::System.Linq.Expressions.Expression[] { i1_expr_1, i1_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Category") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d10c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d10c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Category")); // o.Category
+            var i361d10c18_expr_3 = typeof(T1).GetConstructors()[0];
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.New(i361d10c18_expr_3, new global::System.Linq.Expressions.Expression[] { i361d10c18_expr_1, i361d10c18_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Category") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d10c18_expr_0, i361d10c18_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.GroupBy_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.GroupBy_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
@@ -3,35 +3,35 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, global::<anonymous type: int Id, string Category>>> __Polyfill_GroupBy_0<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<T1, T0>> __Polyfill_GroupBy_361d_11_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: x => x.Category
-            var i0_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_x, typeof(T0).GetProperty("Category")); // x.Category
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i0_expr_0, i0_p_x);
-            return (global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, global::<anonymous type: int Id, string Category>>>)(object)
+            var i361d11c18_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_x, typeof(T0).GetProperty("Category")); // x.Category
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d11c18_expr_0, i361d11c18_p_x);
+            return (global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<T1, T0>>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.GroupBy(
                         (global::System.Linq.IQueryable<T0>)(object)source,
                         __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_1<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_10_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, o.Category }
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i1_expr_1 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i1_expr_2 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Category")); // o.Category
-            var i1_expr_3 = typeof(T1).GetConstructors()[0];
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.New(i1_expr_3, new global::System.Linq.Expressions.Expression[] { i1_expr_1, i1_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Category") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d10c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d10c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Category")); // o.Category
+            var i361d10c18_expr_3 = typeof(T1).GetConstructors()[0];
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.New(i361d10c18_expr_3, new global::System.Linq.Expressions.Expression[] { i361d10c18_expr_1, i361d10c18_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Category") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d10c18_expr_0, i361d10c18_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.OrderByDescending_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.OrderByDescending_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T0> __Polyfill_OrderByDescending_0<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T0> __Polyfill_OrderByDescending_361d_11_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: x => x.Name
-            var i0_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_x, typeof(T0).GetProperty("Name")); // x.Name
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i0_expr_0, i0_p_x);
+            var i361d11c18_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_x, typeof(T0).GetProperty("Name")); // x.Name
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d11c18_expr_0, i361d11c18_p_x);
             return (global::ExpressiveSharp.IExpressiveQueryable<T0>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.OrderByDescending(
@@ -21,17 +21,17 @@ namespace ExpressiveSharp.Generated.Interceptors
                         __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_1<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_10_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, o.Name }
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i1_expr_1 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i1_expr_2 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Name")); // o.Name
-            var i1_expr_3 = typeof(T1).GetConstructors()[0];
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.New(i1_expr_3, new global::System.Linq.Expressions.Expression[] { i1_expr_1, i1_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Name") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d10c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d10c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Name")); // o.Name
+            var i361d10c18_expr_3 = typeof(T1).GetConstructors()[0];
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.New(i361d10c18_expr_3, new global::System.Linq.Expressions.Expression[] { i361d10c18_expr_1, i361d10c18_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Name") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d10c18_expr_0, i361d10c18_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.Select_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.Select_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_0<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_11_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: x => x.Id
-            var i0_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_x, typeof(T0).GetProperty("Id")); // x.Id
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i0_expr_0, i0_p_x);
+            var i361d11c18_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_x, typeof(T0).GetProperty("Id")); // x.Id
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d11c18_expr_0, i361d11c18_p_x);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(
@@ -21,17 +21,17 @@ namespace ExpressiveSharp.Generated.Interceptors
                         __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_1<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_10_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, o.Name }
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i1_expr_1 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i1_expr_2 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Name")); // o.Name
-            var i1_expr_3 = typeof(T1).GetConstructors()[0];
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.New(i1_expr_3, new global::System.Linq.Expressions.Expression[] { i1_expr_1, i1_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Name") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d10c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d10c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Name")); // o.Name
+            var i361d10c18_expr_3 = typeof(T1).GetConstructors()[0];
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.New(i361d10c18_expr_3, new global::System.Linq.Expressions.Expression[] { i361d10c18_expr_1, i361d10c18_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Name") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d10c18_expr_0, i361d10c18_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.Where_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/AnonymousElementTests.Where_AfterAnonymousSelect_GeneratesInterceptor.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T0> __Polyfill_Where_0<T0>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T0> __Polyfill_Where_361d_11_18<T0>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, bool> __func)
         {
             // Source: x => x.Total > 100m
-            var i0_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_x, typeof(T0).GetProperty("Total")); // x.Total
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant(100m, typeof(decimal)); // 100m
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, bool>>(i0_expr_0, i0_p_x);
+            var i361d11c18_p_x = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "x");
+            var i361d11c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_x, typeof(T0).GetProperty("Total")); // x.Total
+            var i361d11c18_expr_2 = global::System.Linq.Expressions.Expression.Constant(100m, typeof(decimal)); // 100m
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d11c18_expr_1, i361d11c18_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, bool>>(i361d11c18_expr_0, i361d11c18_p_x);
             return (global::ExpressiveSharp.IExpressiveQueryable<T0>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Where(
@@ -23,17 +23,17 @@ namespace ExpressiveSharp.Generated.Interceptors
                         __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_1<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_10_18<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, o.Total }
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i1_expr_1 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i1_expr_2 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(T0).GetProperty("Total")); // o.Total
-            var i1_expr_3 = typeof(T1).GetConstructors()[0];
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.New(i1_expr_3, new global::System.Linq.Expressions.Expression[] { i1_expr_1, i1_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Total") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d10c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d10c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(T0).GetProperty("Total")); // o.Total
+            var i361d10c18_expr_3 = typeof(T1).GetConstructors()[0];
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.New(i361d10c18_expr_3, new global::System.Linq.Expressions.Expression[] { i361d10c18_expr_1, i361d10c18_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Total") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d10c18_expr_0, i361d10c18_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ComparerOverloadTests.DistinctBy_WithComparer_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ComparerOverloadTests.DistinctBy_WithComparer_GeneratesInterceptor.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_DistinctBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_DistinctBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func,
                     global::System.Collections.Generic.IEqualityComparer<string> comparer)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.DistinctBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ComparerOverloadTests.GroupBy_WithComparer_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ComparerOverloadTests.GroupBy_WithComparer_GeneratesInterceptor.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, global::TestNs.Order>> __Polyfill_GroupBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, global::TestNs.Order>> __Polyfill_GroupBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func,
                     global::System.Collections.Generic.IEqualityComparer<string> comparer)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.GroupBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ComparerOverloadTests.OrderBy_WithComparer_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ComparerOverloadTests.OrderBy_WithComparer_GeneratesInterceptor.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func,
                     global::System.Collections.Generic.IComparer<string> comparer)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.OrderBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdateAsync_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdateAsync_GeneratesInterceptor.verified.txt
@@ -3,22 +3,22 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::System.Threading.Tasks.Task<int> __Polyfill_ExecuteUpdateAsync_0(
+        internal static global::System.Threading.Tasks.Task<int> __Polyfill_ExecuteUpdateAsync_361d_58_24(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>> __func,
                     global::System.Threading.CancellationToken cancellationToken)
         {
             // Source: s => s.SetProperty(o => o.Tag, "updated")
-            var i0_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
+            var i361d58c24_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
             var p_o_1 = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o"); // o => o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_2, p_o_1);
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Constant("updated", typeof(string)); // "updated"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Call(i0_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericParameter && !m.GetParameters()[1].ParameterType.IsGenericType)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i0_expr_3, i0_expr_4 });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i0_expr_0, i0_p_s);
+            var i361d58c24_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d58c24_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d58c24_expr_2, p_o_1);
+            var i361d58c24_expr_4 = global::System.Linq.Expressions.Expression.Constant("updated", typeof(string)); // "updated"
+            var i361d58c24_expr_0 = global::System.Linq.Expressions.Expression.Call(i361d58c24_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericParameter && !m.GetParameters()[1].ParameterType.IsGenericType)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i361d58c24_expr_3, i361d58c24_expr_4 });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i361d58c24_expr_0, i361d58c24_p_s);
             return global::TestNs.MockRelationalExtensions.ExecuteUpdateAsync(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdate_SetProperty_ConstantValue.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdate_SetProperty_ConstantValue.verified.txt
@@ -3,21 +3,21 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static int __Polyfill_ExecuteUpdate_0(
+        internal static int __Polyfill_ExecuteUpdate_361d_58_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>> __func)
         {
             // Source: s => s.SetProperty(o => o.Tag, "updated")
-            var i0_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
+            var i361d58c18_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
             var p_o_1 = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o"); // o => o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_2, p_o_1);
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Constant("updated", typeof(string)); // "updated"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Call(i0_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericParameter && !m.GetParameters()[1].ParameterType.IsGenericType)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i0_expr_3, i0_expr_4 });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i0_expr_0, i0_p_s);
+            var i361d58c18_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d58c18_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d58c18_expr_2, p_o_1);
+            var i361d58c18_expr_4 = global::System.Linq.Expressions.Expression.Constant("updated", typeof(string)); // "updated"
+            var i361d58c18_expr_0 = global::System.Linq.Expressions.Expression.Call(i361d58c18_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericParameter && !m.GetParameters()[1].ParameterType.IsGenericType)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i361d58c18_expr_3, i361d58c18_expr_4 });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i361d58c18_expr_0, i361d58c18_p_s);
             return global::TestNs.MockRelationalExtensions.ExecuteUpdate(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdate_SetProperty_WithNullConditional.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdate_SetProperty_WithNullConditional.verified.txt
@@ -3,30 +3,30 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static int __Polyfill_ExecuteUpdate_0(
+        internal static int __Polyfill_ExecuteUpdate_361d_63_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>> __func)
         {
             // Source: s => s.SetProperty(o => o.Tag, o => o.Customer?.Name ?? "none")
-            var i0_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
+            var i361d63c18_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
             var p_o_1 = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o"); // o => o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_2, p_o_1);
+            var i361d63c18_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d63c18_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d63c18_expr_2, p_o_1);
             var p_o_4 = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o"); // o => o.Customer?.Name ?? "none"
-            var i0_expr_6 = global::System.Linq.Expressions.Expression.Property(p_o_4, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
-            var i0_expr_7 = global::System.Linq.Expressions.Expression.Property(i0_expr_6, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
-            var i0_expr_9 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
-            var i0_expr_10 = global::System.Linq.Expressions.Expression.NotEqual(i0_expr_6, i0_expr_9);
-            var i0_expr_11 = global::System.Linq.Expressions.Expression.Default(typeof(string));
-            var i0_expr_8 = global::System.Linq.Expressions.Expression.Condition(i0_expr_10, i0_expr_7, i0_expr_11, typeof(string));
-            var i0_expr_12 = global::System.Linq.Expressions.Expression.Constant("none", typeof(string)); // "none"
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.Coalesce(i0_expr_8, i0_expr_12);
-            var i0_expr_13 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_5, p_o_4);
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Call(i0_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericType && !m.GetParameters()[1].ParameterType.IsGenericParameter)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i0_expr_3, i0_expr_13 });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i0_expr_0, i0_p_s);
+            var i361d63c18_expr_6 = global::System.Linq.Expressions.Expression.Property(p_o_4, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
+            var i361d63c18_expr_7 = global::System.Linq.Expressions.Expression.Property(i361d63c18_expr_6, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
+            var i361d63c18_expr_9 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
+            var i361d63c18_expr_10 = global::System.Linq.Expressions.Expression.NotEqual(i361d63c18_expr_6, i361d63c18_expr_9);
+            var i361d63c18_expr_11 = global::System.Linq.Expressions.Expression.Default(typeof(string));
+            var i361d63c18_expr_8 = global::System.Linq.Expressions.Expression.Condition(i361d63c18_expr_10, i361d63c18_expr_7, i361d63c18_expr_11, typeof(string));
+            var i361d63c18_expr_12 = global::System.Linq.Expressions.Expression.Constant("none", typeof(string)); // "none"
+            var i361d63c18_expr_5 = global::System.Linq.Expressions.Expression.Coalesce(i361d63c18_expr_8, i361d63c18_expr_12);
+            var i361d63c18_expr_13 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d63c18_expr_5, p_o_4);
+            var i361d63c18_expr_0 = global::System.Linq.Expressions.Expression.Call(i361d63c18_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericType && !m.GetParameters()[1].ParameterType.IsGenericParameter)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i361d63c18_expr_3, i361d63c18_expr_13 });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i361d63c18_expr_0, i361d63c18_p_s);
             return global::TestNs.MockRelationalExtensions.ExecuteUpdate(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdate_SetProperty_WithSwitchExpression.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ExecuteUpdateTests.ExecuteUpdate_SetProperty_WithSwitchExpression.verified.txt
@@ -3,32 +3,32 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static int __Polyfill_ExecuteUpdate_0(
+        internal static int __Polyfill_ExecuteUpdate_361d_62_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>> __func)
         {
             // Source: s => s.SetProperty(o => o.Tag, o => o.Amount switch {     > 100 => "high",     > 50 => "medium",     _ => "low" })
-            var i0_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
+            var i361d62c18_p_s = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>), "s");
             var p_o_1 = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o"); // o => o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_2, p_o_1);
+            var i361d62c18_expr_2 = global::System.Linq.Expressions.Expression.Property(p_o_1, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d62c18_expr_3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d62c18_expr_2, p_o_1);
             var p_o_4 = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o"); // o => o.Amount switch                      {              ...
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.Property(p_o_4, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var i0_expr_6 = global::System.Linq.Expressions.Expression.Constant("low", typeof(string)); // "low"
-            var i0_expr_8 = global::System.Linq.Expressions.Expression.Constant(50, typeof(int)); // 50
-            var i0_expr_7 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_5, i0_expr_8);
-            var i0_expr_9 = global::System.Linq.Expressions.Expression.Constant("medium", typeof(string)); // "medium"
-            var i0_expr_10 = global::System.Linq.Expressions.Expression.Condition(i0_expr_7, i0_expr_9, i0_expr_6, typeof(string));
-            var i0_expr_12 = global::System.Linq.Expressions.Expression.Constant(100, typeof(int)); // 100
-            var i0_expr_11 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_5, i0_expr_12);
-            var i0_expr_13 = global::System.Linq.Expressions.Expression.Constant("high", typeof(string)); // "high"
-            var i0_expr_14 = global::System.Linq.Expressions.Expression.Condition(i0_expr_11, i0_expr_13, i0_expr_10, typeof(string));
-            var i0_expr_15 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_14, p_o_4);
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Call(i0_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericType && !m.GetParameters()[1].ParameterType.IsGenericParameter)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i0_expr_3, i0_expr_15 });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i0_expr_0, i0_p_s);
+            var i361d62c18_expr_5 = global::System.Linq.Expressions.Expression.Property(p_o_4, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var i361d62c18_expr_6 = global::System.Linq.Expressions.Expression.Constant("low", typeof(string)); // "low"
+            var i361d62c18_expr_8 = global::System.Linq.Expressions.Expression.Constant(50, typeof(int)); // 50
+            var i361d62c18_expr_7 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d62c18_expr_5, i361d62c18_expr_8);
+            var i361d62c18_expr_9 = global::System.Linq.Expressions.Expression.Constant("medium", typeof(string)); // "medium"
+            var i361d62c18_expr_10 = global::System.Linq.Expressions.Expression.Condition(i361d62c18_expr_7, i361d62c18_expr_9, i361d62c18_expr_6, typeof(string));
+            var i361d62c18_expr_12 = global::System.Linq.Expressions.Expression.Constant(100, typeof(int)); // 100
+            var i361d62c18_expr_11 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d62c18_expr_5, i361d62c18_expr_12);
+            var i361d62c18_expr_13 = global::System.Linq.Expressions.Expression.Constant("high", typeof(string)); // "high"
+            var i361d62c18_expr_14 = global::System.Linq.Expressions.Expression.Condition(i361d62c18_expr_11, i361d62c18_expr_13, i361d62c18_expr_10, typeof(string));
+            var i361d62c18_expr_15 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d62c18_expr_14, p_o_4);
+            var i361d62c18_expr_0 = global::System.Linq.Expressions.Expression.Call(i361d62c18_p_s, global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::TestNs.SetPropertyCalls<global::TestNs.Order>).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Instance), m => m.Name == "SetProperty" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter && m.GetParameters()[1].ParameterType.IsGenericType && !m.GetParameters()[1].ParameterType.IsGenericParameter)).MakeGenericMethod(typeof(string)), new global::System.Linq.Expressions.Expression[] { i361d62c18_expr_3, i361d62c18_expr_15 });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.SetPropertyCalls<global::TestNs.Order>, global::TestNs.SetPropertyCalls<global::TestNs.Order>>>(i361d62c18_expr_0, i361d62c18_p_s);
             return global::TestNs.MockRelationalExtensions.ExecuteUpdate(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GlobalOptionsTests.Polyfill_GlobalNullConditionalIgnore_UsesIgnoreMode.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GlobalOptionsTests.Polyfill_GlobalNullConditionalIgnore_UsesIgnoreMode.verified.txt
@@ -3,22 +3,22 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, int?>> __Polyfill_Create_0(
+        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, int?>> __Polyfill_Create_361d_9_68(
             global::System.Func<global::TestNs.Order, int?> __func)
         {
             // Source: o => o.Tag?.Length
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_expr_0, typeof(string).GetProperty("Length")); // .Length
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Convert(i0_expr_1, typeof(int?));
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(string));
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i0_expr_0, i0_expr_4);
-            var i0_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(int?));
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Condition(i0_expr_5, i0_expr_2, i0_expr_6, typeof(int?));
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i0_expr_3, i0_p_o);
+            var i361d9c68_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c68_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c68_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d9c68_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c68_expr_0, typeof(string).GetProperty("Length")); // .Length
+            var i361d9c68_expr_2 = global::System.Linq.Expressions.Expression.Convert(i361d9c68_expr_1, typeof(int?));
+            var i361d9c68_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(string));
+            var i361d9c68_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i361d9c68_expr_0, i361d9c68_expr_4);
+            var i361d9c68_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(int?));
+            var i361d9c68_expr_3 = global::System.Linq.Expressions.Expression.Condition(i361d9c68_expr_5, i361d9c68_expr_2, i361d9c68_expr_6, typeof(int?));
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i361d9c68_expr_3, i361d9c68_p_o);
             return __lambda;
         }
     }

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GlobalOptionsTests.Where_GlobalNullConditionalRewrite_AppliesWithoutPerCallOverride.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GlobalOptionsTests.Where_GlobalNullConditionalRewrite_AppliesWithoutPerCallOverride.verified.txt
@@ -3,24 +3,24 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_361d_11_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Customer?.Name == "Alice"
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(i0_expr_1, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i0_expr_1, i0_expr_4);
-            var i0_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(string));
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Condition(i0_expr_5, i0_expr_2, i0_expr_6, typeof(string));
-            var i0_expr_7 = global::System.Linq.Expressions.Expression.Constant("Alice", typeof(string)); // "Alice"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i0_expr_3, i0_expr_7);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d11c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_o, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
+            var i361d11c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d11c18_expr_1, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
+            var i361d11c18_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
+            var i361d11c18_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i361d11c18_expr_1, i361d11c18_expr_4);
+            var i361d11c18_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(string));
+            var i361d11c18_expr_3 = global::System.Linq.Expressions.Expression.Condition(i361d11c18_expr_5, i361d11c18_expr_2, i361d11c18_expr_6, typeof(string));
+            var i361d11c18_expr_7 = global::System.Linq.Expressions.Expression.Constant("Alice", typeof(string)); // "Alice"
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d11c18_expr_3, i361d11c18_expr_7);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d11c18_expr_0, i361d11c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Where(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GlobalOptionsTests.Where_PerCallOverridesGlobal.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GlobalOptionsTests.Where_PerCallOverridesGlobal.verified.txt
@@ -3,24 +3,24 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_361d_11_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Customer?.Name == "Alice"
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(i0_expr_1, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i0_expr_1, i0_expr_4);
-            var i0_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(string));
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Condition(i0_expr_5, i0_expr_2, i0_expr_6, typeof(string));
-            var i0_expr_7 = global::System.Linq.Expressions.Expression.Constant("Alice", typeof(string)); // "Alice"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i0_expr_3, i0_expr_7);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d11c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_o, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
+            var i361d11c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d11c18_expr_1, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
+            var i361d11c18_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
+            var i361d11c18_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i361d11c18_expr_1, i361d11c18_expr_4);
+            var i361d11c18_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(string));
+            var i361d11c18_expr_3 = global::System.Linq.Expressions.Expression.Condition(i361d11c18_expr_5, i361d11c18_expr_2, i361d11c18_expr_6, typeof(string));
+            var i361d11c18_expr_7 = global::System.Linq.Expressions.Expression.Constant("Alice", typeof(string)); // "Alice"
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d11c18_expr_3, i361d11c18_expr_7);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d11c18_expr_0, i361d11c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Where(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_GeneratesGroupingReturnType.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_GeneratesGroupingReturnType.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, global::TestNs.Order>> __Polyfill_GroupBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, global::TestNs.Order>> __Polyfill_GroupBy_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.GroupBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_WithElementAndResultSelector_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_WithElementAndResultSelector_GeneratesInterceptor.verified.txt
@@ -3,27 +3,27 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_GroupBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_GroupBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func1,
                     global::System.Func<global::TestNs.Order, string> __func2,
                     global::System.Func<string, global::System.Collections.Generic.IEnumerable<string>, string> __func3)
         {
             // Source: o => o.Tag
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0a_expr_0, i0a_p_o);
+            var i361d10c18a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18a_expr_0, i361d10c18a_p_o);
             // Source: o => o.Name
-            var i0b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Property(i0b_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0b_expr_0, i0b_p_o);
+            var i361d10c18b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18b_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18b_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18b_expr_0, i361d10c18b_p_o);
             // Source: (key, names) => key
-            var i0c_p_key = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "key");
-            var i0c_p_names = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<string>), "names");
-            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<string, global::System.Collections.Generic.IEnumerable<string>, string>>(i0c_p_key, i0c_p_key, i0c_p_names);
+            var i361d10c18c_p_key = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "key");
+            var i361d10c18c_p_names = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<string>), "names");
+            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<string, global::System.Collections.Generic.IEnumerable<string>, string>>(i361d10c18c_p_key, i361d10c18c_p_key, i361d10c18c_p_names);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.GroupBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_WithElementSelector_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_WithElementSelector_GeneratesInterceptor.verified.txt
@@ -3,22 +3,22 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, string>> __Polyfill_GroupBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Linq.IGrouping<string, string>> __Polyfill_GroupBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func1,
                     global::System.Func<global::TestNs.Order, string> __func2)
         {
             // Source: o => o.Tag
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0a_expr_0, i0a_p_o);
+            var i361d10c18a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18a_expr_0, i361d10c18a_p_o);
             // Source: o => o.Name
-            var i0b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Property(i0b_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0b_expr_0, i0b_p_o);
+            var i361d10c18b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18b_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18b_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18b_expr_0, i361d10c18b_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.GroupBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_WithResultSelector_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/GroupByTests.GroupBy_WithResultSelector_GeneratesInterceptor.verified.txt
@@ -3,22 +3,22 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_GroupBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_GroupBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func1,
                     global::System.Func<string, global::System.Collections.Generic.IEnumerable<global::TestNs.Order>, string> __func2)
         {
             // Source: o => o.Tag
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0a_expr_0, i0a_p_o);
+            var i361d10c18a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18a_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18a_expr_0, i361d10c18a_p_o);
             // Source: (key, orders) => key
-            var i0b_p_key = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "key");
-            var i0b_p_orders = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<global::TestNs.Order>), "orders");
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<string, global::System.Collections.Generic.IEnumerable<global::TestNs.Order>, string>>(i0b_p_key, i0b_p_key, i0b_p_orders);
+            var i361d10c18b_p_key = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "key");
+            var i361d10c18b_p_orders = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<global::TestNs.Order>), "orders");
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<string, global::System.Collections.Generic.IEnumerable<global::TestNs.Order>, string>>(i361d10c18b_p_key, i361d10c18b_p_key, i361d10c18b_p_orders);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.GroupBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.GroupJoin_AnonymousResultSelector_GeneratesGenericInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.GroupJoin_AnonymousResultSelector_GeneratesGenericInterceptor.verified.txt
@@ -3,10 +3,10 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T3> __Polyfill_GroupJoin_0<T0, T1, T2, T3>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T3> __Polyfill_GroupJoin_361d_11_19<T0, T1, T2, T3>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Collections.Generic.IEnumerable<T1> inner,
                     global::System.Func<T0, T2> __func1,
@@ -14,21 +14,21 @@ namespace ExpressiveSharp.Generated.Interceptors
                     global::System.Func<T0, global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>, T3> __func3)
         {
             // Source: o => o.CustomerId
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(T0).GetProperty("CustomerId")); // o.CustomerId
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T2>>(i0a_expr_0, i0a_p_o);
+            var i361d11c19a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d11c19a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19a_p_o, typeof(T0).GetProperty("CustomerId")); // o.CustomerId
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T2>>(i361d11c19a_expr_0, i361d11c19a_p_o);
             // Source: c => c.Id
-            var i0b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(T1), "c");
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Property(i0b_p_c, typeof(T1).GetProperty("Id")); // c.Id
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T1, T2>>(i0b_expr_0, i0b_p_c);
+            var i361d11c19b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(T1), "c");
+            var i361d11c19b_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19b_p_c, typeof(T1).GetProperty("Id")); // c.Id
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T1, T2>>(i361d11c19b_expr_0, i361d11c19b_p_c);
             // Source: (o, cs) => new { o.CustomerId, Count = cs.Count() }
-            var i0c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i0c_p_cs = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>), "cs");
-            var i0c_expr_1 = global::System.Linq.Expressions.Expression.Property(i0c_p_o, typeof(T0).GetProperty("CustomerId")); // o.CustomerId
-            var i0c_expr_2 = global::System.Linq.Expressions.Expression.Call(global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::System.Linq.Enumerable).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static), m => m.Name == "Count" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter)).MakeGenericMethod(typeof(T1)), new global::System.Linq.Expressions.Expression[] { i0c_p_cs }); // cs.Count()
-            var i0c_expr_3 = typeof(T3).GetConstructors()[0];
-            var i0c_expr_0 = global::System.Linq.Expressions.Expression.New(i0c_expr_3, new global::System.Linq.Expressions.Expression[] { i0c_expr_1, i0c_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T3).GetProperty("CustomerId"), typeof(T3).GetProperty("Count") });
-            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>, T3>>(i0c_expr_0, i0c_p_o, i0c_p_cs);
+            var i361d11c19c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d11c19c_p_cs = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>), "cs");
+            var i361d11c19c_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c19c_p_o, typeof(T0).GetProperty("CustomerId")); // o.CustomerId
+            var i361d11c19c_expr_2 = global::System.Linq.Expressions.Expression.Call(global::System.Linq.Enumerable.First(global::System.Linq.Enumerable.Where(typeof(global::System.Linq.Enumerable).GetMethods(global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static), m => m.Name == "Count" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1 && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType.IsGenericType && !m.GetParameters()[0].ParameterType.IsGenericParameter)).MakeGenericMethod(typeof(T1)), new global::System.Linq.Expressions.Expression[] { i361d11c19c_p_cs }); // cs.Count()
+            var i361d11c19c_expr_3 = typeof(T3).GetConstructors()[0];
+            var i361d11c19c_expr_0 = global::System.Linq.Expressions.Expression.New(i361d11c19c_expr_3, new global::System.Linq.Expressions.Expression[] { i361d11c19c_expr_1, i361d11c19c_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T3).GetProperty("CustomerId"), typeof(T3).GetProperty("Count") });
+            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>, T3>>(i361d11c19c_expr_0, i361d11c19c_p_o, i361d11c19c_p_cs);
             return (global::ExpressiveSharp.IExpressiveQueryable<T3>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.GroupJoin(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.GroupJoin_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.GroupJoin_GeneratesInterceptor.verified.txt
@@ -3,10 +3,10 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<int> __Polyfill_GroupJoin_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<int> __Polyfill_GroupJoin_361d_11_19(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Collections.Generic.IEnumerable<global::TestNs.Customer> inner,
                     global::System.Func<global::TestNs.Order, int> __func1,
@@ -14,18 +14,18 @@ namespace ExpressiveSharp.Generated.Interceptors
                     global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>, int> __func3)
         {
             // Source: o => o.CustomerId
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("CustomerId")); // o.CustomerId
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0a_expr_0, i0a_p_o);
+            var i361d11c19a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c19a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19a_p_o, typeof(global::TestNs.Order).GetProperty("CustomerId")); // o.CustomerId
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d11c19a_expr_0, i361d11c19a_p_o);
             // Source: c => c.Id
-            var i0b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Customer), "c");
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Property(i0b_p_c, typeof(global::TestNs.Customer).GetProperty("Id")); // c.Id
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Customer, int>>(i0b_expr_0, i0b_p_c);
+            var i361d11c19b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Customer), "c");
+            var i361d11c19b_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19b_p_c, typeof(global::TestNs.Customer).GetProperty("Id")); // c.Id
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Customer, int>>(i361d11c19b_expr_0, i361d11c19b_p_c);
             // Source: (o, cs) => o.CustomerId
-            var i0c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0c_p_cs = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>), "cs");
-            var i0c_expr_0 = global::System.Linq.Expressions.Expression.Property(i0c_p_o, typeof(global::TestNs.Order).GetProperty("CustomerId")); // o.CustomerId
-            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>, int>>(i0c_expr_0, i0c_p_o, i0c_p_cs);
+            var i361d11c19c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c19c_p_cs = global::System.Linq.Expressions.Expression.Parameter(typeof(global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>), "cs");
+            var i361d11c19c_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19c_p_o, typeof(global::TestNs.Order).GetProperty("CustomerId")); // o.CustomerId
+            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<global::TestNs.Customer>, int>>(i361d11c19c_expr_0, i361d11c19c_p_o, i361d11c19c_p_cs);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.GroupJoin(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.Join_AnonymousResultSelector_GeneratesGenericInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.Join_AnonymousResultSelector_GeneratesGenericInterceptor.verified.txt
@@ -3,10 +3,10 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T3> __Polyfill_Join_0<T0, T1, T2, T3>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T3> __Polyfill_Join_361d_11_19<T0, T1, T2, T3>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Collections.Generic.IEnumerable<T1> inner,
                     global::System.Func<T0, T2> __func1,
@@ -14,21 +14,21 @@ namespace ExpressiveSharp.Generated.Interceptors
                     global::System.Func<T0, T1, T3> __func3)
         {
             // Source: o => o.CustomerId
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(T0).GetProperty("CustomerId")); // o.CustomerId
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T2>>(i0a_expr_0, i0a_p_o);
+            var i361d11c19a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d11c19a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19a_p_o, typeof(T0).GetProperty("CustomerId")); // o.CustomerId
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T2>>(i361d11c19a_expr_0, i361d11c19a_p_o);
             // Source: c => c.Id
-            var i0b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(T1), "c");
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Property(i0b_p_c, typeof(T1).GetProperty("Id")); // c.Id
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T1, T2>>(i0b_expr_0, i0b_p_c);
+            var i361d11c19b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(T1), "c");
+            var i361d11c19b_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19b_p_c, typeof(T1).GetProperty("Id")); // c.Id
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T1, T2>>(i361d11c19b_expr_0, i361d11c19b_p_c);
             // Source: (o, c) => new { o.Product, CustomerName = c.Name }
-            var i0c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i0c_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(T1), "c");
-            var i0c_expr_1 = global::System.Linq.Expressions.Expression.Property(i0c_p_o, typeof(T0).GetProperty("Product")); // o.Product
-            var i0c_expr_2 = global::System.Linq.Expressions.Expression.Property(i0c_p_c, typeof(T1).GetProperty("Name")); // c.Name
-            var i0c_expr_3 = typeof(T3).GetConstructors()[0];
-            var i0c_expr_0 = global::System.Linq.Expressions.Expression.New(i0c_expr_3, new global::System.Linq.Expressions.Expression[] { i0c_expr_1, i0c_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T3).GetProperty("Product"), typeof(T3).GetProperty("CustomerName") });
-            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1, T3>>(i0c_expr_0, i0c_p_o, i0c_p_c);
+            var i361d11c19c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d11c19c_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(T1), "c");
+            var i361d11c19c_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c19c_p_o, typeof(T0).GetProperty("Product")); // o.Product
+            var i361d11c19c_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d11c19c_p_c, typeof(T1).GetProperty("Name")); // c.Name
+            var i361d11c19c_expr_3 = typeof(T3).GetConstructors()[0];
+            var i361d11c19c_expr_0 = global::System.Linq.Expressions.Expression.New(i361d11c19c_expr_3, new global::System.Linq.Expressions.Expression[] { i361d11c19c_expr_1, i361d11c19c_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T3).GetProperty("Product"), typeof(T3).GetProperty("CustomerName") });
+            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1, T3>>(i361d11c19c_expr_0, i361d11c19c_p_o, i361d11c19c_p_c);
             return (global::ExpressiveSharp.IExpressiveQueryable<T3>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Join(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.Join_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/JoinTests.Join_GeneratesInterceptor.verified.txt
@@ -3,10 +3,10 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Join_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Join_361d_11_19(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Collections.Generic.IEnumerable<global::TestNs.Customer> inner,
                     global::System.Func<global::TestNs.Order, int> __func1,
@@ -14,22 +14,22 @@ namespace ExpressiveSharp.Generated.Interceptors
                     global::System.Func<global::TestNs.Order, global::TestNs.Customer, string> __func3)
         {
             // Source: o => o.CustomerId
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("CustomerId")); // o.CustomerId
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0a_expr_0, i0a_p_o);
+            var i361d11c19a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c19a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19a_p_o, typeof(global::TestNs.Order).GetProperty("CustomerId")); // o.CustomerId
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d11c19a_expr_0, i361d11c19a_p_o);
             // Source: c => c.Id
-            var i0b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Customer), "c");
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Property(i0b_p_c, typeof(global::TestNs.Customer).GetProperty("Id")); // c.Id
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Customer, int>>(i0b_expr_0, i0b_p_c);
+            var i361d11c19b_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Customer), "c");
+            var i361d11c19b_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19b_p_c, typeof(global::TestNs.Customer).GetProperty("Id")); // c.Id
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Customer, int>>(i361d11c19b_expr_0, i361d11c19b_p_c);
             // Source: (o, c) => o.Product + " - " + c.Name
-            var i0c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0c_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Customer), "c");
-            var i0c_expr_2 = global::System.Linq.Expressions.Expression.Property(i0c_p_o, typeof(global::TestNs.Order).GetProperty("Product")); // o.Product
-            var i0c_expr_3 = global::System.Linq.Expressions.Expression.Constant(" - ", typeof(string)); // " - "
-            var i0c_expr_1 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i0c_expr_2, i0c_expr_3);
-            var i0c_expr_4 = global::System.Linq.Expressions.Expression.Property(i0c_p_c, typeof(global::TestNs.Customer).GetProperty("Name")); // c.Name
-            var i0c_expr_0 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i0c_expr_1, i0c_expr_4);
-            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::TestNs.Customer, string>>(i0c_expr_0, i0c_p_o, i0c_p_c);
+            var i361d11c19c_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c19c_p_c = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Customer), "c");
+            var i361d11c19c_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d11c19c_p_o, typeof(global::TestNs.Order).GetProperty("Product")); // o.Product
+            var i361d11c19c_expr_3 = global::System.Linq.Expressions.Expression.Constant(" - ", typeof(string)); // " - "
+            var i361d11c19c_expr_1 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i361d11c19c_expr_2, i361d11c19c_expr_3);
+            var i361d11c19c_expr_4 = global::System.Linq.Expressions.Expression.Property(i361d11c19c_p_c, typeof(global::TestNs.Customer).GetProperty("Name")); // c.Name
+            var i361d11c19c_expr_0 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i361d11c19c_expr_1, i361d11c19c_expr_4);
+            var __lambda3 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::TestNs.Customer, string>>(i361d11c19c_expr_0, i361d11c19c_p_o, i361d11c19c_p_c);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Join(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/NullConditionalTests.NullConditionalRewrite_ExpandsInWhereBody.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/NullConditionalTests.NullConditionalRewrite_ExpandsInWhereBody.verified.txt
@@ -3,24 +3,24 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_361d_11_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Customer?.Name == "Alice"
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(i0_expr_1, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i0_expr_1, i0_expr_4);
-            var i0_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(string));
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Condition(i0_expr_5, i0_expr_2, i0_expr_6, typeof(string));
-            var i0_expr_7 = global::System.Linq.Expressions.Expression.Constant("Alice", typeof(string)); // "Alice"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i0_expr_3, i0_expr_7);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d11c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_o, typeof(global::TestNs.Order).GetProperty("Customer")); // o.Customer
+            var i361d11c18_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d11c18_expr_1, typeof(global::TestNs.Customer).GetProperty("Name")); // .Name
+            var i361d11c18_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(global::TestNs.Customer));
+            var i361d11c18_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i361d11c18_expr_1, i361d11c18_expr_4);
+            var i361d11c18_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(string));
+            var i361d11c18_expr_3 = global::System.Linq.Expressions.Expression.Condition(i361d11c18_expr_5, i361d11c18_expr_2, i361d11c18_expr_6, typeof(string));
+            var i361d11c18_expr_7 = global::System.Linq.Expressions.Expression.Constant("Alice", typeof(string)); // "Alice"
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d11c18_expr_3, i361d11c18_expr_7);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d11c18_expr_0, i361d11c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Where(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/OrderByTests.OrderBy_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/OrderByTests.OrderBy_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Priority
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Priority")); // o.Priority
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Priority")); // o.Priority
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.OrderBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/OrderByTests.ThenBy_CastsToIOrderedQueryable.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/OrderByTests.ThenBy_CastsToIOrderedQueryable.verified.txt
@@ -3,31 +3,31 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_ThenBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_ThenBy_361d_11_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Name
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d11c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d11c18_expr_0, i361d11c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.ThenBy(
                     (global::System.Linq.IOrderedQueryable<global::TestNs.Order>)source,
                     __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_1(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Priority
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(global::TestNs.Order).GetProperty("Priority")); // o.Priority
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Priority")); // o.Priority
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.OrderBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/OrderByTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/OrderByTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VerifyMSTest;
 using ExpressiveSharp.Generator.Tests.Infrastructure;

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTargetTests.PolyfillTarget_RoutesToSpecifiedType.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTargetTests.PolyfillTarget_RoutesToSpecifiedType.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::System.Threading.Tasks.Task<bool> __Polyfill_AnyAsync_0(
+        internal static global::System.Threading.Tasks.Task<bool> __Polyfill_AnyAsync_361d_33_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func,
                     global::System.Threading.CancellationToken cancellationToken)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d33c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d33c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d33c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d33c46_expr_0, i361d33c46_p_o);
             return global::TestNs.MockEfExtensions.AnyAsync(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTargetTests.PolyfillTarget_WithoutAttribute_DefaultsToQueryable.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTargetTests.PolyfillTarget_WithoutAttribute_DefaultsToQueryable.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static bool __Polyfill_Any_0(
+        internal static bool __Polyfill_Any_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Any(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_CapturedVariable_GeneratesClosureAccess.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_CapturedVariable_GeneratesClosureAccess.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, bool>> __Polyfill_Create_0(
+        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, bool>> __Polyfill_Create_361d_9_42(
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: (Order o) => o.Price > threshold
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.MakeMemberAccess(global::System.Linq.Expressions.Expression.Constant(__func.Target), __func.Target.GetType().GetField("threshold", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)); // threshold
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c42_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c42_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c42_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
+            var i361d9c42_expr_2 = global::System.Linq.Expressions.Expression.MakeMemberAccess(global::System.Linq.Expressions.Expression.Constant(__func.Target), __func.Target.GetType().GetField("threshold", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)); // threshold
+            var i361d9c42_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d9c42_expr_1, i361d9c42_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c42_expr_0, i361d9c42_p_o);
             return __lambda;
         }
     }

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_InferredTypeArgument_GeneratesExpression.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_InferredTypeArgument_GeneratesExpression.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, bool>> __Polyfill_Create_0(
+        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, bool>> __Polyfill_Create_361d_9_42(
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: (Order o) => o.Tag == "urgent"
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c42_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c42_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c42_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d9c42_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
+            var i361d9c42_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d9c42_expr_1, i361d9c42_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c42_expr_0, i361d9c42_p_o);
             return __lambda;
         }
     }

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_NullConditional_RewritesOperator.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_NullConditional_RewritesOperator.verified.txt
@@ -3,22 +3,22 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, int?>> __Polyfill_Create_0(
+        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, int?>> __Polyfill_Create_361d_9_68(
             global::System.Func<global::TestNs.Order, int?> __func)
         {
             // Source: o => o.Tag?.Length
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_expr_0, typeof(string).GetProperty("Length")); // .Length
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Convert(i0_expr_1, typeof(int?));
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(string));
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i0_expr_0, i0_expr_4);
-            var i0_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(int?));
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Condition(i0_expr_5, i0_expr_2, i0_expr_6, typeof(int?));
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i0_expr_3, i0_p_o);
+            var i361d9c68_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c68_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c68_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d9c68_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c68_expr_0, typeof(string).GetProperty("Length")); // .Length
+            var i361d9c68_expr_2 = global::System.Linq.Expressions.Expression.Convert(i361d9c68_expr_1, typeof(int?));
+            var i361d9c68_expr_4 = global::System.Linq.Expressions.Expression.Constant(null, typeof(string));
+            var i361d9c68_expr_5 = global::System.Linq.Expressions.Expression.NotEqual(i361d9c68_expr_0, i361d9c68_expr_4);
+            var i361d9c68_expr_6 = global::System.Linq.Expressions.Expression.Default(typeof(int?));
+            var i361d9c68_expr_3 = global::System.Linq.Expressions.Expression.Condition(i361d9c68_expr_5, i361d9c68_expr_2, i361d9c68_expr_6, typeof(int?));
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i361d9c68_expr_3, i361d9c68_p_o);
             return __lambda;
         }
     }

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_SimpleLambda_GeneratesExpression.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/PolyfillTests.Polyfill_SimpleLambda_GeneratesExpression.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, bool>> __Polyfill_Create_0(
+        internal static global::System.Linq.Expressions.Expression<global::System.Func<global::TestNs.Order, bool>> __Polyfill_Create_361d_9_68(
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Tag == "urgent"
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c68_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c68_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c68_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d9c68_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
+            var i361d9c68_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d9c68_expr_1, i361d9c68_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c68_expr_0, i361d9c68_p_o);
             return __lambda;
         }
     }

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.All_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.All_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static bool __Polyfill_All_0(
+        internal static bool __Polyfill_All_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.All(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Any_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Any_GeneratesScalarInterceptor.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static bool __Polyfill_Any_0(
+        internal static bool __Polyfill_Any_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Tag == "urgent"
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d9c46_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d9c46_expr_1, i361d9c46_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Any(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_DecimalSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_DecimalSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static decimal __Polyfill_Average_0(
+        internal static decimal __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, decimal> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_DoubleSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_DoubleSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double __Polyfill_Average_0(
+        internal static double __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, double> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_FloatSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_FloatSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static float __Polyfill_Average_0(
+        internal static float __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, float> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_IntSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_IntSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double __Polyfill_Average_0(
+        internal static double __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_LongSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_LongSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double __Polyfill_Average_0(
+        internal static double __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, long> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableDecimalSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableDecimalSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static decimal? __Polyfill_Average_0(
+        internal static decimal? __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, decimal?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableDoubleSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableDoubleSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double? __Polyfill_Average_0(
+        internal static double? __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, double?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableFloatSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableFloatSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static float? __Polyfill_Average_0(
+        internal static float? __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, float?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableIntSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableIntSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double? __Polyfill_Average_0(
+        internal static double? __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableLongSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Average_NullableLongSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double? __Polyfill_Average_0(
+        internal static double? __Polyfill_Average_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, long?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Average(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Count_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Count_GeneratesScalarInterceptor.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static int __Polyfill_Count_0(
+        internal static int __Polyfill_Count_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Amount > 100
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant(100, typeof(int)); // 100
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var i361d9c46_expr_2 = global::System.Linq.Expressions.Expression.Constant(100, typeof(int)); // 100
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d9c46_expr_1, i361d9c46_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Count(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.FirstOrDefault_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.FirstOrDefault_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_FirstOrDefault_0(
+        internal static global::TestNs.Order __Polyfill_FirstOrDefault_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.FirstOrDefault(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.First_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.First_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_First_0(
+        internal static global::TestNs.Order __Polyfill_First_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.First(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.LastOrDefault_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.LastOrDefault_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_LastOrDefault_0(
+        internal static global::TestNs.Order __Polyfill_LastOrDefault_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.LastOrDefault(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Last_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Last_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_Last_0(
+        internal static global::TestNs.Order __Polyfill_Last_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Last(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.LongCount_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.LongCount_GeneratesScalarInterceptor.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static long __Polyfill_LongCount_0(
+        internal static long __Polyfill_LongCount_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Amount > 100
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant(100, typeof(int)); // 100
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var i361d9c46_expr_2 = global::System.Linq.Expressions.Expression.Constant(100, typeof(int)); // 100
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d9c46_expr_1, i361d9c46_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.LongCount(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.MaxBy_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.MaxBy_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_MaxBy_0(
+        internal static global::TestNs.Order __Polyfill_MaxBy_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.MaxBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Max_GenericSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Max_GenericSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static string __Polyfill_Max_0(
+        internal static string __Polyfill_Max_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Name
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Max(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.MinBy_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.MinBy_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_MinBy_0(
+        internal static global::TestNs.Order __Polyfill_MinBy_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.MinBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Min_GenericSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Min_GenericSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static string __Polyfill_Min_0(
+        internal static string __Polyfill_Min_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Name
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Min(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.SingleOrDefault_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.SingleOrDefault_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_SingleOrDefault_0(
+        internal static global::TestNs.Order __Polyfill_SingleOrDefault_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.SingleOrDefault(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Single_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Single_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::TestNs.Order __Polyfill_Single_0(
+        internal static global::TestNs.Order __Polyfill_Single_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Single(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_DecimalSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_DecimalSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static decimal __Polyfill_Sum_0(
+        internal static decimal __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, decimal> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_DoubleSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_DoubleSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double __Polyfill_Sum_0(
+        internal static double __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, double> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_FloatSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_FloatSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static float __Polyfill_Sum_0(
+        internal static float __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, float> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_IntSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_IntSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static int __Polyfill_Sum_0(
+        internal static int __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_LongSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_LongSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static long __Polyfill_Sum_0(
+        internal static long __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, long> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableDecimalSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableDecimalSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static decimal? __Polyfill_Sum_0(
+        internal static decimal? __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, decimal?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, decimal?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableDoubleSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableDoubleSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static double? __Polyfill_Sum_0(
+        internal static double? __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, double?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, double?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableFloatSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableFloatSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static float? __Polyfill_Sum_0(
+        internal static float? __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, float?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, float?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableIntSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableIntSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static int? __Polyfill_Sum_0(
+        internal static int? __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableLongSelector_GeneratesScalarInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.Sum_NullableLongSelector_GeneratesScalarInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static long? __Polyfill_Sum_0(
+        internal static long? __Polyfill_Sum_361d_9_46(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, long?> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long?>>(i0_expr_0, i0_p_o);
+            var i361d9c46_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c46_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c46_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, long?>>(i361d9c46_expr_0, i361d9c46_p_o);
             return global::System.Linq.Queryable.Sum(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda);

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectManyTests.SelectMany_CollectionSelector_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectManyTests.SelectMany_CollectionSelector_GeneratesInterceptor.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_SelectMany_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_SelectMany_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<string>> __func)
         {
             // Source: o => o.Tags
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tags")); // o.Tags
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Convert(i0_expr_0, typeof(global::System.Collections.Generic.IEnumerable<string>));
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<string>>>(i0_expr_1, i0_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tags")); // o.Tags
+            var i361d10c18_expr_1 = global::System.Linq.Expressions.Expression.Convert(i361d10c18_expr_0, typeof(global::System.Collections.Generic.IEnumerable<string>));
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<string>>>(i361d10c18_expr_1, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.SelectMany(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectManyTests.SelectMany_WithResultSelector_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectManyTests.SelectMany_WithResultSelector_GeneratesInterceptor.verified.txt
@@ -3,27 +3,27 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_SelectMany_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_SelectMany_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<string>> __func1,
                     global::System.Func<global::TestNs.Order, string, string> __func2)
         {
             // Source: o => o.Tags
-            var i0a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0a_expr_0 = global::System.Linq.Expressions.Expression.Property(i0a_p_o, typeof(global::TestNs.Order).GetProperty("Tags")); // o.Tags
-            var i0a_expr_1 = global::System.Linq.Expressions.Expression.Convert(i0a_expr_0, typeof(global::System.Collections.Generic.IEnumerable<string>));
-            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<string>>>(i0a_expr_1, i0a_p_o);
+            var i361d10c18a_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18a_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18a_p_o, typeof(global::TestNs.Order).GetProperty("Tags")); // o.Tags
+            var i361d10c18a_expr_1 = global::System.Linq.Expressions.Expression.Convert(i361d10c18a_expr_0, typeof(global::System.Collections.Generic.IEnumerable<string>));
+            var __lambda1 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::System.Collections.Generic.IEnumerable<string>>>(i361d10c18a_expr_1, i361d10c18a_p_o);
             // Source: (o, t) => o.Name + ": " + t
-            var i0b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0b_p_t = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "t");
-            var i0b_expr_2 = global::System.Linq.Expressions.Expression.Property(i0b_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var i0b_expr_3 = global::System.Linq.Expressions.Expression.Constant(": ", typeof(string)); // ": "
-            var i0b_expr_1 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i0b_expr_2, i0b_expr_3);
-            var i0b_expr_0 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i0b_expr_1, i0b_p_t);
-            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string, string>>(i0b_expr_0, i0b_p_o, i0b_p_t);
+            var i361d10c18b_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18b_p_t = global::System.Linq.Expressions.Expression.Parameter(typeof(string), "t");
+            var i361d10c18b_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d10c18b_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var i361d10c18b_expr_3 = global::System.Linq.Expressions.Expression.Constant(": ", typeof(string)); // ": "
+            var i361d10c18b_expr_1 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i361d10c18b_expr_2, i361d10c18b_expr_3);
+            var i361d10c18b_expr_0 = global::System.Linq.Expressions.Expression.Call(typeof(string).GetMethod("Concat", global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.Static, null, new global::System.Type[] { typeof(string), typeof(string) }, null), i361d10c18b_expr_1, i361d10c18b_p_t);
+            var __lambda2 = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string, string>>(i361d10c18b_expr_0, i361d10c18b_p_o, i361d10c18b_p_t);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.SelectMany(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectTests.Select_AnonymousType_GeneratesGenericInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectTests.Select_AnonymousType_GeneratesGenericInterceptor.verified.txt
@@ -3,20 +3,20 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_0<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_9_33<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, o.Name }
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(T0).GetProperty("Name")); // o.Name
-            var i0_expr_3 = typeof(T1).GetConstructors()[0];
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.New(i0_expr_3, new global::System.Linq.Expressions.Expression[] { i0_expr_1, i0_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Name") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d9c33_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d9c33_expr_2 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(T0).GetProperty("Name")); // o.Name
+            var i361d9c33_expr_3 = typeof(T1).GetConstructors()[0];
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.New(i361d9c33_expr_3, new global::System.Linq.Expressions.Expression[] { i361d9c33_expr_1, i361d9c33_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Name") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d9c33_expr_0, i361d9c33_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectTests.Select_AnonymousType_WithComputedExpression_GeneratesCorrectly.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectTests.Select_AnonymousType_WithComputedExpression_GeneratesCorrectly.verified.txt
@@ -3,23 +3,23 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_0<T0, T1>(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<T1> __Polyfill_Select_361d_9_33<T0, T1>(
             this global::ExpressiveSharp.IExpressiveQueryable<T0> source,
             global::System.Func<T0, T1> __func)
         {
             // Source: o => new { o.Id, Total = o.Price * o.Qty }
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(T0).GetProperty("Id")); // o.Id
-            var i0_expr_3 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(T0).GetProperty("Price")); // o.Price
-            var i0_expr_5 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(T0).GetProperty("Qty")); // o.Qty
-            var i0_expr_4 = global::System.Linq.Expressions.Expression.Convert(i0_expr_5, typeof(decimal));
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Multiply, i0_expr_3, i0_expr_4);
-            var i0_expr_6 = typeof(T1).GetConstructors()[0];
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.New(i0_expr_6, new global::System.Linq.Expressions.Expression[] { i0_expr_1, i0_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Total") });
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(T0), "o");
+            var i361d9c33_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(T0).GetProperty("Id")); // o.Id
+            var i361d9c33_expr_3 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(T0).GetProperty("Price")); // o.Price
+            var i361d9c33_expr_5 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(T0).GetProperty("Qty")); // o.Qty
+            var i361d9c33_expr_4 = global::System.Linq.Expressions.Expression.Convert(i361d9c33_expr_5, typeof(decimal));
+            var i361d9c33_expr_2 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Multiply, i361d9c33_expr_3, i361d9c33_expr_4);
+            var i361d9c33_expr_6 = typeof(T1).GetConstructors()[0];
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.New(i361d9c33_expr_6, new global::System.Linq.Expressions.Expression[] { i361d9c33_expr_1, i361d9c33_expr_2 }, new global::System.Reflection.MemberInfo[] { typeof(T1).GetProperty("Id"), typeof(T1).GetProperty("Total") });
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<T0, T1>>(i361d9c33_expr_0, i361d9c33_p_o);
             return (global::ExpressiveSharp.IExpressiveQueryable<T1>)(object)
                 global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                     global::System.Linq.Queryable.Select(

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectTests.Select_NamedType_GeneratesConcreteInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SelectTests.Select_NamedType_GeneratesConcreteInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Select_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Select_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Name
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Select(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SetOperationTests.ExceptBy_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SetOperationTests.ExceptBy_GeneratesInterceptor.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_ExceptBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_ExceptBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Collections.Generic.IEnumerable<string> second,
                     global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.ExceptBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SetOperationTests.IntersectBy_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SetOperationTests.IntersectBy_GeneratesInterceptor.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_IntersectBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_IntersectBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Collections.Generic.IEnumerable<string> second,
                     global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.IntersectBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SetOperationTests.UnionBy_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SetOperationTests.UnionBy_GeneratesInterceptor.verified.txt
@@ -3,18 +3,18 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_UnionBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_UnionBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Collections.Generic.IEnumerable<string> second,
                     global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.UnionBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.CountBy_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.CountBy_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Collections.Generic.KeyValuePair<string, int>> __Polyfill_CountBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::System.Collections.Generic.KeyValuePair<string, int>> __Polyfill_CountBy_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.CountBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.DistinctBy_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.DistinctBy_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_DistinctBy_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_DistinctBy_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.DistinctBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.OrderByDescending_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.OrderByDescending_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderByDescending_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderByDescending_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Amount
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.OrderByDescending(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.SkipWhile_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.SkipWhile_GeneratesInterceptor.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_SkipWhile_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_SkipWhile_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Amount < 50
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant(50, typeof(int)); // 50
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.LessThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var i361d9c33_expr_2 = global::System.Linq.Expressions.Expression.Constant(50, typeof(int)); // 50
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.LessThan, i361d9c33_expr_1, i361d9c33_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.SkipWhile(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.TakeWhile_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.TakeWhile_GeneratesInterceptor.verified.txt
@@ -3,17 +3,17 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_TakeWhile_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_TakeWhile_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Active
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Active")); // o.Active
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.TakeWhile(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.ThenByDescending_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.ThenByDescending_GeneratesInterceptor.verified.txt
@@ -3,31 +3,31 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_ThenByDescending_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_ThenByDescending_361d_11_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Tag
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d11c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d11c18_expr_0, i361d11c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.ThenByDescending(
                     (global::System.Linq.IOrderedQueryable<global::TestNs.Order>)source,
                     __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_1(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_OrderBy_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, int> __func)
         {
             // Source: o => o.Amount
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Amount")); // o.Amount
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, int>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.OrderBy(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/SingleLambdaQueryableTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VerifyMSTest;
 using ExpressiveSharp.Generator.Tests.Infrastructure;

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.ChainedWhereAndSelect_GeneratesTwoInterceptors.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.ChainedWhereAndSelect_GeneratesTwoInterceptors.verified.txt
@@ -3,33 +3,33 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Select_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Select_361d_11_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, string> __func)
         {
             // Source: o => o.Name
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i0_expr_0, i0_p_o);
+            var i361d11c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c18_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c18_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, string>>(i361d11c18_expr_0, i361d11c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Select(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,
                     __lambda));
         }
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_1(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_361d_10_18(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Tag == "urgent"
-            var i1_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i1_expr_1 = global::System.Linq.Expressions.Expression.Property(i1_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i1_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
-            var i1_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i1_expr_1, i1_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i1_expr_0, i1_p_o);
+            var i361d10c18_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d10c18_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d10c18_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d10c18_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
+            var i361d10c18_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d10c18_expr_1, i361d10c18_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d10c18_expr_0, i361d10c18_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Where(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.Where_CapturedInstanceField_GeneratesClosureAccess.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.Where_CapturedInstanceField_GeneratesClosureAccess.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_361d_11_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Price > _minPrice
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
-            var i0_expr_2 = __ClosureHelper.ResolveCapturedInstanceMember(__func, typeof(global::TestNs.TestClass), "_minPrice"); // _minPrice
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d11c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c33_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d11c33_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
+            var i361d11c33_expr_2 = __ClosureHelper.ResolveCapturedInstanceMember(__func, typeof(global::TestNs.TestClass), "_minPrice"); // _minPrice
+            var i361d11c33_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d11c33_expr_1, i361d11c33_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d11c33_expr_0, i361d11c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Where(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.Where_CapturedVariable_GeneratesClosureAccess.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.Where_CapturedVariable_GeneratesClosureAccess.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Price > minPrice
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.MakeMemberAccess(global::System.Linq.Expressions.Expression.Constant(__func.Target), __func.Target.GetType().GetField("minPrice", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)); // minPrice
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Price")); // o.Price
+            var i361d9c33_expr_2 = global::System.Linq.Expressions.Expression.MakeMemberAccess(global::System.Linq.Expressions.Expression.Constant(__func.Target), __func.Target.GetType().GetField("minPrice", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic)); // minPrice
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.GreaterThan, i361d9c33_expr_1, i361d9c33_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Where(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.Where_SimpleCondition_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.Where_SimpleCondition_GeneratesInterceptor.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> __Polyfill_Where_361d_9_33(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Func<global::TestNs.Order, bool> __func)
         {
             // Source: o => o.Tag == "urgent"
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_expr_1 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
-            var i0_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i0_expr_1, i0_expr_2);
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i0_expr_0, i0_p_o);
+            var i361d9c33_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d9c33_expr_1 = global::System.Linq.Expressions.Expression.Property(i361d9c33_p_o, typeof(global::TestNs.Order).GetProperty("Tag")); // o.Tag
+            var i361d9c33_expr_2 = global::System.Linq.Expressions.Expression.Constant("urgent", typeof(string)); // "urgent"
+            var i361d9c33_expr_0 = global::System.Linq.Expressions.Expression.MakeBinary(global::System.Linq.Expressions.ExpressionType.Equal, i361d9c33_expr_1, i361d9c33_expr_2);
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, bool>>(i361d9c33_expr_0, i361d9c33_p_o);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Where(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/WhereTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VerifyMSTest;
 using ExpressiveSharp.Generator.Tests.Infrastructure;

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ZipTests.Zip_WithResultSelector_GeneratesInterceptor.verified.txt
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ZipTests.Zip_WithResultSelector_GeneratesInterceptor.verified.txt
@@ -3,19 +3,19 @@
 
 namespace ExpressiveSharp.Generated.Interceptors
 {
-    internal static class PolyfillInterceptors
+    internal static partial class PolyfillInterceptors
     {
         [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(/* scrubbed */)]
-        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Zip_0(
+        internal static global::ExpressiveSharp.IExpressiveQueryable<string> __Polyfill_Zip_361d_11_19(
             this global::ExpressiveSharp.IExpressiveQueryable<global::TestNs.Order> source,
             global::System.Collections.Generic.IEnumerable<global::TestNs.Price> second,
                     global::System.Func<global::TestNs.Order, global::TestNs.Price, string> __func)
         {
             // Source: (o, p) => o.Name
-            var i0_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
-            var i0_p_p = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Price), "p");
-            var i0_expr_0 = global::System.Linq.Expressions.Expression.Property(i0_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
-            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::TestNs.Price, string>>(i0_expr_0, i0_p_o, i0_p_p);
+            var i361d11c19_p_o = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Order), "o");
+            var i361d11c19_p_p = global::System.Linq.Expressions.Expression.Parameter(typeof(global::TestNs.Price), "p");
+            var i361d11c19_expr_0 = global::System.Linq.Expressions.Expression.Property(i361d11c19_p_o, typeof(global::TestNs.Order).GetProperty("Name")); // o.Name
+            var __lambda = global::System.Linq.Expressions.Expression.Lambda<global::System.Func<global::TestNs.Order, global::TestNs.Price, string>>(i361d11c19_expr_0, i361d11c19_p_o, i361d11c19_p_p);
             return global::ExpressiveSharp.ExpressiveQueryableExtensions.AsExpressive(
                 global::System.Linq.Queryable.Zip(
                     (global::System.Linq.IQueryable<global::TestNs.Order>)source,


### PR DESCRIPTION
I noticed a single file was emitted for every generated polyfill, which might become problematic, here are the benchmarks, for multiple files :

<img width="1193" height="387" alt="image" src="https://github.com/user-attachments/assets/c1a7a1a7-592f-4cad-b7a1-fe6cf51a4331" />
