### PR TITLE
perf(polyfill): skip semantic binding on non-lambda invocations

### DIFF
--- a/benchmarks/ExpressiveSharp.Benchmarks/PolyfillGeneratorBenchmarks.cs
+++ b/benchmarks/ExpressiveSharp.Benchmarks/PolyfillGeneratorBenchmarks.cs
@@ -288,3 +288,129 @@ public static class BenchHelper { public static string Describe(int id) => $""#{
         return sources;
     }
 }
+
+/// <summary>
+/// Cold-build cost in a codebase where query files are mixed with ordinary non-lambda
+/// member-access calls (<c>sb.Append(x)</c>, <c>list.Add(x)</c>, <c>Console.WriteLine</c>)
+/// — the shape of real production code.
+/// <para>
+/// Fixed 10 files × 5 real call sites per file; <see cref="NoiseInvocationsPerFile"/>
+/// controls how many non-intercept invocations sit alongside them. The gap between
+/// <c>NoiseInvocationsPerFile = 0</c> and higher values reflects how well the generator
+/// filters out invocations it cannot intercept.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class PolyfillColdBuildWithNoiseBenchmarks
+{
+    [Params(0, 25, 100)]
+    public int NoiseInvocationsPerFile { get; set; }
+
+    private const int FileCount = 10;
+    private const int CallSitesPerFile = 5;
+
+    private Compilation _compilation = null!;
+    private GeneratorDriver _warmedDriver = null!;
+    private Compilation _callSiteFileModified = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var sources = BuildSources(FileCount, CallSitesPerFile, NoiseInvocationsPerFile);
+        _compilation = CreateCompilation(sources);
+
+        _warmedDriver = CSharpGeneratorDriver
+            .Create(new PolyfillInterceptorGenerator())
+            .RunGenerators(_compilation);
+
+        // Index FileCount = last query file (has CallSitesPerFile real call sites + noise)
+        var callSiteTree = _compilation.SyntaxTrees.ElementAt(FileCount);
+        _callSiteFileModified = _compilation.ReplaceSyntaxTree(
+            callSiteTree,
+            callSiteTree.WithChangedText(SourceText.From(callSiteTree.GetText() + "\n// bench-edit")));
+    }
+
+    // ── Generator-only (no compilation rebuild) ──────────────────────────────
+
+    [Benchmark(Baseline = true)]
+    public GeneratorDriver Cold()
+        => CSharpGeneratorDriver
+            .Create(new PolyfillInterceptorGenerator())
+            .RunGenerators(_compilation);
+
+    [Benchmark]
+    public GeneratorDriver Incremental_EditCallSiteFile()
+        => _warmedDriver.RunGenerators(_callSiteFileModified);
+
+    // ── End-to-end (generator + Roslyn compilation rebuild) ──────────────────
+
+    [Benchmark]
+    public GeneratorDriver Cold_E2E()
+        => CSharpGeneratorDriver
+            .Create(new PolyfillInterceptorGenerator())
+            .RunGeneratorsAndUpdateCompilation(_compilation, out _, out _);
+
+    [Benchmark]
+    public GeneratorDriver Incremental_EditCallSiteFile_E2E()
+        => _warmedDriver.RunGeneratorsAndUpdateCompilation(_callSiteFileModified, out _, out _);
+
+    private static Compilation CreateCompilation(IReadOnlyList<string> sources)
+    {
+        var refs = Basic.Reference.Assemblies.Net100.References.All.ToList();
+        refs.Add(MetadataReference.CreateFromFile(typeof(ExpressiveAttribute).Assembly.Location));
+        return CSharpCompilation.Create(
+            "PolyfillColdBuildNoiseBench",
+            sources.Select((s, i) => CSharpSyntaxTree.ParseText(s, path: $"PolyfillNoise{i}.cs")),
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static IReadOnlyList<string> BuildSources(int fileCount, int sitesPerFile, int noisePerFile)
+    {
+        // index 0: entity
+        var sources = new List<string>
+        {
+            @"using System.Linq; using ExpressiveSharp; namespace PolyfillBench;
+public class BenchEntity { public int Id { get; set; } public string Name { get; set; } = """"; }"
+        };
+
+        // indices 1..fileCount: query files (real call sites + noise invocations)
+        var sb = new StringBuilder();
+        for (var f = 0; f < fileCount; f++)
+        {
+            sb.Clear();
+            sb.AppendLine("using System; using System.Linq; using System.Text; using System.Collections.Generic; using ExpressiveSharp;");
+            sb.AppendLine("namespace PolyfillBench;");
+            sb.AppendLine($"public static class NoisyQueries{f} {{");
+
+            for (var i = 0; i < sitesPerFile; i++)
+                sb.AppendLine($"  public static IQueryable<int> Q{f}_{i}(IExpressiveQueryable<BenchEntity> q) => q.Select(x => x.Id + {f * 100 + i});");
+
+            if (noisePerFile > 0)
+            {
+                sb.AppendLine($"  public static string Helper{f}() {{");
+                sb.AppendLine("    var buf = new StringBuilder();");
+                sb.AppendLine("    var items = new List<int>();");
+                for (var n = 0; n < noisePerFile; n++)
+                {
+                    // Rotate through common call shapes so the sample isn't pathologically uniform.
+                    switch (n % 5)
+                    {
+                        case 0: sb.AppendLine($"    buf.Append(\"a{n}\");"); break;
+                        case 1: sb.AppendLine($"    buf.AppendLine(\"line{n}\");"); break;
+                        case 2: sb.AppendLine($"    items.Add({n});"); break;
+                        case 3: sb.AppendLine($"    Console.WriteLine(\"msg{n}\");"); break;
+                        case 4: sb.AppendLine($"    buf.Insert(0, {n}.ToString());"); break;
+                    }
+                }
+                sb.AppendLine("    return buf.ToString();");
+                sb.AppendLine("  }");
+            }
+
+            sb.AppendLine("}");
+            sources.Add(sb.ToString());
+        }
+
+        return sources;
+    }
+}

--- a/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
+++ b/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
@@ -105,12 +105,14 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             {
                 ct.ThrowIfCancellationRequested();
                 var unit = (CompilationUnitSyntax)ctx.Node;
-                // Quick syntactic pre-filter: any member-access invocation with ≥1 argument?
+                // Every intercepted call site (Polyfill.Create + IExpressiveQueryable stubs)
+                // takes at least one lambda argument. Files with no lambda-bearing invocations
+                // can't contain anything we'd intercept, so drop them before semantic binding.
                 foreach (var descendant in unit.DescendantNodes())
                 {
                     if (descendant is InvocationExpressionSyntax inv &&
                         inv.Expression is MemberAccessExpressionSyntax &&
-                        inv.ArgumentList.Arguments.Count > 0)
+                        HasLambdaArgument(inv))
                         return unit;
                 }
                 return null;
@@ -162,8 +164,8 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         foreach (var descendant in unit.DescendantNodes())
         {
             if (descendant is not InvocationExpressionSyntax inv) continue;
-            if (inv.Expression is not MemberAccessExpressionSyntax) continue;
-            if (inv.ArgumentList.Arguments.Count == 0) continue;
+            if (inv.Expression is not MemberAccessExpressionSyntax ma) continue;
+            if (!HasLambdaArgument(inv)) continue;
 
             ct.ThrowIfCancellationRequested();
             try
@@ -171,13 +173,25 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 // Use the METHOD NAME token position for stable, unique naming.
                 // Using the invocation's span-start would collide in chained calls
                 // (e.g. query.AsExpressive().Where(…) — both start at 'query').
-                var ma = (MemberAccessExpressionSyntax)inv.Expression;
                 var nameLineSpan = ma.Name.GetLocation().GetLineSpan();
                 var line = nameLineSpan.StartLinePosition.Line;
                 var col  = nameLineSpan.StartLinePosition.Character;
 
-                var methodCode = TryEmitPolyfill(inv, model, line, col, fileTag, spc)
-                              ?? TryEmit(inv, model, line, col, fileTag, spc);
+                // Exclusive dispatch: ExpressionPolyfill.Create<T> takes the polyfill path,
+                // everything else takes the IExpressiveQueryable path.
+                if (model.GetSymbolInfo(inv).Symbol is not IMethodSymbol method) continue;
+
+                string? methodCode;
+                if (ma.Name.Identifier.Text == PolyfillMethodName &&
+                    method.ContainingType?.ToDisplayString() == PolyfillTypeName)
+                {
+                    methodCode = TryEmitPolyfill(inv, model, method, line, col, fileTag, spc);
+                }
+                else
+                {
+                    methodCode = TryEmit(inv, ma, model, method, line, col, fileTag, spc);
+                }
+
                 if (methodCode is null) continue;
 
                 methodCodes.Add(methodCode);
@@ -271,19 +285,13 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     /// </summary>
     private static string? TryEmitPolyfill(InvocationExpressionSyntax inv,
         SemanticModel model,
+        IMethodSymbol method,
         int line,
         int col,
         string fileTag,
         SourceProductionContext spc)
     {
-        if (model.GetSymbolInfo(inv).Symbol is not IMethodSymbol method)
-            return null;
-
-        // Must be ExpressionPolyfill.Create<TDelegate>(...)
-        if (method.Name != PolyfillMethodName)
-            return null;
-        if (method.ContainingType?.ToDisplayString() != PolyfillTypeName)
-            return null;
+        // Caller guarantees method is ExpressionPolyfill.Create.
         if (method.TypeArguments.Length != 1)
             return null;
 
@@ -352,23 +360,20 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     // ── Per-invocation dispatch (IExpressiveQueryable) ───────────────────────
 
     private static string? TryEmit(InvocationExpressionSyntax inv,
+        MemberAccessExpressionSyntax ma,
         SemanticModel model,
+        IMethodSymbol method,
         int line,
         int col,
         string fileTag,
         SourceProductionContext spc)
     {
-        var ma = (MemberAccessExpressionSyntax)inv.Expression;
-
         // Receiver must be or implement IExpressiveQueryable<T>.
         if (model.GetTypeInfo(ma.Expression).Type is not INamedTypeSymbol receiverType)
             return null;
 
         // Check both the type itself and its implemented interfaces
         if (!IsExpressiveQueryable(receiverType))
-            return null;
-
-        if (model.GetSymbolInfo(inv).Symbol is not IMethodSymbol method)
             return null;
 
         // The stub convention: at least one non-receiver parameter must be a Func<> delegate,
@@ -519,6 +524,17 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         => type is INamedTypeSymbol { IsAnonymousType: true };
 
     // ── Formatting helpers ───────────────────────────────────────────────────
+
+    private static bool HasLambdaArgument(InvocationExpressionSyntax inv)
+    {
+        var args = inv.ArgumentList.Arguments;
+        for (var i = 0; i < args.Count; i++)
+        {
+            if (args[i].Expression is LambdaExpressionSyntax)
+                return true;
+        }
+        return false;
+    }
 
     /// <summary>
     /// Produces a unique, stable interceptor method name based on the call site's


### PR DESCRIPTION
## Summary

- Narrow the `PolyfillInterceptorGenerator` syntactic predicate to require a lambda argument before engaging the `SemanticModel`. Non-lambda member-access calls (`sb.Append`, `list.Add`, `Console.WriteLine`, …) are filtered out before any `GetSymbolInfo` / `GetTypeInfo`.
- Bind the method symbol once per surviving invocation and dispatch exclusively (`ExpressionPolyfill.Create` vs `IExpressiveQueryable`), gated by a cheap method-name-token check for the polyfill path.
- Add `PolyfillColdBuildWithNoiseBenchmarks` covering the case the existing benches can't: real call sites mixed with ordinary non-intercept invocations (the shape of production code).

## Why

PR #41 fixed incremental IDE edits via reference-equality caching on `CompilationUnitSyntax`. It does not fix two other paths:

1. **Cold builds** (first compile, CI, post-clean) — every transform runs from scratch.
2. **Edits to files that contain call sites** — full file re-enters the transform.

On both, the pre-existing predicate fired `GetSymbolInfo` on every `MemberAccessExpressionSyntax` invocation with ≥1 arg, including tens of thousands of ordinary non-LINQ calls. Every intercepted call site the generator actually emits takes a lambda, so requiring a lambda syntactically is a safe, strong filter.

## Results

Measured with `PolyfillColdBuildWithNoiseBenchmarks` (10 files × 5 real call sites, `NoiseInvocationsPerFile` varied):

| Scenario | Noise=0 | Noise=25 | Noise=100 |
|---|---|---|---|
| `Cold` baseline | 3,489 µs | 10,858 µs | **81,511 µs** |
| `Cold` optimized | 3,414 µs | 3,711 µs | **4,171 µs** |
| Speedup | 1.0× | 2.9× | **19.5×** |
| `Cold_E2E` baseline | 3,580 µs | 11,354 µs | **155,758 µs** |
| `Cold_E2E` optimized | 3,469 µs | 3,655 µs | **4,150 µs** |
| Speedup | 1.0× | 3.1× | **37.5×** |
| `Incremental_EditCallSiteFile` baseline | 386 µs | 2,125 µs | 5,385 µs |
| `Incremental_EditCallSiteFile` optimized | 409 µs | 419 µs | 463 µs |

Memory at noise=100: 5,538 KB → 1,965 KB (**−64 %**).

At noise=0 everything is within measurement noise, so PR #41's incremental-edit win is preserved intact.

## Safety

- Method-group args (`query.Select(SomeMethod)`) and `Func<>`-variable args (`query.Select(f)`) were never intercepted — both `TryEmitPolyfill` and `EmitGenericLambda` already returned null for them, and the stubs throw `UnreachableException` at runtime. The tighter predicate drops these one step earlier; observable behavior is identical.
- `EXP0013` (warns on non-`[Expressive]` method groups) lives in `ExpressiveSharp.CodeFixers`, an independent analyzer. Unaffected.
- Full test suites pass: generator snapshot tests (1239), `ExpressiveSharp.IntegrationTests` (228), `ExpressiveSharp.EntityFrameworkCore.IntegrationTests` (562). Every `.verified.txt` matches byte-for-byte, so the intercepted set and emitted code are unchanged.

## Test plan

- [x] `dotnet test tests/ExpressiveSharp.Generator.Tests` — 1239 passed (net8/9/10)
- [x] `dotnet test tests/ExpressiveSharp.IntegrationTests` — 228 passed
- [x] `dotnet test tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests` — 562 passed
- [x] `PolyfillColdBuildWithNoiseBenchmarks` baseline + optimized run on the same machine, numbers above
- [x] `PolyfillSingleFileBenchmarks` + `PolyfillMultiFileBenchmarks` spot-checked — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)