### PR TITLE
chore: remove bloated comments across the codebase

### DIFF
--- a/src/Docs/Playground.Wasm/Program.cs
+++ b/src/Docs/Playground.Wasm/Program.cs
@@ -11,10 +11,9 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.RegisterCustomElement<PlaygroundHost>("expressive-playground");
 
 // BaseAddress must point to the playground's own directory (where _framework/
-// lives) so PlaygroundReferences can fetch reference DLLs. When the web
-// component is hosted on a VitePress page, HostEnvironment.BaseAddress is
-// the docs site root — not the playground subdirectory. We detect this by
-// checking whether the base ends with /playground/.
+// lives) so PlaygroundReferences can fetch reference DLLs. On a VitePress page
+// HostEnvironment.BaseAddress is the docs site root, not the playground
+// subdirectory — detect by checking whether the base ends with /playground/.
 var baseAddress = builder.HostEnvironment.BaseAddress;
 if (!baseAddress.TrimEnd('/').EndsWith("/_playground", StringComparison.OrdinalIgnoreCase)
     && !baseAddress.TrimEnd('/').EndsWith("/playground", StringComparison.OrdinalIgnoreCase))
@@ -29,8 +28,6 @@ builder.Services.AddSingleton<PlaygroundRuntime>();
 
 var host = builder.Build();
 
-// Register Monaco completion + hover providers via our JS interop module.
-// The DotNetObjectReference callbacks dispatch to PlaygroundLanguageServices.
 var runtime = host.Services.GetRequiredService<PlaygroundRuntime>();
 var jsRuntime = host.Services.GetRequiredService<IJSRuntime>();
 
@@ -40,10 +37,8 @@ await jsRuntime.InvokeVoidAsync("monacoInterop.registerHoverProvider", providerR
 
 await host.RunAsync();
 
-/// <summary>
-/// Bridge object exposed to JS via DotNetObjectReference. Monaco's completion
-/// and hover providers call back into these [JSInvokable] methods.
-/// </summary>
+// Bridge object exposed to JS via DotNetObjectReference. Monaco's completion
+// and hover providers call back into these [JSInvokable] methods.
 internal sealed class MonacoLanguageProviderBridge
 {
     private readonly PlaygroundRuntime _runtime;

--- a/src/Docs/Playground.Wasm/Services/ManagedSqliteStub.cs
+++ b/src/Docs/Playground.Wasm/Services/ManagedSqliteStub.cs
@@ -1,16 +1,12 @@
-// ManagedSqliteStub — a fully-managed SQLitePCL.ISQLite3Provider implementation
-// that EF Core can interrogate at startup *without* needing the native sqlite3
-// engine. The playground only ever calls ToQueryString() on a queryable; that
-// path goes through EF Core's relational query translator and never executes
-// real SQL, but the SqliteUpdateSqlGenerator constructor probes
-// connection.ServerVersion → SQLitePCL.raw.sqlite3_libversion() during DI
-// graph construction. This stub answers the metadata calls that EF Core makes
-// during model build, and throws NotSupportedException for anything that would
-// require running real queries.
+// Fully-managed SQLitePCL.ISQLite3Provider so EF Core can be interrogated at
+// startup without the native sqlite3 engine. The playground only calls
+// ToQueryString() — never executes real SQL — but SqliteUpdateSqlGenerator's
+// ctor probes connection.ServerVersion → sqlite3_libversion() during DI graph
+// construction. This stub answers the metadata calls EF Core makes during
+// model build; everything else throws.
 //
-// The interface has 152 methods (utf8z is a ref struct so DispatchProxy can't
-// be used). Most just throw — only a handful of "metadata" calls have real
-// answers. Generated from reflection at design time and committed.
+// utf8z is a ref struct so DispatchProxy can't be used; the 152 methods are
+// generated from reflection at design time and committed.
 
 #pragma warning disable IDE0060 // Unused parameters — interface forces us to declare them
 
@@ -20,10 +16,7 @@ namespace ExpressiveSharp.Docs.Playground.Wasm.Services;
 
 public sealed class ManagedSqliteStub : ISQLite3Provider
 {
-    /// <summary>
-    /// Registers this stub as the global SQLitePCL provider. Idempotent.
-    /// Must be called before any DbContext that uses Sqlite.Core is constructed.
-    /// </summary>
+    // Idempotent — must be called before any DbContext using Sqlite.Core is constructed.
     public static void Register()
     {
         try
@@ -32,36 +25,29 @@ public sealed class ManagedSqliteStub : ISQLite3Provider
         }
         catch (System.InvalidOperationException)
         {
-            // SetProvider throws if a provider is already registered. Tolerate
-            // double-registration so the stub can be installed eagerly from
-            // multiple host entrypoints (Program.cs, test setup, etc).
+            // SetProvider throws if a provider is already registered; tolerate
+            // double-registration from multiple host entrypoints.
         }
     }
 
-    // ── Metadata calls EF Core makes during DbContext init ─────────────────
-
-    // Reported as the SQLite library version. EF Core uses this for feature
-    // detection (RETURNING clause support added in 3.35). Reporting a recent
-    // version unlocks all relational translator features.
+    // EF Core uses libversion for feature detection (RETURNING added in 3.35).
+    // Reporting a recent version unlocks all relational translator features.
     public utf8z sqlite3_libversion() => utf8z.FromString("3.45.0");
 
-    // Companion to libversion. Format is major*1_000_000 + minor*1_000 + patch.
+    // Format is major*1_000_000 + minor*1_000 + patch.
     public int sqlite3_libversion_number() => 3045000;
 
     public utf8z sqlite3_sourceid() => utf8z.FromString("managed-stub-no-sourceid");
 
-    // 1 = single-threaded. WASM is single-threaded anyway.
     public int sqlite3_threadsafe() => 1;
 
     public string GetNativeLibraryName() => "managed-stub";
 
-    // SQLitePCL.raw initializes by calling these once. They must succeed.
+    // SQLitePCL.raw calls these once during init — they must succeed.
     public int sqlite3_initialize() => 0; // SQLITE_OK
     public int sqlite3_shutdown() => 0;
     public int sqlite3_config_log(global::SQLitePCL.delegate_log @func, global::System.Object @v) => 0;
     public int sqlite3_enable_shared_cache(int @enable) => 0;
-
-    // ── Everything else throws ─────────────────────────────────────────────
 
     private static System.Exception NotSupported(string method) =>
         new System.NotSupportedException(

--- a/src/Docs/Playground.Wasm/Services/MonacoTypes.cs
+++ b/src/Docs/Playground.Wasm/Services/MonacoTypes.cs
@@ -1,8 +1,7 @@
 namespace ExpressiveSharp.Docs.Playground.Wasm.Services;
 
-// DTOs for JSInterop serialization with Monaco editor.
-// These replace the BlazorMonaco C# types with plain records
-// that serialize cleanly to/from the Monaco JS API.
+// DTOs for JSInterop with Monaco editor; replace BlazorMonaco's types with
+// plain records that serialize cleanly to/from the Monaco JS API.
 
 public sealed class MonacoPosition
 {
@@ -50,7 +49,6 @@ public sealed class MonacoMarkerData
     public int EndColumn { get; set; }
 }
 
-// Completion types
 public sealed class MonacoCompletionList
 {
     public List<MonacoCompletionItem> Suggestions { get; set; } = new();
@@ -68,7 +66,6 @@ public sealed class MonacoCompletionItem
     public MonacoRange? Range { get; set; }
 }
 
-// Hover types
 public sealed class MonacoHover
 {
     public List<MonacoMarkdownString> Contents { get; set; } = new();
@@ -81,7 +78,7 @@ public sealed class MonacoMarkdownString
     public bool IsTrusted { get; set; }
 }
 
-// Monaco CompletionItemKind enum values (matching monaco.languages.CompletionItemKind)
+// Values match monaco.languages.CompletionItemKind.
 public static class MonacoCompletionItemKind
 {
     public const int Method = 0;
@@ -109,7 +106,7 @@ public static class MonacoCompletionItemKind
     public const int TypeParameter = 24;
 }
 
-// Monaco MarkerSeverity values (matching monaco.MarkerSeverity)
+// Values match monaco.MarkerSeverity.
 public static class MonacoMarkerSeverity
 {
     public const int Hint = 1;

--- a/src/Docs/Playground.Wasm/Services/PlaygroundLanguageServices.cs
+++ b/src/Docs/Playground.Wasm/Services/PlaygroundLanguageServices.cs
@@ -1,12 +1,10 @@
-// PlaygroundLanguageServices — long-lived AdhocWorkspace that backs Monaco's
-// completion + hover providers. Separate from SnippetCompiler (which builds
-// fresh CSharpCompilations per keystroke for the run path); the workspace's
-// incremental semantic model gives sub-ms per-keystroke completion.
-//
-// Architecture inspired by DotNetLab/src/Compiler/LanguageServices.cs (MIT):
-// one AdhocWorkspace, one Project, one Document per <expressive-playground>
-// instance routed by Monaco model URI. The DefaultPersistentStorageConfiguration
-// cctor PNSE is bypassed by the WorkspaceShim project — see its header.
+// Long-lived AdhocWorkspace backing Monaco's completion + hover providers; the
+// incremental semantic model gives sub-ms per-keystroke completion. Separate
+// from SnippetCompiler, which builds fresh CSharpCompilations per run.
+// One Document per <expressive-playground> instance, routed by Monaco model
+// URI. The DefaultPersistentStorageConfiguration cctor PNSE on WASM is bypassed
+// by the WorkspaceShim project — see its header.
+// Architecture inspired by DotNetLab/src/Compiler/LanguageServices.cs (MIT).
 
 using ExpressiveSharp.Docs.Playground.Core.Services;
 using ExpressiveSharp.Docs.Playground.Core.Services.Scenarios;
@@ -38,11 +36,10 @@ internal sealed class PlaygroundLanguageServices : IDisposable
             throw new InvalidOperationException(
                 "PlaygroundReferences must be loaded before PlaygroundLanguageServices is constructed.");
 
-        // Append the WorkspaceShim assembly AFTER MefHostServices.DefaultAssemblies.
-        // The shim's NoOpPersistentStorageConfiguration is exported with
-        // ServiceLayer.Test which gives it MEF priority over Roslyn's broken
-        // DefaultPersistentStorageConfiguration, so the latter's cctor never
-        // runs and Process.GetCurrentProcess() (PNSE on WASM) is never called.
+        // Append WorkspaceShim AFTER DefaultAssemblies. Its NoOpPersistentStorageConfiguration
+        // exports with ServiceLayer.Test, gaining MEF priority over Roslyn's
+        // DefaultPersistentStorageConfiguration so the latter's cctor never runs
+        // (it calls Process.GetCurrentProcess() — PNSE on WASM).
         var hostServices = MefHostServices.Create(
             MefHostServices.DefaultAssemblies
                 .Append(typeof(NoOpPersistentStorageConfiguration).Assembly));
@@ -56,8 +53,7 @@ internal sealed class PlaygroundLanguageServices : IDisposable
             assemblyName: "PlaygroundProject",
             language: LanguageNames.CSharp,
             metadataReferences: references.References,
-            // WithConcurrentBuild(false): WASM is single-threaded, parallel
-            // Roslyn compile threads deadlock or throw.
+            // WASM is single-threaded; parallel Roslyn compile threads deadlock or throw.
             compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                 .WithNullableContextOptions(NullableContextOptions.Enable)
                 .WithConcurrentBuild(false),
@@ -67,12 +63,9 @@ internal sealed class PlaygroundLanguageServices : IDisposable
         _projectId = projectInfo.Id;
     }
 
-    /// <summary>
-    /// Forces MEF composition during page load instead of lazily on the first
-    /// keystroke. Adds a throwaway document, asks for its CompletionService
-    /// (the act of resolving it triggers MEF + the cctor moment WorkspaceShim
-    /// guards against), discards. Subsequent real completions hit warm caches.
-    /// </summary>
+    // Forces MEF composition during page load instead of lazily on the first
+    // keystroke. Resolving CompletionService triggers MEF + the cctor moment
+    // WorkspaceShim guards against; subsequent real completions hit warm caches.
     public async Task PrewarmAsync()
     {
         await _lock.WaitAsync();
@@ -117,8 +110,7 @@ internal sealed class PlaygroundLanguageServices : IDisposable
         await _lock.WaitAsync();
         try
         {
-            // Drop any prior document under the same URI (rare — happens if
-            // an instance disposes and remounts) to avoid duplicate routing.
+            // Drop any prior document under the same URI (instance dispose + remount).
             if (_modelToDocument.TryGetValue(modelUri, out var existingId))
             {
                 _workspace.TryApplyChanges(_workspace.CurrentSolution.RemoveDocument(existingId));
@@ -137,7 +129,7 @@ internal sealed class PlaygroundLanguageServices : IDisposable
         }
     }
 
-    // Per-keystroke (no debounce — Roslyn diffs the syntax tree, sub-ms).
+    // Called per-keystroke; no debounce — Roslyn diffs the syntax tree (sub-ms).
     public async Task UpdateEditorAsync(string modelUri, string snippetText, string? setupText, IPlaygroundScenario scenario)
     {
         var wrap = SnippetWrap.Build(scenario.WrapperTemplate, snippetText, setupText);
@@ -158,7 +150,6 @@ internal sealed class PlaygroundLanguageServices : IDisposable
         }
     }
 
-    // Best-effort: silently no-ops if the model URI is unknown.
     public async Task UnregisterEditorAsync(string modelUri)
     {
         await _lock.WaitAsync();
@@ -236,9 +227,9 @@ internal sealed class PlaygroundLanguageServices : IDisposable
     }
 
     // Returns -1 if the position falls outside the snippet region.
+    // Monaco is 1-based, LinePosition is 0-based.
     private static int MonacoPositionToCaretOffset(MonacoPosition position, SourceText text, SnippetWrap wrap)
     {
-        // Monaco is 1-based, LinePosition is 0-based.
         var snippetRelative = new LinePosition(
             line: Math.Max(0, position.LineNumber - 1),
             character: Math.Max(0, position.Column - 1));

--- a/src/Docs/Playground.Wasm/Services/PlaygroundReferences.cs
+++ b/src/Docs/Playground.Wasm/Services/PlaygroundReferences.cs
@@ -1,12 +1,7 @@
-// PlaygroundReferences — fetches the reference assemblies the SnippetCompiler
-// needs into MetadataReference instances. In a Blazor WASM app every loaded
-// assembly is shipped under /_framework/<name>.dll, so we use HttpClient to
-// pull the raw bytes and feed them to MetadataReference.CreateFromImage.
-//
-// The reference set is the union of every scenario's ReferenceAssemblies,
-// loaded once at startup and cached. Adding a new scenario in Phase 2
-// automatically extends the reference set with its assemblies — no edits to
-// this file are required.
+// In Blazor WASM every loaded assembly ships under /_framework/<name>.dll, so
+// HttpClient pulls the raw bytes and feeds them to MetadataReference.CreateFromImage.
+// The reference set is the union of every scenario's ReferenceAssemblies —
+// adding a scenario to ScenarioRegistry automatically extends the set.
 
 using System.Collections.Immutable;
 using Basic.Reference.Assemblies;
@@ -36,17 +31,9 @@ internal sealed class PlaygroundReferences : IPlaygroundReferences
 
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();
 
-        // .NET 10 ref-only BCL — embedded as resources in the
-        // Basic.Reference.Assemblies.Net100 assembly. No HTTP needed; the
-        // package's own embedded resources are loaded by the normal Blazor
-        // assembly loader at startup.
+        // .NET 10 ref-only BCL — embedded resources in Basic.Reference.Assemblies.Net100.
         builder.AddRange(Net100.References.All);
 
-        // Take the union of every scenario's ReferenceAssemblies. With one
-        // scenario today this loads ExpressiveSharp + ExpressiveSharp.EntityFrameworkCore
-        // + EF Core 10 + the PlaygroundModel assembly. Future scenarios are
-        // additive: registering a Mongo scenario in ScenarioRegistry would
-        // automatically pull in MongoDB.Driver here.
         var seenNames = new HashSet<string>(StringComparer.Ordinal);
         var fetchTasks = new List<Task<MetadataReference?>>();
 
@@ -78,8 +65,7 @@ internal sealed class PlaygroundReferences : IPlaygroundReferences
         }
         catch (HttpRequestException)
         {
-            // Missing DLL → skip; Roslyn surfaces a "missing reference" diagnostic
-            // later if the snippet actually needs the type.
+            // Missing DLL → skip; Roslyn reports "missing reference" later if needed.
             return null;
         }
     }

--- a/src/Docs/Playground.Wasm/Services/PlaygroundRuntime.cs
+++ b/src/Docs/Playground.Wasm/Services/PlaygroundRuntime.cs
@@ -1,7 +1,7 @@
-// PlaygroundRuntime — singleton DI service shared by every PlaygroundHost on
-// the page. Owns the reference set, the SnippetCompiler, the IntelliSense
-// workspace, the lazy-loaded provider assemblies, and a per-page compile cache.
-// Provider-neutral; dispatch goes through IPlaygroundScenario / IScenarioInstance.
+// Singleton DI service shared by every PlaygroundHost on the page; owns the
+// reference set, SnippetCompiler, IntelliSense workspace, lazy-loaded provider
+// assemblies, and per-page compile cache. Dispatch goes through
+// IPlaygroundScenario / IScenarioInstance.
 
 using ExpressiveSharp.Docs.Playground.Core.Services;
 using ExpressiveSharp.Docs.Playground.Core.Services.Scenarios;
@@ -11,11 +11,9 @@ namespace ExpressiveSharp.Docs.Playground.Wasm.Services;
 
 internal sealed class PlaygroundRuntime : IAsyncDisposable
 {
-    /// <summary>Sentinel target id for the universal "show generator output" target.</summary>
+    // Sentinel target id for the universal "show generator output" target.
     public const string GeneratorTargetId = "generator";
 
-    // Bounded so a runaway editor session can't grow the cache forever.
-    // Realistic page sessions hit ~10–20 distinct snippets at most.
     private const int CompileCacheMaxSize = 32;
 
     private readonly PlaygroundReferences _references;
@@ -43,20 +41,13 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
         _languageServices ?? throw new InvalidOperationException(
             "PlaygroundRuntime.LanguageServices accessed before InitializeAsync completed.");
 
-    /// <summary>
-    /// Most recent target id chosen by any PlaygroundHost on the page. Dynamic
-    /// instances mounting after a broadcast read this to pick up the active
-    /// target instead of the scenario default.
-    /// </summary>
+    // Most recent target id chosen by any PlaygroundHost on the page. Dynamic
+    // instances mounting after a broadcast read this to pick up the active
+    // target instead of the scenario default.
     public string? SharedTargetId => _sharedTargetId;
 
     public void SetSharedTargetId(string targetId) => _sharedTargetId = targetId;
 
-    /// <summary>
-    /// One-time async init: loads reference assemblies, instantiates the
-    /// SnippetCompiler, prewarms the IntelliSense workspace. Idempotent and
-    /// safe under concurrent callers via _initLock.
-    /// </summary>
     public async Task InitializeAsync()
     {
         if (_initialized) return;
@@ -68,9 +59,6 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
             await _references.LoadAsync();
             _compiler = new SnippetCompiler(_references);
             _languageServices = new PlaygroundLanguageServices(_references);
-            // Prewarm forces MEF composition (and the cctor moment that would
-            // otherwise PNSE in WASM without WorkspaceShim) up-front, so the
-            // first user keystroke hits a warm cache.
             await _languageServices.PrewarmAsync();
             _initialized = true;
         }
@@ -80,12 +68,9 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// Compiles a snippet and renders it through the chosen target. Memoized
-    /// by (scenarioId, setup, snippet); the cache stores the snippet's Run
-    /// method as a callable Func so multi-provider scenarios can invoke it
-    /// against a different argument per render target without recompiling.
-    /// </summary>
+    // Memoized by (scenarioId, setup, snippet); the cache stores the snippet's
+    // Run method as a callable Func so multi-provider scenarios can invoke it
+    // against a different argument per render target without recompiling.
     public async Task<RenderResult> RunAsync(
         string snippet,
         string? setup,
@@ -95,9 +80,9 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
         if (!_initialized || _compiler is null)
             throw new InvalidOperationException("PlaygroundRuntime is not initialized.");
 
-        // Lazy-load before the cache check + Task.Run, because LazyAssemblyLoader
-        // yields to the JS event loop while fetching and the assembly must be
-        // resolved before any IL referencing it gets JIT-compiled.
+        // Must run before the cache check + Task.Run: LazyAssemblyLoader yields
+        // to the JS event loop, and the assembly must be resolved before any IL
+        // referencing it gets JIT-compiled.
         var renderTarget = scenario.RenderTargets.FirstOrDefault(t => t.Id == targetId);
         if (renderTarget?.LazyLoadAssemblies is { Count: > 0 } lazyAssemblies)
         {
@@ -165,15 +150,13 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
         });
     }
 
-    // Null bytes between fields prevent ambiguous concatenation collisions.
-    // targetId is intentionally NOT in the key — the cache serves any target
-    // from one compile.
+    // Null bytes prevent ambiguous concatenation collisions. targetId is
+    // intentionally NOT in the key — one compile serves any target.
     private static string MakeCompileCacheKey(string scenarioId, string? setup, string snippet) =>
         scenarioId + "\0" + (setup ?? "") + "\0" + snippet;
 
-    // Idempotent — re-loaded assemblies are skipped via _loadedLazyAssemblies.
     // The lock serializes concurrent loads from a dropdown broadcast hitting
-    // all 6 instances at once with the same target.
+    // multiple instances at once with the same target.
     private async Task EnsureLazyAssembliesLoadedAsync(IReadOnlyList<string> assemblyFileNames)
     {
         var needsLoad = false;
@@ -214,11 +197,6 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
         _compileCache[key] = entry;
     }
 
-    // Looks up the render target, gets its query argument from the scenario
-    // instance, invokes the cached Run method, runs the target's render
-    // delegate. The reflection invoke is ~1ms — fast enough for dropdown
-    // thrash where 6 instances re-render against the same cache entry with
-    // different per-target arguments.
     private RenderResult RenderFromCache(CachedCompile cached, string targetId, IPlaygroundScenario scenario)
     {
         try
@@ -280,10 +258,9 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
         return fresh;
     }
 
-    // Splits diagnostics into snippet markers (in-region; translated to user
-    // coordinates for Monaco squiggles) and setup messages (in-setup-region;
-    // shown in PlaygroundHost's error block since Monaco doesn't see setup).
-    // Anything anchored elsewhere in the wrapped source is dropped.
+    // Snippet markers go to Monaco squiggles (translated to user coordinates);
+    // setup messages go to PlaygroundHost's error block since Monaco doesn't
+    // see setup. Anything anchored elsewhere in the wrapped source is dropped.
     private static (List<SnippetMarker> snippet, List<string> setup) PartitionDiagnostics(CompileResult result)
     {
         var snippetMarkers = new List<SnippetMarker>();
@@ -305,8 +282,7 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
                     StartLine: startRel.Line + 1,
                     StartColumn: startRel.Character + 1,
                     EndLine: endRel.Line + 1,
-                    // Force at least one column of width so zero-width
-                    // diagnostics still get a visible squiggle.
+                    // At least one column wide so zero-width diagnostics still get a squiggle.
                     EndColumn: Math.Max(endRel.Character + 1, startRel.Character + 2)));
             }
             else if (result.Wrap.IsInSetup(span.Start))
@@ -318,9 +294,8 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
         return (snippetMarkers, setupMessages);
     }
 
-    // Walks reflection wrapper exceptions to surface the actual root cause —
-    // TargetInvocationException wraps anything thrown by a reflection-invoked
-    // method body, TypeInitializationException wraps cctor failures.
+    // Unwraps TargetInvocationException / TypeInitializationException to surface
+    // the actual root cause from reflection-invoked methods and cctor failures.
     private static Exception Unwrap(Exception ex)
     {
         while (true)
@@ -368,10 +343,8 @@ internal sealed class PlaygroundRuntime : IAsyncDisposable
     }
 }
 
-/// <summary>
-/// Diagnostic in the user's snippet region with positions already translated
-/// to snippet-relative 1-based coordinates for Monaco's setModelMarkers.
-/// </summary>
+// Diagnostic in the user's snippet region with positions translated to
+// snippet-relative 1-based coordinates for Monaco's setModelMarkers.
 internal sealed record SnippetMarker(
     Microsoft.CodeAnalysis.DiagnosticSeverity Severity,
     string Code,

--- a/src/Docs/Playground.WasmWorkspaceShim/NoOpPersistentStorageConfiguration.cs
+++ b/src/Docs/Playground.WasmWorkspaceShim/NoOpPersistentStorageConfiguration.cs
@@ -1,24 +1,21 @@
 // Adapted from DotNetLab/src/RoslynWorkspaceAccess/RoslynWorkspaceAccessors.cs (MIT).
-// https://github.com/jjonescz/DotNetLab
 //
-// Why this exists: Roslyn's DefaultPersistentStorageConfiguration..cctor() calls
-// Process.GetCurrentProcess(), which throws PlatformNotSupportedException on
-// Blazor WebAssembly. MEF discovers it on the first CompletionService.GetService()
-// call inside an AdhocWorkspace. By exporting our own IPersistentStorageConfiguration
-// with ServiceLayer.Test, MEF prefers ours over the default and never instantiates
-// the broken type — its cctor never runs, the PNSE is never thrown, and completions
-// work in WASM.
+// Roslyn's DefaultPersistentStorageConfiguration..cctor() calls
+// Process.GetCurrentProcess(), which PNSEs on Blazor WebAssembly; MEF
+// discovers it on the first CompletionService.GetService() inside an
+// AdhocWorkspace. Exporting our own IPersistentStorageConfiguration with
+// ServiceLayer.Test gives it MEF priority over the default so the broken
+// type's cctor never runs.
 //
-// This file lives in an assembly whose AssemblyName is impersonated to
-// "Microsoft.CodeAnalysis.Workspaces.UnitTests" (see csproj) so Roslyn's
-// [InternalsVisibleTo] attribute lets us reference IPersistentStorageConfiguration,
-// MefConstruction, ExportWorkspaceServiceAttribute, and ServiceLayer — all of
-// which are `internal` in Microsoft.CodeAnalysis.Workspaces.dll.
+// The csproj impersonates AssemblyName "Microsoft.CodeAnalysis.Workspaces.UnitTests"
+// so Roslyn's [InternalsVisibleTo] lets us reference the internal types
+// IPersistentStorageConfiguration, MefConstruction, ExportWorkspaceServiceAttribute,
+// and ServiceLayer.
 
 using System.Composition;
-using Microsoft.CodeAnalysis.Host;       // IPersistentStorageConfiguration
-using Microsoft.CodeAnalysis.Host.Mef;   // ExportWorkspaceService, ServiceLayer, MefConstruction
-using Microsoft.CodeAnalysis.Storage;    // SolutionKey
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Storage;
 
 namespace ExpressiveSharp.Docs.Playground.Wasm.WorkspaceShim;
 

--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/Customer.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/Customer.cs
@@ -1,8 +1,3 @@
-// Plain data only — no [Expressive] members. Samples that demonstrate
-// computed members do so with their own inline [Expressive] extension methods
-// declared in the snippet's `setup` attribute, so the docs reader sees the
-// definition next to the query that uses it.
-
 namespace ExpressiveSharp.Docs.PlaygroundModel.Webshop;
 
 public class Customer

--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/IWebshopQueryRoots.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/IWebshopQueryRoots.cs
@@ -2,10 +2,8 @@ using ExpressiveSharp;
 
 namespace ExpressiveSharp.Docs.PlaygroundModel.Webshop;
 
-/// <summary>
-/// Query context passed to sample snippets; each render target supplies its own
-/// implementation (EF Core DbContext, MongoDB collections, in-memory arrays).
-/// </summary>
+// Query context passed to sample snippets; each render target supplies its
+// own implementation (EF Core DbContext, MongoDB collections, etc.).
 public interface IWebshopQueryRoots
 {
     IExpressiveQueryable<Customer> Customers { get; }

--- a/src/Docs/PlaygroundModel/Scenarios/Webshop/WebshopDbContext.cs
+++ b/src/Docs/PlaygroundModel/Scenarios/Webshop/WebshopDbContext.cs
@@ -1,7 +1,3 @@
-// WebshopDbContext — the in-memory DbContext the playground's webshop scenario
-// uses to back EF Core's ToQueryString(). Constructed once per scenario instance
-// in WebshopScenarioInstance; no real database connection is ever opened.
-
 using ExpressiveSharp.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Docs/Prerenderer/LocalPlaygroundReferences.cs
+++ b/src/Docs/Prerenderer/LocalPlaygroundReferences.cs
@@ -7,10 +7,8 @@ using Microsoft.CodeAnalysis;
 
 namespace ExpressiveSharp.Docs.Prerenderer;
 
-/// <summary>
-/// Loads reference assemblies from disk (the build output of the referenced
-/// projects) instead of fetching via HTTP like the WASM <c>PlaygroundReferences</c>.
-/// </summary>
+// Loads reference assemblies from disk instead of fetching via HTTP like the
+// WASM PlaygroundReferences.
 internal sealed class LocalPlaygroundReferences : IPlaygroundReferences
 {
     private ImmutableArray<MetadataReference> _references;

--- a/src/Docs/Prerenderer/Program.cs
+++ b/src/Docs/Prerenderer/Program.cs
@@ -26,14 +26,12 @@ if (!Directory.Exists(docsRoot))
 
 Console.WriteLine($"Docs root: {docsRoot}");
 
-// Load references and create compiler
 var references = new LocalPlaygroundReferences();
 references.Load();
 
 var compiler = new SnippetCompiler(references);
 
-// Scan all markdown files for samples. Skip VitePress build artifacts and
-// node_modules so the scan doesn't pick up generated or vendored .md.
+// Skip VitePress build artifacts and node_modules.
 var mdFiles = Directory.GetFiles(docsRoot, "*.md", SearchOption.AllDirectories)
     .Where(f =>
     {
@@ -62,7 +60,6 @@ if (allSamples.Count == 0)
 
 Console.WriteLine($"Found {allSamples.Count} sample(s) across {allSamples.Select(s => s.relativePath).Distinct().Count()} file(s).");
 
-// Render all samples
 await using var renderer = new SampleRenderer(compiler);
 var failed = 0;
 var byFile = new Dictionary<string, List<RenderedSample>>(StringComparer.Ordinal);
@@ -87,7 +84,6 @@ foreach (var (relativePath, sample) in allSamples)
     }
 }
 
-// Write output JSON files
 var outputDir = Path.Combine(docsRoot, ".vitepress", "data", "samples");
 Directory.CreateDirectory(outputDir);
 
@@ -105,7 +101,7 @@ foreach (var (relativePath, samples) in byFile)
 
     var json = JsonSerializer.Serialize(samples, jsonOptions);
 
-    // Only overwrite if content changed (keeps git diffs clean)
+    // Only overwrite if content changed, to keep git diffs clean.
     if (File.Exists(jsonPath) && File.ReadAllText(jsonPath) == json)
     {
         Console.WriteLine($"  Unchanged: {Path.GetRelativePath(docsRoot, jsonPath)}");

--- a/src/Docs/Prerenderer/SampleExtractor.cs
+++ b/src/Docs/Prerenderer/SampleExtractor.cs
@@ -32,7 +32,7 @@ internal static class SampleExtractor
                 continue;
             }
 
-            // Parse optional scenario from the opening line: "::: expressive-sample webshop"
+            // Optional scenario id: "::: expressive-sample webshop"
             var scenarioId = "webshop";
             var afterMarker = trimmed[ContainerOpen.Length..].Trim();
             if (afterMarker.Length > 0)

--- a/src/Docs/Prerenderer/SampleRenderer.cs
+++ b/src/Docs/Prerenderer/SampleRenderer.cs
@@ -109,9 +109,9 @@ internal sealed class SampleRenderer : IAsyncDisposable
             (IQueryable?)runMethod.Invoke(null, new[] { arg })
                 ?? throw new InvalidOperationException("Snippet.Run returned null.");
 
-        // Isolate each sample from prior ones: clear resolver caches and
-        // restrict registry scanning to the current snippet's assembly so
-        // accumulated [ExpressiveFor] registrations don't collide.
+        // Isolate each sample: clear resolver caches and restrict registry
+        // scanning to the snippet's assembly so accumulated [ExpressiveFor]
+        // registrations from prior samples don't collide.
         ExpressiveSharp.Services.ExpressiveResolver.ResetAllCaches();
         var snippetAssembly = result.Assembly;
         ExpressiveSharp.Services.ExpressiveResolver.SetAssemblyScanFilter(
@@ -141,7 +141,7 @@ internal sealed class SampleRenderer : IAsyncDisposable
             }
         }
 
-        // Prerenderer-only providers — their client libraries throw on WASM.
+        // Prerenderer-only providers; their client libraries throw on WASM.
         if (scenario.Id == "webshop")
         {
             using var sqlServer = BuildSqlServerContext();
@@ -151,7 +151,6 @@ internal sealed class SampleRenderer : IAsyncDisposable
                 BuildMongoRoots(), static (q, _) => FormatMongoOutput(q.ToString()!));
         }
 
-        // Generator output
         var generatorOutput = FormatGeneratorOutput(result.GeneratedSources);
         targets["generator"] = new RenderedTarget("Generator output", "csharp", generatorOutput);
 
@@ -226,7 +225,7 @@ internal sealed class SampleRenderer : IAsyncDisposable
         using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
         var formatted = Formatter.Format(root, workspace).ToFullString().Trim();
 
-        // Collapse accidental blank lines the rewriter may introduce
+        // Collapse blank lines the rewriter may introduce.
         formatted = System.Text.RegularExpressions.Regex.Replace(formatted, @"\n\s*\n", "\n");
 
         if (formatted.StartsWith("_ = ", StringComparison.Ordinal))
@@ -244,7 +243,6 @@ internal sealed class SampleRenderer : IAsyncDisposable
             var visited = (Microsoft.CodeAnalysis.CSharp.Syntax.SwitchExpressionSyntax)base.VisitSwitchExpression(node)!;
             var newline = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.EndOfLine("\n");
 
-            // Put each arm on its own line by injecting a newline before each arm's leading trivia
             var newArms = visited.Arms.Select(arm =>
                 arm.WithLeadingTrivia(arm.GetLeadingTrivia().Insert(0, newline)));
 
@@ -302,13 +300,12 @@ internal sealed class SampleRenderer : IAsyncDisposable
             if (c == '{' || c == '[')
             {
                 sb.Append(c);
-                // Check if contents are simple (no nested objects/arrays)
                 var closing = c == '{' ? '}' : ']';
                 var end = FindMatchingBrace(json, i, c, closing);
                 var inner = end > i ? json[(i + 1)..end] : "";
                 if (end > i && !ContainsNested(inner))
                 {
-                    // Keep short object/array inline
+                    // Keep primitive-only object/array inline.
                     sb.Append(inner).Append(closing);
                     i = end;
                     continue;
@@ -329,7 +326,6 @@ internal sealed class SampleRenderer : IAsyncDisposable
                 sb.Append(',');
                 sb.AppendLine();
                 sb.Append(new string(' ', depth * 4));
-                // Skip the following space if present
                 if (i + 1 < json.Length && json[i + 1] == ' ') i++;
             }
             else
@@ -410,7 +406,5 @@ internal sealed class SampleRenderer : IAsyncDisposable
         return sb.ToString();
     }
 
-    // All per-sample state is now disposed in Render() itself; nothing to
-    // clean up at the renderer level.
     public ValueTask DisposeAsync() => default;
 }

--- a/src/ExpressiveSharp.Abstractions/ExpressiveAttribute.cs
+++ b/src/ExpressiveSharp.Abstractions/ExpressiveAttribute.cs
@@ -1,13 +1,5 @@
 namespace ExpressiveSharp;
 
-/// <summary>
-/// Declares this property, method or constructor to be Expressive.
-/// A companion expression tree will be generated.
-/// </summary>
-/// <remarks>
-/// Use the <see cref="Transformers"/> property to apply custom <see cref="IExpressionTreeTransformer"/>
-/// implementations at runtime when the expression is resolved.
-/// </remarks>
 [AttributeUsage(
     AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor,
     Inherited = true, AllowMultiple = false)]
@@ -15,15 +7,13 @@ public sealed class ExpressiveAttribute : Attribute
 {
     /// <summary>
     /// When <c>true</c>, allows block-bodied members (methods/properties with <c>{ }</c> bodies).
-    /// Block bodies support local variables, if/else, foreach loops, and more, but not all
-    /// constructs are translatable by every LINQ provider.
     /// When not explicitly set, the MSBuild property <c>Expressive_AllowBlockBody</c> is used
     /// (defaults to <c>false</c>).
     /// </summary>
     public bool AllowBlockBody { get; set; }
 
     /// <summary>
-    /// Additional <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
+    /// <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
     /// Each type must have a parameterless constructor.
     /// </summary>
     public Type[]? Transformers { get; set; }

--- a/src/ExpressiveSharp.Abstractions/IExpressionTreeTransformer.cs
+++ b/src/ExpressiveSharp.Abstractions/IExpressionTreeTransformer.cs
@@ -3,13 +3,9 @@ using System.Linq.Expressions;
 namespace ExpressiveSharp;
 
 /// <summary>
-/// Transforms an expression tree at runtime. Implementations are pure functions
-/// that take an expression and return a transformed version.
+/// Transforms an expression tree at runtime. Implementations must be pure.
 /// </summary>
 public interface IExpressionTreeTransformer
 {
-    /// <summary>
-    /// Transforms the given expression tree.
-    /// </summary>
     Expression Transform(Expression expression);
 }

--- a/src/ExpressiveSharp.Abstractions/Mapping/ExpressiveForAttribute.cs
+++ b/src/ExpressiveSharp.Abstractions/Mapping/ExpressiveForAttribute.cs
@@ -2,8 +2,6 @@ namespace ExpressiveSharp.Mapping;
 
 /// <summary>
 /// Maps an external method or property to an expression-tree body provided by the decorated stub method.
-/// The stub's body is compiled into an <c>Expression&lt;TDelegate&gt;</c> that replaces
-/// calls to the target member during expression-tree expansion.
 /// </summary>
 /// <remarks>
 /// <para>For <b>static methods</b>, the stub parameters must match the target method's parameters exactly.</para>
@@ -16,25 +14,21 @@ namespace ExpressiveSharp.Mapping;
 public sealed class ExpressiveForAttribute : Attribute
 {
     /// <summary>
-    /// The type that declares the target member, or <c>null</c> when the single-argument constructor
-    /// is used (in which case the target defaults to the stub's containing type at generator time).
+    /// The declaring type of the target member, or <c>null</c> when the single-argument constructor
+    /// is used (the target then defaults to the stub's containing type).
     /// </summary>
     public Type? TargetType { get; }
 
-    /// <summary>
-    /// The name of the target member on <see cref="TargetType"/>.
-    /// </summary>
     public string MemberName { get; }
 
     /// <summary>
-    /// When <c>true</c>, allows block-bodied stubs (methods with <c>{ }</c> bodies).
-    /// When not explicitly set, the MSBuild property <c>Expressive_AllowBlockBody</c> is used
-    /// (defaults to <c>false</c>).
+    /// When <c>true</c>, allows block-bodied stubs. When not explicitly set, the MSBuild property
+    /// <c>Expressive_AllowBlockBody</c> is used (defaults to <c>false</c>).
     /// </summary>
     public bool AllowBlockBody { get; set; }
 
     /// <summary>
-    /// Additional <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
+    /// <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
     /// Each type must have a parameterless constructor.
     /// </summary>
     public Type[]? Transformers { get; set; }
@@ -46,8 +40,7 @@ public sealed class ExpressiveForAttribute : Attribute
     }
 
     /// <summary>
-    /// Shorthand for <c>[ExpressiveFor(typeof(ContainingType), memberName)]</c> —
-    /// use when the target member is on the same type as the stub.
+    /// Shorthand for <c>[ExpressiveFor(typeof(ContainingType), memberName)]</c>.
     /// </summary>
     public ExpressiveForAttribute(string memberName)
     {

--- a/src/ExpressiveSharp.Abstractions/Mapping/ExpressiveForConstructorAttribute.cs
+++ b/src/ExpressiveSharp.Abstractions/Mapping/ExpressiveForConstructorAttribute.cs
@@ -2,27 +2,22 @@ namespace ExpressiveSharp.Mapping;
 
 /// <summary>
 /// Maps an external constructor to an expression-tree body provided by the decorated stub method.
-/// The stub's parameters must match the target constructor's parameters. The stub's return type
-/// must be the target type. The stub's body is compiled into an <c>Expression&lt;TDelegate&gt;</c>
-/// that replaces <c>new T(...)</c> calls during expression-tree expansion.
+/// The stub's parameters must match the target constructor's parameters and its return type must
+/// be the target type. Replaces <c>new T(...)</c> calls during expression-tree expansion.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 public sealed class ExpressiveForConstructorAttribute : Attribute
 {
-    /// <summary>
-    /// The type whose constructor is being mapped.
-    /// </summary>
     public Type TargetType { get; }
 
     /// <summary>
-    /// When <c>true</c>, allows block-bodied stubs (methods with <c>{ }</c> bodies).
-    /// When not explicitly set, the MSBuild property <c>Expressive_AllowBlockBody</c> is used
-    /// (defaults to <c>false</c>).
+    /// When <c>true</c>, allows block-bodied stubs. When not explicitly set, the MSBuild property
+    /// <c>Expressive_AllowBlockBody</c> is used (defaults to <c>false</c>).
     /// </summary>
     public bool AllowBlockBody { get; set; }
 
     /// <summary>
-    /// Additional <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
+    /// <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
     /// Each type must have a parameterless constructor.
     /// </summary>
     public Type[]? Transformers { get; set; }

--- a/src/ExpressiveSharp.Abstractions/Mapping/ExpressivePropertyAttribute.cs
+++ b/src/ExpressiveSharp.Abstractions/Mapping/ExpressivePropertyAttribute.cs
@@ -10,7 +10,7 @@ namespace ExpressiveSharp.Mapping;
 /// <remarks>
 /// <para>The stub must be an <b>instance property</b> with an <b>expression body</b>
 /// (<c>=&gt; expr</c>). Method stubs, accessor-list forms, and static stubs are rejected.</para>
-/// <para>The containing type must be declared <c>partial</c> (class, struct, or record).</para>
+/// <para>The containing type must be declared <c>partial</c>.</para>
 /// <para>To map a stub onto an <i>existing</i> member instead of synthesizing a new one,
 /// use <see cref="ExpressiveForAttribute"/>.</para>
 /// </remarks>
@@ -18,13 +18,13 @@ namespace ExpressiveSharp.Mapping;
 public sealed class ExpressivePropertyAttribute : Attribute
 {
     /// <summary>
-    /// Name of the property to synthesize on the stub's containing type. Must be supplied as a
-    /// string literal — <c>nameof(X)</c> cannot resolve because <c>X</c> doesn't exist yet.
+    /// Name of the property to synthesize. Must be a string literal — <c>nameof(X)</c> cannot
+    /// resolve because <c>X</c> doesn't exist yet.
     /// </summary>
     public string TargetName { get; }
 
     /// <summary>
-    /// Additional <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
+    /// <see cref="IExpressionTreeTransformer"/> types to apply at runtime.
     /// Each type must have a parameterless constructor.
     /// </summary>
     public Type[]? Transformers { get; set; }

--- a/src/ExpressiveSharp.Abstractions/PolyfillTargetAttribute.cs
+++ b/src/ExpressiveSharp.Abstractions/PolyfillTargetAttribute.cs
@@ -2,19 +2,13 @@ namespace ExpressiveSharp;
 
 /// <summary>
 /// Specifies the static type whose extension method the polyfill interceptor should forward to,
-/// instead of the default <see cref="System.Linq.Queryable"/>.
+/// instead of the default <see cref="System.Linq.Queryable"/>. Apply to delegate-based
+/// <see cref="IExpressiveQueryable{T}"/> stubs when the matching <c>Expression&lt;Func&lt;…&gt;&gt;</c>
+/// overload lives elsewhere (e.g., EF Core's <c>EntityFrameworkQueryableExtensions</c>).
 /// </summary>
-/// <remarks>
-/// Apply this attribute to delegate-based <see cref="IExpressiveQueryable{T}"/> stubs when the
-/// matching <c>Expression&lt;Func&lt;…&gt;&gt;</c> overload lives in a type other than
-/// <see cref="System.Linq.Queryable"/> (e.g., EF Core's <c>EntityFrameworkQueryableExtensions</c>).
-/// </remarks>
 [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 public sealed class PolyfillTargetAttribute : Attribute
 {
-    /// <summary>
-    /// The static type that declares the target extension method.
-    /// </summary>
     public Type TargetType { get; }
 
     public PolyfillTargetAttribute(Type targetType) => TargetType = targetType;

--- a/src/ExpressiveSharp.CodeFixers/AddExpressiveCodeFixProvider.cs
+++ b/src/ExpressiveSharp.CodeFixers/AddExpressiveCodeFixProvider.cs
@@ -12,8 +12,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace ExpressiveSharp.CodeFixers;
 
 /// <summary>
-/// Provides a code fix for EXP0013 that adds [Expressive] to the referenced member's declaration.
-/// The diagnostic's additional location (index 0) points to the member declaration.
+/// Code fix for EXP0013: adds [Expressive] to the referenced member's declaration.
+/// The diagnostic's additional location (index 0) points to that declaration.
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddExpressiveCodeFixProvider))]
 [Shared]
@@ -70,8 +70,6 @@ public sealed class AddExpressiveCodeFixProvider : CodeFixProvider
             memberDecl.AttributeLists.Add(attributeList));
 
         var newRoot = root.ReplaceNode(memberDecl, newMemberDecl);
-
-        // Add using ExpressiveSharp if not already present
         newRoot = EnsureUsingDirective(newRoot);
 
         return declDocument.Project.Solution.WithDocumentSyntaxRoot(declDocument.Id, newRoot);

--- a/src/ExpressiveSharp.CodeFixers/MissingExpressiveAnalyzer.cs
+++ b/src/ExpressiveSharp.CodeFixers/MissingExpressiveAnalyzer.cs
@@ -42,8 +42,6 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
             SyntaxKind.InvocationExpression);
     }
 
-    // ── Prong 1: [Expressive] member bodies ─────────────────────────────────
-
     private static void AnalyzeExpressiveMember(SyntaxNodeAnalysisContext context)
     {
         var memberDecl = (MemberDeclarationSyntax)context.Node;
@@ -54,8 +52,6 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
 
         AnalyzeDescendants(context, memberDecl);
     }
-
-    // ── Prong 2: polyfill / rewritable-queryable lambdas ────────────────────
 
     private static void AnalyzePolyfillInvocation(SyntaxNodeAnalysisContext context)
     {
@@ -96,7 +92,6 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         if (!method.IsExtensionMethod)
             return false;
 
-        // Check if the first parameter (the receiver) is IExpressiveQueryable<T>
         var originalMethod = method.ReducedFrom ?? method;
         if (originalMethod.Parameters.Length == 0)
             return false;
@@ -123,8 +118,6 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         type.Name == "IExpressiveQueryable" &&
         type.ContainingNamespace?.ToDisplayString() == "ExpressiveSharp";
 
-    // ── Shared: walk descendants for member references ──────────────────────
-
     private static void AnalyzeDescendants(SyntaxNodeAnalysisContext context, SyntaxNode scope)
     {
         foreach (var node in scope.DescendantNodes())
@@ -150,7 +143,6 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
             else if (node is MemberAccessExpressionSyntax memberAccessExpr &&
                      memberAccessExpr.Parent is not InvocationExpressionSyntax)
             {
-                // Property/field access (not a method call receiver)
                 var info = context.SemanticModel.GetSymbolInfo(memberAccessExpr, context.CancellationToken);
                 if (info.Symbol is IPropertySymbol)
                 {
@@ -178,11 +170,8 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    /// <summary>
-    /// Returns true when the invocation's receiver (or first extension-method arg) is an enum
-    /// or Nullable&lt;Enum&gt;. The generator already expands these via TryEmitEnumMethodExpansion,
-    /// so EXP0013 would be a false positive.
-    /// </summary>
+    // Generator already expands enum/Nullable<Enum> receivers via TryEmitEnumMethodExpansion,
+    // so EXP0013 would be a false positive.
     private static bool HasEnumReceiver(
         IMethodSymbol method,
         InvocationExpressionSyntax invocation,
@@ -219,8 +208,7 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    // ── Core logic (matches ExpressionTreeEmitter.WarnIfMissingExpressive) ──
-
+    // Mirrors ExpressionTreeEmitter.WarnIfMissingExpressive.
     private static void WarnIfMissingExpressive(
         SyntaxNodeAnalysisContext context, ISymbol symbol, Location location)
     {
@@ -253,11 +241,9 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// True when the containing type declares a sibling stub whose mapping attribute names
-    /// <paramref name="symbol"/> as its target — i.e. <c>[ExpressiveProperty("X")]</c> or
-    /// <c>[ExpressiveFor("X")]</c> / <c>[ExpressiveFor(typeof(ThisType), "X")]</c>. In any of
-    /// those cases the registry has an entry for the member even though it carries no direct
-    /// <c>[Expressive]</c> attribute.
+    /// True when a sibling stub declares <c>[ExpressiveProperty("X")]</c> or
+    /// <c>[ExpressiveFor("X")]</c> targeting <paramref name="symbol"/>. Such siblings register
+    /// an entry for the member even without a direct <c>[Expressive]</c> attribute.
     /// </summary>
     private static bool HasSiblingMappingTargetingMember(ISymbol symbol)
     {
@@ -294,11 +280,6 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    /// <summary>
-    /// Resolves <c>[ExpressiveFor]</c>'s target-name argument in either supported form and
-    /// checks it against <paramref name="targetName"/>, and — for the two-argument form —
-    /// verifies the <c>typeof(...)</c> argument matches <paramref name="containingType"/>.
-    /// </summary>
     private static bool MapsExpressiveForTo(AttributeData attr, INamedTypeSymbol containingType, string targetName)
     {
         if (attr.ConstructorArguments.Length == 1 &&

--- a/src/ExpressiveSharp.CodeFixers/MissingExpressiveImportAnalyzer.cs
+++ b/src/ExpressiveSharp.CodeFixers/MissingExpressiveImportAnalyzer.cs
@@ -51,11 +51,9 @@ public sealed class MissingExpressiveImportAnalyzer : DiagnosticAnalyzer
         if (symbolInfo.Symbol is not IMethodSymbol method)
             return;
 
-        // Only care about System.Linq.Queryable methods
         if (!IsQueryableMethod(method))
             return;
 
-        // Get the receiver expression and its type
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
             return;
 
@@ -64,13 +62,12 @@ public sealed class MissingExpressiveImportAnalyzer : DiagnosticAnalyzer
         if (receiverType is null || !IsOrImplementsExpressiveQueryable(receiverType))
             return;
 
-        // Check if a matching stub exists in ExpressiveQueryableLinqExtensions
         var stubType = context.SemanticModel.Compilation
             .GetTypeByMetadataName("ExpressiveSharp.ExpressiveQueryableLinqExtensions");
 
         if (stubType != null && stubType.GetMembers(method.Name).Length > 0)
         {
-            // Stub exists but wasn't resolved — missing using
+            // Stub exists but wasn't resolved — missing using.
             context.ReportDiagnostic(Diagnostic.Create(
                 StubNotResolved,
                 memberAccess.Name.GetLocation(),
@@ -78,7 +75,7 @@ public sealed class MissingExpressiveImportAnalyzer : DiagnosticAnalyzer
         }
         else
         {
-            // No stub exists — chain will be broken
+            // No stub exists — chain will be broken.
             context.ReportDiagnostic(Diagnostic.Create(
                 NoStubExists,
                 memberAccess.Name.GetLocation(),

--- a/src/ExpressiveSharp.EntityFrameworkCore.CodeFixers/MigrationAnalyzer.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.CodeFixers/MigrationAnalyzer.cs
@@ -7,8 +7,8 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ExpressiveSharp.EntityFrameworkCore.CodeFixers;
 
 /// <summary>
-/// Detects EntityFrameworkCore.Projectables API usage and reports diagnostics
-/// so that <see cref="MigrationCodeFixProvider"/> can offer automated fixes.
+/// Detects EntityFrameworkCore.Projectables API usage so <see cref="MigrationCodeFixProvider"/>
+/// can offer automated migrations.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class MigrationAnalyzer : DiagnosticAnalyzer
@@ -63,7 +63,6 @@ public sealed class MigrationAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Verify it's actually the Projectables attribute via semantic model
         var symbolInfo = context.SemanticModel.GetSymbolInfo(attribute, context.CancellationToken);
         if (symbolInfo.Symbol is IMethodSymbol ctor &&
             ctor.ContainingType.ToDisplayString() == "EntityFrameworkCore.Projectables.ProjectableAttribute")

--- a/src/ExpressiveSharp.EntityFrameworkCore.CodeFixers/MigrationCodeFixProvider.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.CodeFixers/MigrationCodeFixProvider.cs
@@ -9,8 +9,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace ExpressiveSharp.EntityFrameworkCore.CodeFixers;
 
 /// <summary>
-/// Provides code fixes for migrating from EntityFrameworkCore.Projectables to ExpressiveSharp.
-/// Handles all three migration diagnostics: attribute rename, method call replacement, and namespace updates.
+/// Code fixes for migrating from EntityFrameworkCore.Projectables to ExpressiveSharp:
+/// attribute rename, method call replacement, and namespace updates.
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MigrationCodeFixProvider))]
 [Shared]
@@ -99,7 +99,7 @@ public sealed class MigrationCodeFixProvider : CodeFixProvider
 
     /// <summary>
     /// Replaces <c>[Projectable(...)]</c> with <c>[Expressive]</c>, keeping only the <c>Transformers</c>
-    /// property if present. All other properties are removed as they have no equivalent.
+    /// property; other Projectable properties have no Expressive equivalent.
     /// </summary>
     private static async Task<Document> ReplaceProjectableAttributeAsync(
         Document document,
@@ -112,13 +112,11 @@ public sealed class MigrationCodeFixProvider : CodeFixProvider
             return document;
         }
 
-        // Build new attribute name
         var oldName = attribute.Name.ToString();
         var newName = oldName == "ProjectableAttribute" ? "ExpressiveAttribute" : "Expressive";
         var newAttributeName = SyntaxFactory.IdentifierName(newName)
             .WithTriviaFrom(attribute.Name);
 
-        // Filter arguments: keep only Transformers
         AttributeArgumentListSyntax? newArgList = null;
         if (attribute.ArgumentList is { Arguments.Count: > 0 })
         {
@@ -141,8 +139,8 @@ public sealed class MigrationCodeFixProvider : CodeFixProvider
     }
 
     /// <summary>
-    /// Replaces <c>UseProjectables(...)</c> with <c>UseExpressives()</c>,
-    /// removing any configuration callback argument.
+    /// Replaces <c>UseProjectables(...)</c> with <c>UseExpressives()</c>, dropping any
+    /// configuration callback (no equivalent in ExpressiveSharp).
     /// </summary>
     private static async Task<Document> ReplaceUseProjectablesAsync(
         Document document,
@@ -160,12 +158,10 @@ public sealed class MigrationCodeFixProvider : CodeFixProvider
             return document;
         }
 
-        // Replace method name
         var newName = SyntaxFactory.IdentifierName("UseExpressives")
             .WithTriviaFrom(memberAccess.Name);
         var newMemberAccess = memberAccess.WithName(newName);
 
-        // Remove all arguments (the callback is no longer needed)
         var newArgList = SyntaxFactory.ArgumentList()
             .WithOpenParenToken(invocation.ArgumentList.OpenParenToken)
             .WithCloseParenToken(invocation.ArgumentList.CloseParenToken);
@@ -178,10 +174,6 @@ public sealed class MigrationCodeFixProvider : CodeFixProvider
         return document.WithSyntaxRoot(newRoot);
     }
 
-    /// <summary>
-    /// Replaces <c>using EntityFrameworkCore.Projectables*</c> with the corresponding
-    /// <c>using ExpressiveSharp*</c> namespace.
-    /// </summary>
     private static async Task<Document> ReplaceUsingDirectiveAsync(
         Document document,
         UsingDirectiveSyntax usingDirective,
@@ -198,7 +190,6 @@ public sealed class MigrationCodeFixProvider : CodeFixProvider
 
         if (newNamespace is null)
         {
-            // No mapping — remove the using directive entirely
             var newRoot = root.RemoveNode(usingDirective, SyntaxRemoveOptions.KeepLeadingTrivia);
             return document.WithSyntaxRoot(newRoot!);
         }
@@ -218,9 +209,8 @@ public sealed class MigrationCodeFixProvider : CodeFixProvider
     {
         "EntityFrameworkCore.Projectables" => "ExpressiveSharp",
         "EntityFrameworkCore.Projectables.Extensions" => "ExpressiveSharp",
-        // Infrastructure namespace (CompatibilityMode, ProjectableOptionsBuilder) has no equivalent
+        // CompatibilityMode, ProjectableOptionsBuilder have no Expressive equivalent.
         "EntityFrameworkCore.Projectables.Infrastructure" => null,
-        // Any other sub-namespace — map the root
         _ when oldNamespace.StartsWith("EntityFrameworkCore.Projectables.") =>
             "ExpressiveSharp" + oldNamespace.Substring("EntityFrameworkCore.Projectables".Length),
         _ => "ExpressiveSharp",

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/Window.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/Window.cs
@@ -1,21 +1,19 @@
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.WindowFunctions;
 
 /// <summary>
-/// Static entry point for building window specifications used in SQL window functions.
-/// These methods are markers — they are translated to SQL by the EF Core query pipeline
-/// and throw at runtime if called directly.
+/// Entry point for building window specifications. Markers — translated to SQL; throw at runtime if called directly.
 /// </summary>
 public static class Window
 {
-    /// <summary>Creates a window specification starting with a PARTITION BY clause.</summary>
+    /// <summary>Starts a window with a PARTITION BY clause.</summary>
     public static PartitionedWindowDefinition PartitionBy<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Creates a window specification starting with an ORDER BY ASC clause.</summary>
+    /// <summary>Starts a window with ORDER BY (ascending).</summary>
     public static OrderedWindowDefinition OrderBy<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Creates a window specification starting with an ORDER BY DESC clause.</summary>
+    /// <summary>Starts a window with ORDER BY (descending).</summary>
     public static OrderedWindowDefinition OrderByDescending<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 }

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/WindowDefinition.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/WindowDefinition.cs
@@ -1,62 +1,46 @@
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.WindowFunctions;
 
-/// <summary>
-/// Represents a window specification after PARTITION BY — can add more partitions or start ordering.
-/// Returned by <see cref="Window.PartitionBy{TKey}"/>.
-/// </summary>
+/// <summary>Window specification after PARTITION BY. Returned by <see cref="Window.PartitionBy{TKey}"/>.</summary>
 public sealed class PartitionedWindowDefinition
 {
     private PartitionedWindowDefinition() =>
         throw new InvalidOperationException("PartitionedWindowDefinition is a marker type for expression trees and cannot be instantiated.");
 
-    /// <summary>Adds another PARTITION BY column.</summary>
     public PartitionedWindowDefinition PartitionBy<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Starts the ORDER BY clause (ascending).</summary>
     public OrderedWindowDefinition OrderBy<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Starts the ORDER BY clause (descending).</summary>
     public OrderedWindowDefinition OrderByDescending<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 }
 
 /// <summary>
-/// Represents a window specification after ORDER BY — can add more orderings via ThenBy.
-/// This is the type accepted by <see cref="WindowFunction"/> methods, ensuring at least one
-/// ORDER BY clause is present at compile time.
+/// Window specification after ORDER BY. The type accepted by <see cref="WindowFunction"/> methods,
+/// ensuring at least one ORDER BY clause is present at compile time.
 /// </summary>
 public sealed class OrderedWindowDefinition
 {
     private OrderedWindowDefinition() =>
         throw new InvalidOperationException("OrderedWindowDefinition is a marker type for expression trees and cannot be instantiated.");
 
-    /// <summary>Adds a subsequent ORDER BY column (ascending).</summary>
     public OrderedWindowDefinition ThenBy<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Adds a subsequent ORDER BY column (descending).</summary>
     public OrderedWindowDefinition ThenByDescending<TKey>(TKey key) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Applies a row-based window frame: <c>ROWS BETWEEN <paramref name="start"/> AND <paramref name="end"/></c>.
-    /// </summary>
+    /// <summary><c>ROWS BETWEEN <paramref name="start"/> AND <paramref name="end"/></c>.</summary>
     public FramedWindowDefinition RowsBetween(WindowFrameBound start, WindowFrameBound end) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Applies a range-based window frame: <c>RANGE BETWEEN <paramref name="start"/> AND <paramref name="end"/></c>.
-    /// </summary>
+    /// <summary><c>RANGE BETWEEN <paramref name="start"/> AND <paramref name="end"/></c>.</summary>
     public FramedWindowDefinition RangeBetween(WindowFrameBound start, WindowFrameBound end) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 }
 
-/// <summary>
-/// Represents a window specification after a frame clause (ROWS/RANGE BETWEEN) has been applied.
-/// Terminal type — no further chaining is possible.
-/// </summary>
+/// <summary>Terminal window specification after a frame clause (ROWS/RANGE BETWEEN) has been applied.</summary>
 public sealed class FramedWindowDefinition
 {
     private FramedWindowDefinition() =>

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/WindowFrameBound.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/WindowFrameBound.cs
@@ -1,10 +1,8 @@
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.WindowFunctions;
 
 /// <summary>
-/// Represents a boundary of a SQL window frame (e.g. <c>UNBOUNDED PRECEDING</c>,
-/// <c>3 PRECEDING</c>, <c>CURRENT ROW</c>, <c>5 FOLLOWING</c>, <c>UNBOUNDED FOLLOWING</c>).
-/// These factory members are translated to SQL by ExpressiveSharp's translators —
-/// they throw at runtime if accessed directly.
+/// SQL window frame boundary (<c>UNBOUNDED PRECEDING</c>, <c>n PRECEDING</c>, <c>CURRENT ROW</c>,
+/// <c>n FOLLOWING</c>, <c>UNBOUNDED FOLLOWING</c>). Markers — translated to SQL; throw at runtime if accessed directly.
 /// </summary>
 public sealed class WindowFrameBound
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/WindowFunction.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Abstractions/WindowFunction.cs
@@ -17,58 +17,36 @@ namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.WindowFunctio
 /// </summary>
 public static class WindowFunction
 {
-    // ── Ranking functions ────────────────────────────────────────────────
-
-    /// <summary>
-    /// Translates to <c>ROW_NUMBER() OVER(...)</c>.
-    /// Returns a sequential number for each row within the window partition.
-    /// </summary>
+    /// <summary>Translates to <c>ROW_NUMBER() OVER(...)</c>.</summary>
     public static long RowNumber(OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
     /// <summary>
-    /// Translates to <c>ROW_NUMBER() OVER()</c> with no ordering or partitioning.
-    /// Row numbering is non-deterministic. Used internally by the indexed Select transformer.
+    /// Translates to <c>ROW_NUMBER() OVER()</c> with no ordering. Used internally by the
+    /// indexed Select transformer; row numbering is non-deterministic without an OrderBy.
     /// </summary>
     public static long RowNumber() =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>RANK() OVER(...)</c>.
-    /// Returns the rank of each row within the window partition, with gaps for ties.
-    /// </summary>
+    /// <summary>Translates to <c>RANK() OVER(...)</c> (with gaps for ties).</summary>
     public static long Rank(OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>DENSE_RANK() OVER(...)</c>.
-    /// Returns the rank of each row within the window partition, without gaps for ties.
-    /// </summary>
+    /// <summary>Translates to <c>DENSE_RANK() OVER(...)</c> (no gaps for ties).</summary>
     public static long DenseRank(OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>NTILE(<paramref name="buckets"/>) OVER(...)</c>.
-    /// Distributes rows into the specified number of roughly equal groups.
-    /// </summary>
+    /// <summary>Translates to <c>NTILE(<paramref name="buckets"/>) OVER(...)</c>.</summary>
     public static long Ntile(int buckets, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>PERCENT_RANK() OVER(...)</c>.
-    /// Returns the relative rank of each row as a value between 0.0 and 1.0.
-    /// </summary>
+    /// <summary>Translates to <c>PERCENT_RANK() OVER(...)</c>.</summary>
     public static double PercentRank(OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>CUME_DIST() OVER(...)</c>.
-    /// Returns the cumulative distribution of each row as a value between 0.0 and 1.0.
-    /// </summary>
+    /// <summary>Translates to <c>CUME_DIST() OVER(...)</c>.</summary>
     public static double CumeDist(OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
-
-    // ── Aggregate functions ──────────────────────────────────────────────
 
     /// <summary>Translates to <c>SUM(expression) OVER(...)</c>.</summary>
     public static T Sum<T>(T expression, OrderedWindowDefinition window) =>
@@ -88,7 +66,7 @@ public static class WindowFunction
 
     // int/long → double (matching Queryable.Average semantics)
 
-    /// <summary>Translates to <c>AVG(expression) OVER(...)</c>. Returns <c>double</c> for integer input.</summary>
+    /// <summary>Translates to <c>AVG(expression) OVER(...)</c> with <c>double</c> result for integer input.</summary>
     public static double Average(int expression, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
@@ -104,7 +82,7 @@ public static class WindowFunction
     public static double? Average(int? expression, FramedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Translates to <c>AVG(expression) OVER(...)</c>. Returns <c>double</c> for long input.</summary>
+    /// <summary>Translates to <c>AVG(expression) OVER(...)</c> with <c>double</c> result for long input.</summary>
     public static double Average(long expression, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
@@ -120,7 +98,7 @@ public static class WindowFunction
     public static double? Average(long? expression, FramedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Translates to <c>COUNT(*) OVER(...)</c>. Counts all rows in the window.</summary>
+    /// <summary>Translates to <c>COUNT(*) OVER(...)</c>.</summary>
     public static int Count(OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
@@ -128,7 +106,7 @@ public static class WindowFunction
     public static int Count(FramedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>Translates to <c>COUNT(expression) OVER(...)</c>. Counts non-null values.</summary>
+    /// <summary>Translates to <c>COUNT(expression) OVER(...)</c> (counts non-null values).</summary>
     public static int Count<T>(T expression, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
@@ -152,18 +130,11 @@ public static class WindowFunction
     public static T Max<T>(T expression, FramedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    // ── Navigation functions ─────────────────────────────────────────────
-    // LAG/LEAD access a row at a specific offset from the current row.
-    // The SQL standard forbids frame clauses on these — OrderedWindowDefinition only.
-    //
-    // Without a default value, the SQL result is NULL when no row exists at the
-    // requested offset. For value types, project into a nullable column explicitly:
+    // LAG/LEAD return NULL when no row exists at the requested offset (without a default).
+    // For value types, project into a nullable column explicitly:
     //   (double?)WindowFunction.Lag(o.Price, Window.OrderBy(o.Price))
 
-    /// <summary>
-    /// Translates to <c>LAG(expression) OVER(...)</c>. Returns the previous row's value (offset 1).
-    /// The result is NULL when no previous row exists; cast to a nullable type if needed.
-    /// </summary>
+    /// <summary>Translates to <c>LAG(expression) OVER(...)</c> (offset 1).</summary>
     public static T Lag<T>(T expression, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
@@ -175,10 +146,7 @@ public static class WindowFunction
     public static T Lag<T>(T expression, int offset, T defaultValue, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>LEAD(expression) OVER(...)</c>. Returns the next row's value (offset 1).
-    /// The result is NULL when no next row exists; cast to a nullable type if needed.
-    /// </summary>
+    /// <summary>Translates to <c>LEAD(expression) OVER(...)</c> (offset 1).</summary>
     public static T Lead<T>(T expression, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
@@ -190,11 +158,7 @@ public static class WindowFunction
     public static T Lead<T>(T expression, int offset, T defaultValue, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>FIRST_VALUE(expression) OVER(...)</c>.
-    /// Returns the first value in the window frame. The result depends on the frame;
-    /// with the default frame this is the first row of the partition.
-    /// </summary>
+    /// <summary>Translates to <c>FIRST_VALUE(expression) OVER(...)</c>.</summary>
     public static T FirstValue<T>(T expression, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
@@ -203,10 +167,9 @@ public static class WindowFunction
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
     /// <summary>
-    /// Translates to <c>LAST_VALUE(expression) OVER(...)</c>.
-    /// Returns the last value in the window frame. With the default frame this returns
-    /// the <em>current row's</em> value — use an explicit frame like
-    /// <c>.RowsBetween(UnboundedPreceding, UnboundedFollowing)</c> to get the partition's last value.
+    /// Translates to <c>LAST_VALUE(expression) OVER(...)</c>. With the default frame this returns
+    /// the <em>current row's</em> value — use <c>.RowsBetween(UnboundedPreceding, UnboundedFollowing)</c>
+    /// for the partition's last value.
     /// </summary>
     public static T LastValue<T>(T expression, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
@@ -215,10 +178,7 @@ public static class WindowFunction
     public static T LastValue<T>(T expression, FramedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 
-    /// <summary>
-    /// Translates to <c>NTH_VALUE(expression, <paramref name="n"/>) OVER(...)</c>.
-    /// Returns the value at the Nth row in the window frame (1-based).
-    /// </summary>
+    /// <summary>Translates to <c>NTH_VALUE(expression, <paramref name="n"/>) OVER(...)</c> (1-based).</summary>
     public static T NthValue<T>(T expression, int n, OrderedWindowDefinition window) =>
         throw new InvalidOperationException("This method is translated to SQL and cannot be called directly.");
 

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/ExpressiveOptionsBuilderExtensions.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/ExpressiveOptionsBuilderExtensions.cs
@@ -6,8 +6,7 @@ namespace ExpressiveSharp.EntityFrameworkCore;
 public static class ExpressiveOptionsBuilderExtensions
 {
     /// <summary>
-    /// Enables relational database extensions: SQL window functions
-    /// (ROW_NUMBER, RANK, DENSE_RANK, NTILE) and indexed Select support.
+    /// Enables relational extensions: SQL window functions and indexed Select support.
     /// </summary>
     public static ExpressiveOptionsBuilder UseRelationalExtensions(this ExpressiveOptionsBuilder builder)
         => builder.AddPlugin(new RelationalExpressivePlugin());

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Extensions/ExpressiveQueryableRelationalExtensions.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Extensions/ExpressiveQueryableRelationalExtensions.cs
@@ -8,15 +8,11 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
-/// Extension methods on <see cref="IExpressiveQueryable{T}"/> for EF Core bulk update operations.
-/// These stubs are intercepted by the ExpressiveSharp source generator via <see cref="PolyfillTargetAttribute"/>
-/// to forward to the appropriate EF Core ExecuteUpdate method.
+/// Bulk update stubs intercepted by the source generator via <see cref="PolyfillTargetAttribute"/>.
+/// EF Core 8/9 only — EF Core 10+ uses <c>Action&lt;UpdateSettersBuilder&lt;T&gt;&gt;</c> which natively
+/// supports modern C# syntax in the outer lambda; use <c>ExpressionPolyfill.Create()</c> for inner
+/// <c>SetProperty</c> value expressions.
 /// </summary>
-/// <remarks>
-/// Only available on EF Core 8/9. In EF Core 10+, <c>ExecuteUpdate</c> uses <c>Action&lt;UpdateSettersBuilder&lt;T&gt;&gt;</c>
-/// which natively supports modern C# syntax in the outer lambda. For inner <c>SetProperty</c> value expressions,
-/// use <c>ExpressionPolyfill.Create()</c> to enable modern C# syntax.
-/// </remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class ExpressiveQueryableRelationalExtensions
 {
@@ -24,9 +20,8 @@ public static class ExpressiveQueryableRelationalExtensions
         "This method must be intercepted by the ExpressiveSharp source generator. " +
         "Ensure the generator package is installed and the InterceptorsNamespaces MSBuild property is configured.";
 
-    // ── Bulk update methods (intercepted) ────────────────────────────────
-    // EF Core 8: ExecuteUpdate lives on RelationalQueryableExtensions (Relational package)
-    // EF Core 9: ExecuteUpdate moved to EntityFrameworkQueryableExtensions (Core package)
+    // EF Core 8: ExecuteUpdate lives on RelationalQueryableExtensions (Relational package).
+    // EF Core 9: moved to EntityFrameworkQueryableExtensions (Core package).
 
 #if NET9_0
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundInfo.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundInfo.cs
@@ -1,9 +1,5 @@
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
-/// <summary>
-/// Kind of a SQL window frame boundary — maps 1:1 to the five forms of
-/// the SQL:2003 frame-bound grammar.
-/// </summary>
 internal enum WindowFrameBoundKind
 {
     UnboundedPreceding,
@@ -14,15 +10,12 @@ internal enum WindowFrameBoundKind
 }
 
 /// <summary>
-/// Fully-resolved description of a single frame boundary carried through the
-/// translation pipeline. The <see cref="Offset"/> is only populated for
-/// <see cref="WindowFrameBoundKind.Preceding"/> and <see cref="WindowFrameBoundKind.Following"/>;
-/// it is stored as a literal integer because SQL requires literal constants for
-/// frame-bound offsets (parameters are not allowed in the frame clause).
+/// Single frame boundary carried through the translation pipeline. <see cref="Offset"/> is only
+/// populated for Preceding/Following and is stored as a literal int — SQL requires literal
+/// constants for frame-bound offsets (parameters are not allowed in the frame clause).
 /// </summary>
 internal readonly record struct WindowFrameBoundInfo(WindowFrameBoundKind Kind, int? Offset)
 {
-    /// <summary>Emits the SQL fragment for this boundary (e.g. <c>3 PRECEDING</c>, <c>CURRENT ROW</c>).</summary>
     public string ToSqlFragment() => Kind switch
     {
         WindowFrameBoundKind.UnboundedPreceding => "UNBOUNDED PRECEDING",

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundMemberTranslator.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundMemberTranslator.cs
@@ -8,15 +8,10 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
 /// <summary>
-/// Translates the no-argument <see cref="WindowFrameBound"/> static property getters
-/// (<c>UnboundedPreceding</c>, <c>CurrentRow</c>, <c>UnboundedFollowing</c>) into
-/// <see cref="WindowFrameBoundSqlExpression"/> intermediate nodes, which are then
-/// consumed by <see cref="WindowSpecMethodCallTranslator"/> when it sees
-/// <c>RowsBetween</c> / <c>RangeBetween</c>.
-/// <para>
-/// The offset-bearing variants (<c>Preceding(int)</c>, <c>Following(int)</c>) are
-/// methods and are handled by <see cref="WindowSpecMethodCallTranslator"/>.
-/// </para>
+/// Translates <see cref="WindowFrameBound"/> static property getters
+/// (<c>UnboundedPreceding</c>, <c>CurrentRow</c>, <c>UnboundedFollowing</c>) into intermediate
+/// <see cref="WindowFrameBoundSqlExpression"/> nodes. The offset-bearing
+/// <c>Preceding(int)</c>/<c>Following(int)</c> are methods and handled by <see cref="WindowSpecMethodCallTranslator"/>.
 /// </summary>
 internal sealed class WindowFrameBoundMemberTranslator : IMemberTranslator
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundSqlExpression.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundSqlExpression.cs
@@ -5,10 +5,9 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
 /// <summary>
-/// Intermediate SQL expression that represents a single window frame boundary.
-/// Produced by <see cref="WindowSpecMethodCallTranslator"/> when it encounters
-/// <c>WindowFrameBound.*</c> members, and consumed by the same translator when
-/// it sees <c>RowsBetween</c> / <c>RangeBetween</c>. Never reaches final SQL rendering.
+/// Intermediate frame-boundary node produced by <see cref="WindowSpecMethodCallTranslator"/>
+/// from <c>WindowFrameBound.*</c> members and consumed by the same translator at
+/// <c>RowsBetween</c> / <c>RangeBetween</c>. Never reaches final SQL rendering.
 /// </summary>
 internal sealed class WindowFrameBoundSqlExpression : SqlExpression
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameType.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameType.cs
@@ -1,9 +1,5 @@
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
-/// <summary>
-/// SQL window frame type — determines whether the frame is row-based (<c>ROWS</c>) or
-/// value-based (<c>RANGE</c>).
-/// </summary>
 internal enum WindowFrameType
 {
     Rows,

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionEvaluatableExpressionFilter.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionEvaluatableExpressionFilter.cs
@@ -5,9 +5,8 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
 /// <summary>
-/// Prevents window function marker method calls and property accesses from being
-/// client-evaluated. These must remain as expression tree nodes for the
-/// method/member translators to handle.
+/// Prevents window function markers from being client-evaluated — they must remain as
+/// expression tree nodes for the method/member translators to handle.
 /// </summary>
 internal sealed class WindowFunctionEvaluatableExpressionFilter : IEvaluatableExpressionFilterPlugin
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionMemberTranslatorPlugin.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionMemberTranslatorPlugin.cs
@@ -2,11 +2,6 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
-/// <summary>
-/// Registers member access translators with EF Core's query pipeline.
-/// Currently handles only <see cref="WindowFunctions.WindowFrameBound"/> property getters
-/// (<c>UnboundedPreceding</c>, <c>CurrentRow</c>, <c>UnboundedFollowing</c>).
-/// </summary>
 internal sealed class WindowFunctionMemberTranslatorPlugin : IMemberTranslatorPlugin
 {
     public IEnumerable<IMemberTranslator> Translators { get; } =

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionMethodCallTranslator.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionMethodCallTranslator.cs
@@ -10,14 +10,9 @@ namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructur
 
 /// <summary>
 /// Translates <see cref="WindowFunction"/> static methods into SQL window function expressions.
-/// <para>
-/// <b>Ranking functions</b> (ROW_NUMBER, RANK, DENSE_RANK, NTILE) never emit a frame clause —
-/// the SQL standard forbids it and SQL Server / PostgreSQL reject the syntax.
-/// </para>
-/// <para>
-/// <b>Aggregate functions</b> (SUM, AVG, COUNT, MIN, MAX) propagate the frame from the
-/// <see cref="WindowSpecSqlExpression"/> into <see cref="WindowFunctionSqlExpression"/>.
-/// </para>
+/// Ranking functions (ROW_NUMBER, RANK, DENSE_RANK, NTILE) never emit a frame clause — the SQL
+/// standard forbids it and SQL Server/PostgreSQL reject the syntax. Aggregate functions
+/// (SUM, AVG, COUNT, MIN, MAX) propagate the frame from <see cref="WindowSpecSqlExpression"/>.
 /// </summary>
 internal sealed class WindowFunctionMethodCallTranslator : IMethodCallTranslator
 {
@@ -45,8 +40,6 @@ internal sealed class WindowFunctionMethodCallTranslator : IMethodCallTranslator
 
         return method.Name switch
         {
-            // ── Ranking functions (no frame) ─────────────────────────────
-
             nameof(WindowFunction.RowNumber) when arguments.Count == 1 && arguments[0] is WindowSpecSqlExpression spec
                 => new RowNumberExpression(spec.Partitions, spec.Orderings, longTypeMapping),
 
@@ -77,8 +70,6 @@ internal sealed class WindowFunctionMethodCallTranslator : IMethodCallTranslator
                 => new WindowFunctionSqlExpression("CUME_DIST", [], spec.Partitions, spec.Orderings,
                     typeof(double), _typeMappingSource.FindMapping(typeof(double))),
 
-            // ── Aggregate functions (with frame) ─────────────────────────
-
             nameof(WindowFunction.Sum) when ExtractAggregateArgs(arguments, out var expr, out var spec)
                 => MakeAggregate("SUM", [expr], spec, method.ReturnType),
 
@@ -104,15 +95,11 @@ internal sealed class WindowFunctionMethodCallTranslator : IMethodCallTranslator
             nameof(WindowFunction.Max) when ExtractAggregateArgs(arguments, out var expr, out var spec)
                 => MakeAggregate("MAX", [expr], spec, method.ReturnType),
 
-            // ── Navigation functions (no frame) ──────────────────────────
-
             nameof(WindowFunction.Lag) when ExtractNavigationArgs(arguments, out var lagArgs, out var lagSpec)
                 => MakeNavigation("LAG", lagArgs, lagSpec, method.ReturnType),
 
             nameof(WindowFunction.Lead) when ExtractNavigationArgs(arguments, out var leadArgs, out var leadSpec)
                 => MakeNavigation("LEAD", leadArgs, leadSpec, method.ReturnType),
-
-            // ── Value functions (with frame) ─────────────────────────────
 
             nameof(WindowFunction.FirstValue) when ExtractAggregateArgs(arguments, out var fvExpr, out var fvSpec)
                 => MakeAggregate("FIRST_VALUE", [fvExpr], fvSpec, method.ReturnType),
@@ -129,10 +116,6 @@ internal sealed class WindowFunctionMethodCallTranslator : IMethodCallTranslator
         };
     }
 
-    /// <summary>
-    /// Extracts the expression argument (first) and window spec (last) from a 2-argument
-    /// aggregate call like <c>Sum(o.Price, window)</c>.
-    /// </summary>
     private static bool ExtractAggregateArgs(
         IReadOnlyList<SqlExpression> arguments,
         out SqlExpression expression,
@@ -151,9 +134,8 @@ internal sealed class WindowFunctionMethodCallTranslator : IMethodCallTranslator
     }
 
     /// <summary>
-    /// Extracts the function arguments (all but last) and window spec (last) from a
-    /// navigation call like <c>Lag(o.Price, 2, window)</c>. Applies default type mapping
-    /// to all function arguments.
+    /// Extracts function args (all but last) and window spec (last) from a navigation call.
+    /// Applies default type mapping to all function arguments.
     /// </summary>
     private bool ExtractNavigationArgs(
         IReadOnlyList<SqlExpression> arguments,
@@ -190,11 +172,8 @@ internal sealed class WindowFunctionMethodCallTranslator : IMethodCallTranslator
             typeMapping);
     }
 
-    /// <summary>
-    /// Returns true when the AVG expression argument's CLR type is an integer type
-    /// but the method's return type is floating-point — SQL Server performs integer
-    /// division for AVG(int), so we need to CAST the argument.
-    /// </summary>
+    // SQL Server performs integer division for AVG(int) — cast the argument when the
+    // CLR return type is floating-point but the expression is an integer type.
     private static bool NeedsFloatCast(SqlExpression expr, Type returnType) =>
         returnType == typeof(double)
         && expr.Type is var t

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionParameterBasedSqlProcessor.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionParameterBasedSqlProcessor.cs
@@ -5,10 +5,8 @@ using Microsoft.EntityFrameworkCore.Query;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
 /// <summary>
-/// Wraps the provider's <see cref="RelationalParameterBasedSqlProcessor"/> to temporarily
-/// hide <see cref="WindowFunctionSqlExpression"/> nodes during nullability processing.
-/// The provider's own processor (with all its provider-specific customizations) handles
-/// the actual work — we only intercept the public entry points to wrap/unwrap.
+/// Wraps the provider's processor to hide <see cref="WindowFunctionSqlExpression"/> nodes
+/// during nullability processing — the provider does the actual work, we only wrap/unwrap.
 /// </summary>
 [SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Required for custom SQL expression nullability processing")]
 internal sealed class WindowFunctionParameterBasedSqlProcessor : RelationalParameterBasedSqlProcessor

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionParameterBasedSqlProcessorFactory.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionParameterBasedSqlProcessorFactory.cs
@@ -3,10 +3,6 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
-/// <summary>
-/// Decorates the existing <see cref="IRelationalParameterBasedSqlProcessorFactory"/> to wrap
-/// the provider's processor with <see cref="WindowFunctionSqlExpression"/> handling.
-/// </summary>
 [SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Required for custom SQL expression nullability processing")]
 internal sealed class WindowFunctionParameterBasedSqlProcessorFactory : IRelationalParameterBasedSqlProcessorFactory
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpression.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpression.cs
@@ -6,21 +6,18 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
 /// <summary>
-/// SQL expression representing a window function call: FUNC_NAME(args) OVER(PARTITION BY ... ORDER BY ... [frame]).
-/// Used for RANK, DENSE_RANK, NTILE (ROW_NUMBER uses the built-in <see cref="RowNumberExpression"/>).
+/// SQL expression for <c>FUNC(args) OVER(PARTITION BY ... ORDER BY ... [frame])</c>. Used for
+/// RANK, DENSE_RANK, NTILE, aggregates, and navigation functions (ROW_NUMBER uses the built-in
+/// <see cref="RowNumberExpression"/>).
 /// <para>
-/// This expression is self-rendering: <see cref="VisitChildren"/> produces correct SQL through
-/// any provider's <see cref="QuerySqlGenerator"/> by interleaving <see cref="SqlFragmentExpression"/>
-/// nodes with the actual column/ordering expressions. This makes it fully provider-agnostic —
-/// no custom QuerySqlGenerator replacement is needed.
+/// Self-rendering: <see cref="VisitChildren"/> interleaves <see cref="SqlFragmentExpression"/>
+/// nodes with column/ordering expressions, producing correct SQL through any provider's
+/// <see cref="QuerySqlGenerator"/> — no custom generator replacement needed.
 /// </para>
 /// <para>
-/// <b>SQL standard assumption:</b> The function names (RANK, DENSE_RANK, NTILE) and the
-/// OVER(PARTITION BY ... ORDER BY ... [ROWS/RANGE BETWEEN ...]) clause syntax are hardcoded as
-/// literal SQL fragments. This relies on SQL:2003 window function syntax which is consistently
-/// implemented by all major databases (SQL Server 2012+, PostgreSQL 8.4+, SQLite 3.25+,
-/// MySQL 8.0+, Oracle 8i+, MariaDB 10.2+). If a provider deviates from this standard syntax,
-/// a provider-specific implementation would be needed.
+/// Function names and clause syntax are hardcoded as literal SQL fragments, relying on SQL:2003
+/// window function syntax (SQL Server 2012+, PostgreSQL 8.4+, SQLite 3.25+, MySQL 8.0+,
+/// Oracle 8i+, MariaDB 10.2+). A provider that deviates would need a custom implementation.
 /// </para>
 /// </summary>
 internal sealed class WindowFunctionSqlExpression : SqlExpression
@@ -54,11 +51,6 @@ internal sealed class WindowFunctionSqlExpression : SqlExpression
         FrameEnd = frameEnd;
     }
 
-    /// <summary>
-    /// Self-rendering: when any QuerySqlGenerator visits this expression via VisitExtension,
-    /// it calls VisitChildren, which visits SqlFragmentExpression and child SqlExpression nodes
-    /// in the correct order to produce <c>FUNC(args) OVER(PARTITION BY ... ORDER BY ... [frame])</c>.
-    /// </summary>
     protected override Expression VisitChildren(ExpressionVisitor visitor)
     {
         EmitWindowFunction(
@@ -67,17 +59,11 @@ internal sealed class WindowFunctionSqlExpression : SqlExpression
         return this;
     }
 
-    /// <summary>Diagnostic output for logging and ToString(). Not used for SQL generation.</summary>
     protected override void Print(ExpressionPrinter expressionPrinter) =>
         EmitWindowFunction(
             text => expressionPrinter.Append(text),
             expr => expressionPrinter.Visit(expr));
 
-    /// <summary>
-    /// Shared rendering logic for both SQL generation (<see cref="VisitChildren"/>) and
-    /// diagnostic output (<see cref="Print"/>). Produces the
-    /// <c>FUNC(args) OVER(PARTITION BY ... ORDER BY ... [ROWS/RANGE BETWEEN ...])</c> structure.
-    /// </summary>
     private void EmitWindowFunction(Action<string> appendText, Action<Expression> visitExpression)
     {
         appendText($"{FunctionName}(");

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpressionWrapper.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpressionWrapper.cs
@@ -4,20 +4,15 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
 /// <summary>
-/// Temporarily wraps <see cref="WindowFunctionSqlExpression"/> nodes in
+/// Temporarily replaces <see cref="WindowFunctionSqlExpression"/> nodes with
 /// <see cref="SqlFragmentExpression"/> placeholders so the provider's
-/// <see cref="Microsoft.EntityFrameworkCore.Query.SqlNullabilityProcessor"/>
-/// can traverse the tree without throwing on unknown expression types.
-/// After nullability processing, the originals are restored.
+/// <see cref="Microsoft.EntityFrameworkCore.Query.SqlNullabilityProcessor"/> can traverse the tree
+/// without throwing on unknown expression types. Originals are restored after nullability processing.
 /// </summary>
 internal static class WindowFunctionSqlExpressionWrapper
 {
     private const string PlaceholderPrefix = "__wf_placeholder_";
 
-    /// <summary>
-    /// Replaces all <see cref="WindowFunctionSqlExpression"/> nodes in the tree with
-    /// <see cref="SqlFragmentExpression"/> placeholders, stashing the originals for later restoration.
-    /// </summary>
     public static Expression WrapAll(Expression expression, out Dictionary<string, WindowFunctionSqlExpression> stash)
     {
         var visitor = new WrapVisitor();
@@ -26,10 +21,6 @@ internal static class WindowFunctionSqlExpressionWrapper
         return result;
     }
 
-    /// <summary>
-    /// Restores all placeholder <see cref="SqlFragmentExpression"/> nodes back to
-    /// their original <see cref="WindowFunctionSqlExpression"/>.
-    /// </summary>
     public static Expression UnwrapAll(Expression expression, Dictionary<string, WindowFunctionSqlExpression> stash)
         => new UnwrapVisitor(stash).Visit(expression);
 

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionTranslatorPlugin.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionTranslatorPlugin.cs
@@ -3,9 +3,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
-/// <summary>
-/// Registers window function method call translators with EF Core's query pipeline.
-/// </summary>
 internal sealed class WindowFunctionTranslatorPlugin : IMethodCallTranslatorPlugin
 {
     public IEnumerable<IMethodCallTranslator> Translators { get; }

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowSpecMethodCallTranslator.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowSpecMethodCallTranslator.cs
@@ -7,12 +7,6 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
-/// <summary>
-/// Translates <see cref="Window"/> static methods, <see cref="PartitionedWindowDefinition"/>/
-/// <see cref="OrderedWindowDefinition"/> instance methods, and <see cref="WindowFrameBound"/>
-/// factory methods into intermediate SQL expression nodes
-/// (<see cref="WindowSpecSqlExpression"/>, <see cref="WindowFrameBoundSqlExpression"/>).
-/// </summary>
 internal sealed class WindowSpecMethodCallTranslator : IMethodCallTranslator
 {
     public SqlExpression? Translate(
@@ -23,7 +17,6 @@ internal sealed class WindowSpecMethodCallTranslator : IMethodCallTranslator
     {
         var declaringType = method.DeclaringType;
 
-        // Static methods on Window class
         if (declaringType == typeof(Window))
         {
             return method.Name switch
@@ -38,9 +31,8 @@ internal sealed class WindowSpecMethodCallTranslator : IMethodCallTranslator
             };
         }
 
-        // Static factory methods on WindowFrameBound (the no-arg variants
-        // UnboundedPreceding/CurrentRow/UnboundedFollowing are properties and are
-        // handled by WindowFrameBoundMemberTranslator instead).
+        // No-arg variants (UnboundedPreceding/CurrentRow/UnboundedFollowing) are properties
+        // and handled by WindowFrameBoundMemberTranslator instead.
         if (declaringType == typeof(WindowFrameBound))
         {
             return method.Name switch
@@ -53,7 +45,6 @@ internal sealed class WindowSpecMethodCallTranslator : IMethodCallTranslator
             };
         }
 
-        // Instance methods on PartitionedWindowDefinition and OrderedWindowDefinition
         if ((declaringType == typeof(PartitionedWindowDefinition) || declaringType == typeof(OrderedWindowDefinition))
             && instance is WindowSpecSqlExpression spec)
         {

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowSpecSqlExpression.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowSpecSqlExpression.cs
@@ -6,9 +6,8 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
 
 /// <summary>
-/// Intermediate SQL expression that carries the PARTITION BY, ORDER BY, and optional
-/// frame (ROWS/RANGE BETWEEN) clauses of a window specification. This node is consumed
-/// by the window function translator and should never reach final SQL rendering.
+/// Intermediate node carrying PARTITION BY, ORDER BY, and optional frame clauses. Consumed by
+/// the window function translator; should never reach final SQL rendering.
 /// </summary>
 internal sealed class WindowSpecSqlExpression : SqlExpression
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/RelationalExpressivePlugin.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/RelationalExpressivePlugin.cs
@@ -10,13 +10,13 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions;
 
 /// <summary>
-/// Plugin that registers window function services into the EF Core service provider.
-/// Activated via <c>.UseExpressives(o => o.UseRelationalExtensions())</c>.
+/// Plugin that registers window function services. Activated via
+/// <c>.UseExpressives(o => o.UseRelationalExtensions())</c>.
 /// </summary>
 public sealed class RelationalExpressivePlugin : IExpressivePlugin
 {
-    // Stable hash — this plugin is stateless, so all instances are equivalent.
-    // Used by ExpressiveOptionsExtension to compute the EF Core service provider cache key.
+    // Stateless — all instances are equivalent. Used by ExpressiveOptionsExtension to compute
+    // the EF Core service provider cache key.
     public override int GetHashCode() => typeof(RelationalExpressivePlugin).GetHashCode();
 
     public override bool Equals(object? obj) => obj is RelationalExpressivePlugin;
@@ -24,18 +24,9 @@ public sealed class RelationalExpressivePlugin : IExpressivePlugin
     [SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Required to decorate EF Core services")]
     public void ApplyServices(IServiceCollection services)
     {
-        // Register method call translator plugin (scoped — matches EF Core's service lifetimes)
         services.AddScoped<IMethodCallTranslatorPlugin, WindowFunctionTranslatorPlugin>();
-
-        // Register member translator plugin for WindowFrameBound property getters
-        // (UnboundedPreceding, CurrentRow, UnboundedFollowing)
         services.AddScoped<IMemberTranslatorPlugin, WindowFunctionMemberTranslatorPlugin>();
-
-        // Register evaluatable expression filter
         services.AddSingleton<IEvaluatableExpressionFilterPlugin, WindowFunctionEvaluatableExpressionFilter>();
-
-        // Decorate the SQL nullability processor factory to handle WindowFunctionSqlExpression.
-        // Uses the decorator pattern to preserve the provider's existing factory.
         DecorateParameterBasedSqlProcessorFactory(services);
     }
 
@@ -63,9 +54,8 @@ public sealed class RelationalExpressivePlugin : IExpressivePlugin
         }
         else
         {
-            // UseExpressives() called before provider — deferred decoration.
-            // Pre-register so the provider's TryAdd becomes a no-op.
-            // At resolution time, create the default factory and wrap it.
+            // UseExpressives() called before provider — pre-register so the provider's TryAdd
+            // becomes a no-op; create the default factory at resolution time and wrap it.
             services.AddScoped<IRelationalParameterBasedSqlProcessorFactory>(sp =>
             {
                 var inner = ActivatorUtilities.CreateInstance<RelationalParameterBasedSqlProcessorFactory>(sp);

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Transformers/RewriteIndexedSelectToRowNumber.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Transformers/RewriteIndexedSelectToRowNumber.cs
@@ -5,14 +5,9 @@ using ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.WindowFunctions;
 namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Transformers;
 
 /// <summary>
-/// Rewrites <c>Queryable.Select(source, (elem, index) => body)</c> into
-/// <c>Queryable.Select(source, elem => body')</c> where references to the
-/// <c>int index</c> parameter are replaced with <c>WindowFunction.RowNumber() - 1</c>.
-/// <para>
-/// The resulting <c>WindowFunction.RowNumber()</c> call produces
-/// <c>ROW_NUMBER() OVER()</c> with no ordering — row numbering is non-deterministic
-/// unless the query includes an explicit <c>OrderBy</c>.
-/// </para>
+/// Rewrites <c>Queryable.Select(source, (elem, index) => body)</c> into a 1-arg Select where
+/// references to <c>index</c> become <c>WindowFunction.RowNumber() - 1</c>. The emitted
+/// <c>ROW_NUMBER() OVER()</c> has no ordering — non-deterministic unless the query has an explicit OrderBy.
 /// </summary>
 public sealed class RewriteIndexedSelectToRowNumber : IExpressionTreeTransformer
 {
@@ -26,13 +21,11 @@ public sealed class RewriteIndexedSelectToRowNumber : IExpressionTreeTransformer
     {
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
-            // Look for Queryable.Select(source, Expression<Func<T, int, TResult>>)
             if (node.Method.DeclaringType != typeof(Queryable)
                 || node.Method.Name != "Select"
                 || node.Arguments.Count != 2)
                 return base.VisitMethodCall(node);
 
-            // The second argument must be a quoted lambda: Expression<Func<T, int, TResult>>
             if (UnwrapQuote(node.Arguments[1]) is not LambdaExpression lambda
                 || lambda.Parameters.Count != 2
                 || lambda.Parameters[1].Type != typeof(int))
@@ -41,18 +34,14 @@ public sealed class RewriteIndexedSelectToRowNumber : IExpressionTreeTransformer
             var elemParam = lambda.Parameters[0];
             var indexParam = lambda.Parameters[1];
 
-            // Build: (long)WindowFunction.RowNumber() - 1L
+            // (int)((long)WindowFunction.RowNumber() - 1L)
             var rowNumberCall = Expression.Call(RowNumberMethod);
             var subtractOne = Expression.Subtract(rowNumberCall, Expression.Constant(1L));
             var castToInt = Expression.Convert(subtractOne, typeof(int));
 
-            // Replace index parameter references with the ROW_NUMBER expression
             var rewrittenBody = new ParameterReplacer(indexParam, castToInt).Visit(lambda.Body);
-
-            // Build new 1-parameter lambda
             var newLambda = Expression.Lambda(rewrittenBody, elemParam);
 
-            // Find the 1-param Queryable.Select<T, TResult> overload
             var sourceType = elemParam.Type;
             var resultType = lambda.ReturnType;
             var selectMethod = typeof(Queryable).GetMethods()
@@ -62,7 +51,6 @@ public sealed class RewriteIndexedSelectToRowNumber : IExpressionTreeTransformer
                         .GetGenericArguments().Length == 2) // Func<T, TResult> has 2 type args
                 .MakeGenericMethod(sourceType, resultType);
 
-            // Visit the source in case it also needs transformation
             var visitedSource = Visit(node.Arguments[0]);
 
             return Expression.Call(selectMethod, visitedSource, Expression.Quote(newLambda));

--- a/src/ExpressiveSharp.EntityFrameworkCore/ExpressiveDbSet.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/ExpressiveDbSet.cs
@@ -9,19 +9,8 @@ namespace ExpressiveSharp.EntityFrameworkCore;
 
 /// <summary>
 /// A <see cref="DbSet{TEntity}"/> wrapper that also implements <see cref="IExpressiveQueryable{T}"/>,
-/// enabling delegate-based LINQ methods with modern C# syntax (e.g., <c>?.</c>) directly on the set.
+/// enabling delegate-based LINQ methods with modern C# syntax directly on the set.
 /// </summary>
-/// <example>
-/// <code>
-/// public class MyDbContext : DbContext
-/// {
-///     public ExpressiveDbSet&lt;Order&gt; Orders => Set&lt;Order&gt;().AsExpressiveDbSet();
-/// }
-///
-/// // Now you can use ?. directly:
-/// ctx.Orders.Where(o => o.Customer?.Name == "Alice")
-/// </code>
-/// </example>
 public class ExpressiveDbSet<TEntity> : DbSet<TEntity>, IExpressiveQueryable<TEntity>
     where TEntity : class
 {
@@ -34,18 +23,12 @@ public class ExpressiveDbSet<TEntity> : DbSet<TEntity>, IExpressiveQueryable<TEn
         _queryable = inner;
     }
 
-    // ── IQueryable ───────────────────────────────────────────────────────
-
     Type IQueryable.ElementType => _queryable.ElementType;
     Expression IQueryable.Expression => _queryable.Expression;
     IQueryProvider IQueryable.Provider => _queryable.Provider;
 
-    // ── IEnumerable ──────────────────────────────────────────────────────
-
     IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator() => _queryable.GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_queryable).GetEnumerator();
-
-    // ── DbSet<TEntity> virtual members ───────────────────────────────────
 
     public override IEntityType EntityType => _inner.EntityType;
     public override LocalView<TEntity> Local => _inner.Local;

--- a/src/ExpressiveSharp.EntityFrameworkCore/ExpressiveOptionsBuilder.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/ExpressiveOptionsBuilder.cs
@@ -10,10 +10,6 @@ public sealed class ExpressiveOptionsBuilder
 
     internal bool ShouldPreserveThrowExpressions { get; private set; }
 
-    /// <summary>
-    /// Registers an <see cref="IExpressivePlugin"/> that contributes services and/or
-    /// expression tree transformers to the EF Core pipeline.
-    /// </summary>
     public ExpressiveOptionsBuilder AddPlugin(IExpressivePlugin plugin)
     {
         Plugins.Add(plugin);
@@ -22,8 +18,7 @@ public sealed class ExpressiveOptionsBuilder
 
     /// <summary>
     /// Prevents the <see cref="ExpressiveSharp.Transformers.ReplaceThrowWithDefault"/> transformer from
-    /// being applied. When set, <c>Expression.Throw</c> nodes are preserved in the
-    /// expression tree, and the LINQ provider is responsible for translating them.
+    /// being applied — <c>Expression.Throw</c> nodes are preserved for the LINQ provider to translate.
     /// </summary>
     public ExpressiveOptionsBuilder PreserveThrowExpressions()
     {

--- a/src/ExpressiveSharp.EntityFrameworkCore/Extensions/DbContextExtensions.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Extensions/DbContextExtensions.cs
@@ -5,10 +5,6 @@ namespace Microsoft.EntityFrameworkCore;
 
 public static class DbContextExtensions
 {
-    /// <summary>
-    /// Returns an <see cref="ExpressiveDbSet{TEntity}"/> for the given entity type,
-    /// enabling delegate-based LINQ methods with modern C# syntax (e.g., <c>?.</c>).
-    /// </summary>
     public static ExpressiveDbSet<TEntity> ExpressiveSet<TEntity>(this DbContext context)
         where TEntity : class
         => context.Set<TEntity>().AsExpressiveDbSet();

--- a/src/ExpressiveSharp.EntityFrameworkCore/Extensions/DbContextOptionsExtensions.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Extensions/DbContextOptionsExtensions.cs
@@ -8,20 +8,13 @@ namespace Microsoft.EntityFrameworkCore;
 public static class DbContextOptionsExtensions
 {
     /// <summary>
-    /// Enables ExpressiveSharp integration with EF Core. This will:
-    /// <list type="bullet">
-    /// <item>Automatically expand <c>[Expressive]</c> member references in LINQ queries</item>
-    /// <item>Mark <c>[Expressive]</c> properties as unmapped in the EF model</item>
-    /// <item>Expand <c>[Expressive]</c> calls in global query filters</item>
-    /// <item>Apply EF Core-compatible transformers (RemoveNullConditionalPatterns, FlattenBlockExpressions)</item>
-    /// </list>
+    /// Enables ExpressiveSharp integration with EF Core: expands <c>[Expressive]</c> members in
+    /// queries and global filters, marks them unmapped, and applies EF-compatible transformers.
     /// </summary>
     public static DbContextOptionsBuilder UseExpressives(this DbContextOptionsBuilder optionsBuilder)
         => optionsBuilder.UseExpressives(_ => { });
 
-    /// <summary>
-    /// Enables ExpressiveSharp integration with EF Core with additional plugin configuration.
-    /// </summary>
+    /// <inheritdoc cref="UseExpressives(DbContextOptionsBuilder)"/>
     /// <param name="optionsBuilder">The EF Core options builder.</param>
     /// <param name="configure">A callback to configure plugins (e.g., <c>options.UseRelationalExtensions()</c>).</param>
     public static DbContextOptionsBuilder UseExpressives(
@@ -38,9 +31,6 @@ public static class DbContextOptionsExtensions
         return optionsBuilder;
     }
 
-    /// <summary>
-    /// Enables ExpressiveSharp integration with EF Core (generic overload).
-    /// </summary>
     public static DbContextOptionsBuilder<TContext> UseExpressives<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder)
         where TContext : DbContext
@@ -49,9 +39,6 @@ public static class DbContextOptionsExtensions
         return optionsBuilder;
     }
 
-    /// <summary>
-    /// Enables ExpressiveSharp integration with EF Core with additional plugin configuration (generic overload).
-    /// </summary>
     public static DbContextOptionsBuilder<TContext> UseExpressives<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         Action<ExpressiveOptionsBuilder> configure)

--- a/src/ExpressiveSharp.EntityFrameworkCore/Extensions/DbSetExtensions.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Extensions/DbSetExtensions.cs
@@ -5,19 +5,6 @@ namespace Microsoft.EntityFrameworkCore;
 
 public static class DbSetExtensions
 {
-    /// <summary>
-    /// Wraps this <see cref="DbSet{TEntity}"/> as a <see cref="ExpressiveDbSet{TEntity}"/>,
-    /// enabling delegate-based LINQ methods with modern C# syntax (e.g., <c>?.</c>, switch expressions)
-    /// directly on the set.
-    /// </summary>
-    /// <example>
-    /// <code>
-    /// public class MyDbContext : DbContext
-    /// {
-    ///     public ExpressiveDbSet&lt;Order&gt; Orders => Set&lt;Order&gt;().AsExpressiveDbSet();
-    /// }
-    /// </code>
-    /// </example>
     public static ExpressiveDbSet<TEntity> AsExpressiveDbSet<TEntity>(this DbSet<TEntity> dbSet)
         where TEntity : class
         => new(dbSet);

--- a/src/ExpressiveSharp.EntityFrameworkCore/Extensions/ExpressiveQueryableEfCoreExtensions.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Extensions/ExpressiveQueryableEfCoreExtensions.cs
@@ -11,9 +11,8 @@ namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
 /// Extension methods on <see cref="IExpressiveQueryable{T}"/> for EF Core operations.
-/// Passthrough stubs maintain the <see cref="IExpressiveQueryable{T}"/> chain.
 /// Async lambda stubs are intercepted by the source generator via <see cref="PolyfillTargetAttribute"/>
-/// to forward to <see cref="EntityFrameworkQueryableExtensions"/>.
+/// and forwarded to <see cref="EntityFrameworkQueryableExtensions"/>.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class ExpressiveQueryableEfCoreExtensions
@@ -21,7 +20,6 @@ public static class ExpressiveQueryableEfCoreExtensions
     private const string InterceptedMessage =
         "This method must be intercepted by the ExpressiveSharp source generator. " +
         "Ensure the generator package is installed and the InterceptorsNamespaces MSBuild property is configured.";
-    // ── Tracking behavior ────────────────────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static IExpressiveQueryable<TEntity> AsNoTracking<TEntity>(
@@ -41,8 +39,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         where TEntity : class
         => EntityFrameworkQueryableExtensions.AsTracking(source).AsExpressive();
 
-    // ── Query filters ────────────────────────────────────────────────────
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static IExpressiveQueryable<TEntity> IgnoreAutoIncludes<TEntity>(
         this IExpressiveQueryable<TEntity> source)
@@ -54,8 +50,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source)
         where TEntity : class
         => EntityFrameworkQueryableExtensions.IgnoreQueryFilters(source).AsExpressive();
-
-    // ── Query tagging ────────────────────────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static IExpressiveQueryable<TEntity> TagWith<TEntity>(
@@ -72,7 +66,7 @@ public static class ExpressiveQueryableEfCoreExtensions
         where TEntity : class
         => EntityFrameworkQueryableExtensions.TagWithCallSite(source, filePath, lineNumber).AsExpressive();
 
-    // ── Include / ThenInclude (runtime, not intercepted) ───────────────
+    // Include / ThenInclude run at runtime, not intercepted.
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static IIncludableExpressiveQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
@@ -107,8 +101,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         where TEntity : class
         => new IncludableExpressiveQueryableWrapper<TEntity, TProperty>(
             EntityFrameworkQueryableExtensions.ThenInclude(source, navigationPropertyPath));
-
-    // ── Async predicate methods (intercepted) ────────────────────────────
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -145,8 +137,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         CancellationToken cancellationToken = default)
         where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
-
-    // ── Async element methods (intercepted) ──────────────────────────────
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -202,8 +192,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
-    // ── Async Sum (intercepted) ──────────────────────────────────────────
-
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<int> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
@@ -244,8 +232,6 @@ public static class ExpressiveQueryableEfCoreExtensions
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<decimal?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
 
-    // ── Async Average (intercepted) ──────────────────────────────────────
-
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<double> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
@@ -285,8 +271,6 @@ public static class ExpressiveQueryableEfCoreExtensions
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Task<decimal?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
-
-    // ── Async Min / Max (intercepted) ────────────────────────────────────
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/ExpressiveSharp.EntityFrameworkCore/IExpressivePlugin.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/IExpressivePlugin.cs
@@ -3,22 +3,12 @@ using Microsoft.Extensions.DependencyInjection;
 namespace ExpressiveSharp.EntityFrameworkCore;
 
 /// <summary>
-/// Interface for ExpressiveSharp plugins that register additional services into
-/// the EF Core service provider. Plugins are registered via
-/// <see cref="ExpressiveOptionsBuilder.AddPlugin"/>.
+/// Plugin that registers additional services and/or expression tree transformers
+/// into the EF Core service provider, registered via <see cref="ExpressiveOptionsBuilder.AddPlugin"/>.
 /// </summary>
 public interface IExpressivePlugin
 {
-    /// <summary>
-    /// Registers services into the EF Core internal service collection.
-    /// Called during <c>UseExpressives()</c> initialization.
-    /// </summary>
     void ApplyServices(IServiceCollection services);
 
-    /// <summary>
-    /// Returns expression tree transformers to add to the EF Core transformer pipeline.
-    /// Called when building <see cref="Services.ExpressiveOptions"/>.
-    /// Default implementation returns an empty array.
-    /// </summary>
     IExpressionTreeTransformer[] GetTransformers() => [];
 }

--- a/src/ExpressiveSharp.EntityFrameworkCore/IIncludableExpressiveQueryable.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/IIncludableExpressiveQueryable.cs
@@ -4,8 +4,8 @@ namespace ExpressiveSharp.EntityFrameworkCore;
 
 /// <summary>
 /// Combines <see cref="IIncludableQueryable{TEntity,TProperty}"/> (for <c>ThenInclude</c> chaining)
-/// with <see cref="IExpressiveQueryable{T}"/> (for delegate-based LINQ stubs with modern C# syntax).
-/// Returned by <c>Include</c> and <c>ThenInclude</c> on <see cref="IExpressiveQueryable{T}"/> sources.
+/// with <see cref="IExpressiveQueryable{T}"/>. Returned by <c>Include</c>/<c>ThenInclude</c>
+/// on expressive sources.
 /// </summary>
 public interface IIncludableExpressiveQueryable<TEntity, TProperty>
     : IIncludableQueryable<TEntity, TProperty>,

--- a/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/IncludableExpressiveQueryableWrapper.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/IncludableExpressiveQueryableWrapper.cs
@@ -4,10 +4,6 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace ExpressiveSharp.EntityFrameworkCore.Infrastructure;
 
-/// <summary>
-/// Wraps an <see cref="IIncludableQueryable{TEntity,TProperty}"/> to also implement
-/// <see cref="IExpressiveQueryable{T}"/>, preserving chain continuity for delegate-based LINQ stubs.
-/// </summary>
 internal sealed class IncludableExpressiveQueryableWrapper<TEntity, TProperty>
     : IIncludableExpressiveQueryable<TEntity, TProperty>
     where TEntity : class

--- a/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveDbSetDiscoveryConvention.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveDbSetDiscoveryConvention.cs
@@ -7,10 +7,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 namespace ExpressiveSharp.EntityFrameworkCore.Infrastructure.Internal;
 
 /// <summary>
-/// Convention that discovers <see cref="ExpressiveDbSet{TEntity}"/> properties on the DbContext
-/// and registers their entity types in the model with the property name as the table name.
-/// Mirrors EF Core's built-in <c>DbSetFindingConvention</c> + <c>TableNameFromDbSetConvention</c>
-/// for <see cref="DbSet{TEntity}"/> subclasses.
+/// Discovers <see cref="ExpressiveDbSet{TEntity}"/> properties on the DbContext and registers
+/// their entity types with the property name as the table name. Mirrors EF Core's built-in
+/// <c>DbSetFindingConvention</c> + <c>TableNameFromDbSetConvention</c> for <see cref="DbSet{TEntity}"/> subclasses.
 /// </summary>
 public class ExpressiveDbSetDiscoveryConvention : IModelInitializedConvention, IEntityTypeAddedConvention
 {
@@ -58,10 +57,9 @@ public class ExpressiveDbSetDiscoveryConvention : IModelInitializedConvention, I
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionContext<IConventionEntityTypeBuilder> context)
     {
-        // Set the table name via the relational annotation (same key that ToTable() uses).
-        // This avoids a hard dependency on Microsoft.EntityFrameworkCore.Relational while
-        // still giving relational providers the correct table name.
-        // Only set if not already mapped by a regular DbSet<T> property.
+        // Set the table name via the relational annotation (same key ToTable() uses) to avoid
+        // a hard dependency on Microsoft.EntityFrameworkCore.Relational. Skip if already mapped
+        // by a regular DbSet<T> property.
         var clrType = entityTypeBuilder.Metadata.ClrType;
         if (_sets.TryGetValue(clrType, out var tableName)
             && entityTypeBuilder.Metadata.FindAnnotation("Relational:TableName") is null)

--- a/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveExpandQueryFiltersConvention.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveExpandQueryFiltersConvention.cs
@@ -7,8 +7,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 namespace ExpressiveSharp.EntityFrameworkCore.Infrastructure.Internal;
 
 /// <summary>
-/// Convention that expands <see cref="ExpressiveAttribute"/> member calls within
-/// global query filters at model-finalizing time.
+/// Expands <see cref="ExpressiveAttribute"/> member calls within global query filters
+/// at model-finalizing time.
 /// </summary>
 public class ExpressiveExpandQueryFiltersConvention : IModelFinalizingConvention
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveOptionsExtension.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveOptionsExtension.cs
@@ -11,10 +11,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ExpressiveSharp.EntityFrameworkCore.Infrastructure.Internal;
 
-/// <summary>
-/// Registers ExpressiveSharp services into the EF Core service provider:
-/// conventions for model building and a query compiler decorator for automatic expansion.
-/// </summary>
 public class ExpressiveOptionsExtension : IDbContextOptionsExtension
 {
     private readonly IReadOnlyList<IExpressivePlugin> _plugins;
@@ -43,16 +39,13 @@ public class ExpressiveOptionsExtension : IDbContextOptionsExtension
     [SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Required to decorate query compiler")]
     public void ApplyServices(IServiceCollection services)
     {
-        // The expressive resolver is stateless at the instance level (all caches are process-static),
-        // so a singleton lifetime is appropriate and cheap to share across scopes.
+        // Stateless at instance level (caches are process-static) — safe as singleton.
         services.TryAddSingleton<IExpressiveResolver, ExpressiveResolver>();
 
-        // Register conventions
         services.AddScoped<IConventionSetPlugin, ExpressiveDbSetDiscoveryConventionPlugin>();
         services.AddScoped<IConventionSetPlugin, ExpressivePropertiesNotMappedConventionPlugin>();
         services.AddScoped<IConventionSetPlugin, ExpressiveExpandQueryFiltersConventionPlugin>();
 
-        // Decorate IQueryCompiler with ExpressiveQueryCompiler
         var targetDescriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IQueryCompiler));
 
         var decoratorFactory = ActivatorUtilities.CreateFactory(
@@ -70,22 +63,17 @@ public class ExpressiveOptionsExtension : IDbContextOptionsExtension
         {
             // UseExpressives() called before provider (e.g. AddSqlite optionsAction) — deferred decoration.
             // Pre-register IQueryCompiler so the provider's TryAdd becomes a no-op.
-            // At resolution time, all provider services (IDatabase, IModel, etc.) are available.
             services.AddScoped<IQueryCompiler>(sp =>
                 (IQueryCompiler)decoratorFactory(sp, [ActivatorUtilities.CreateInstance<QueryCompiler>(sp)]));
         }
 
-        // Apply plugin services
         foreach (var plugin in _plugins)
             plugin.ApplyServices(services);
 
-        // Collect plugin transformers (captured by value in the closure)
         var extraTransformers = _plugins
             .SelectMany(p => p.GetTransformers())
             .ToArray();
 
-        // Register a dedicated ExpressiveOptions instance with EF Core transformers
-        // plus any transformers contributed by plugins
         var preserveThrow = _preserveThrowExpressions;
         services.AddSingleton(sp =>
         {

--- a/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressivePropertiesNotMappedConvention.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressivePropertiesNotMappedConvention.cs
@@ -7,13 +7,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 namespace ExpressiveSharp.EntityFrameworkCore.Infrastructure.Internal;
 
 /// <summary>
-/// Convention that marks properties as unmapped in the EF Core model when they have no backing
-/// database column:
-/// <list type="bullet">
-///   <item>decorated with <see cref="ExpressiveAttribute"/>,</item>
-///   <item>decorated with <see cref="ExpressiveForAttribute"/> (the property is a stub itself), or</item>
-///   <item>the target of an <see cref="ExpressiveForAttribute"/> stub elsewhere in the solution.</item>
-/// </list>
+/// Marks properties as unmapped when they have no backing column: decorated with
+/// <see cref="ExpressiveAttribute"/> or <see cref="ExpressiveForAttribute"/>, or the target
+/// of an <see cref="ExpressiveForAttribute"/> stub elsewhere in the solution.
 /// </summary>
 public class ExpressivePropertiesNotMappedConvention : IEntityTypeAddedConvention
 {

--- a/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveQueryCompiler.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Infrastructure/Internal/ExpressiveQueryCompiler.cs
@@ -13,8 +13,8 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace ExpressiveSharp.EntityFrameworkCore.Infrastructure.Internal;
 
 /// <summary>
-/// Decorates the EF Core <see cref="IQueryCompiler"/> to automatically expand
-/// <see cref="ExpressiveAttribute"/> member references before query compilation.
+/// Decorates the EF Core <see cref="IQueryCompiler"/> to expand <see cref="ExpressiveAttribute"/>
+/// member references before query compilation.
 /// </summary>
 [SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Required to intercept query compilation")]
 public sealed class ExpressiveQueryCompiler : QueryCompiler

--- a/src/ExpressiveSharp.Generator/Comparers/ExpressiveForMemberCompilationEqualityComparer.cs
+++ b/src/ExpressiveSharp.Generator/Comparers/ExpressiveForMemberCompilationEqualityComparer.cs
@@ -5,11 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ExpressiveSharp.Generator.Comparers;
 
-/// <summary>
-/// Equality comparer for [ExpressiveFor] pipeline tuples,
-/// mirroring <see cref="MemberDeclarationSyntaxAndCompilationEqualityComparer"/> for the standard pipeline.
-/// The <c>Member</c> field is a <see cref="MemberDeclarationSyntax"/> to cover both method and property stubs.
-/// </summary>
+// Mirrors MemberDeclarationSyntaxAndCompilationEqualityComparer for the [ExpressiveFor] pipeline.
 internal class ExpressiveForMemberCompilationEqualityComparer
     : IEqualityComparer<((MemberDeclarationSyntax Member, ExpressiveForAttributeData Attribute, ExpressiveGlobalOptions GlobalOptions), Compilation)>
 {

--- a/src/ExpressiveSharp.Generator/Comparers/MemberDeclarationSyntaxAndCompilationEqualityComparer.cs
+++ b/src/ExpressiveSharp.Generator/Comparers/MemberDeclarationSyntaxAndCompilationEqualityComparer.cs
@@ -5,10 +5,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ExpressiveSharp.Generator.Comparers;
 
-/// <summary>
-/// Equality comparer for tuples of (MemberDeclarationSyntax, ExpressiveAttributeData, ExpressiveGlobalOptions) and Compilation,
-/// used as keys in the registry to determine if a member's expressive status has changed across incremental generation steps.
-/// </summary>
 internal class MemberDeclarationSyntaxAndCompilationEqualityComparer
     : IEqualityComparer<((MemberDeclarationSyntax Member, ExpressiveAttributeData Attribute, ExpressiveGlobalOptions GlobalOptions), Compilation)>
 {
@@ -21,7 +17,6 @@ internal class MemberDeclarationSyntaxAndCompilationEqualityComparer
         var (xLeft, xCompilation) = x;
         var (yLeft, yCompilation) = y;
 
-        // 1. Fast reference equality short-circuit
         if (ReferenceEquals(xLeft.Member, yLeft.Member) &&
             ReferenceEquals(xCompilation, yCompilation) &&
             xLeft.GlobalOptions == yLeft.GlobalOptions)
@@ -29,34 +24,28 @@ internal class MemberDeclarationSyntaxAndCompilationEqualityComparer
             return true;
         }
 
-        // 2. The syntax tree of the member's own file must be the same object
-        //    (Roslyn reuses SyntaxTree instances for unchanged files, even when
-        //    the Compilation object itself is new due to edits elsewhere)
-        //    Single pointer comparison — very cheap.
+        // Roslyn reuses SyntaxTree instances for unchanged files even when the Compilation
+        // object itself is new due to edits elsewhere — pointer comparison is enough.
         if (!ReferenceEquals(xLeft.Member.SyntaxTree, yLeft.Member.SyntaxTree))
         {
             return false;
         }
 
-        // 3. Attribute arguments (primitive record struct) — cheap value comparison
         if (xLeft.Attribute != yLeft.Attribute)
         {
             return false;
         }
 
-        // 4. Global options (primitive record struct) — cheap value comparison
         if (xLeft.GlobalOptions != yLeft.GlobalOptions)
         {
             return false;
         }
 
-        // 5. Member text — string allocation, only reached when the SyntaxTree is shared
         if (!_memberComparer.Equals(xLeft.Member, yLeft.Member))
         {
             return false;
         }
 
-        // 6. Assembly-level references — most expensive (ImmutableArray enumeration)
         return xCompilation.ExternalReferences.SequenceEqual(yCompilation.ExternalReferences);
     }
 
@@ -71,7 +60,6 @@ internal class MemberDeclarationSyntaxAndCompilationEqualityComparer
             hash = hash * 31 + left.Attribute.GetHashCode();
             hash = hash * 31 + left.GlobalOptions.GetHashCode();
 
-            // Incorporate compilation external references to align with Equals
             var references = compilation.ExternalReferences;
             var referencesHash = 17;
             referencesHash = referencesHash * 31 + references.Length;

--- a/src/ExpressiveSharp.Generator/Comparers/MemberDeclarationSyntaxEqualityComparer.cs
+++ b/src/ExpressiveSharp.Generator/Comparers/MemberDeclarationSyntaxEqualityComparer.cs
@@ -3,10 +3,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ExpressiveSharp.Generator.Comparers;
 
-/// <summary>
-/// Equality comparer for MemberDeclarationSyntax nodes that treats nodes as equal if they are from the same syntax
-/// tree and have the same structure, even if they are different instances.
-/// </summary>
 internal class MemberDeclarationSyntaxEqualityComparer : IEqualityComparer<MemberDeclarationSyntax>
 {
     public bool Equals(MemberDeclarationSyntax x, MemberDeclarationSyntax y)
@@ -16,15 +12,13 @@ internal class MemberDeclarationSyntaxEqualityComparer : IEqualityComparer<Membe
             return true;
         }
 
-        // Must be in the same file — if the syntax tree changed, treat as different
-        // (Roslyn reuses SyntaxTree objects for unchanged files, so a new SyntaxTree
-        // means the file was edited, even if this specific node text looks the same)
+        // Roslyn reuses SyntaxTree objects for unchanged files, so a new SyntaxTree
+        // means the file was edited even if this specific node text looks the same.
         if (!ReferenceEquals(x.SyntaxTree, y.SyntaxTree))
         {
             return false;
         }
 
-        // Pré-filtres O(1) avant IsEquivalentTo
         if (x.RawKind != y.RawKind)
         {
             return false;
@@ -35,7 +29,6 @@ internal class MemberDeclarationSyntaxEqualityComparer : IEqualityComparer<Membe
             return false;
         }
 
-        // Comparaison structurelle Roslyn — pas d'allocation de string
         return x.IsEquivalentTo(y);
     }
 

--- a/src/ExpressiveSharp.Generator/Emitter/EmitResult.cs
+++ b/src/ExpressiveSharp.Generator/Emitter/EmitResult.cs
@@ -1,15 +1,8 @@
 namespace ExpressiveSharp.Generator.Emitter;
 
-/// <summary>
-/// The result of translating a C# expression body into imperative
-/// <c>System.Linq.Expressions.Expression.*</c> factory calls.
-/// </summary>
 internal sealed class EmitResult
 {
-    /// <summary>
-    /// C# statements that build the expression tree (the method body).
-    /// The last statement is a <c>return Expression.Lambda&lt;…&gt;(…);</c>.
-    /// </summary>
+    // C# statements that build the expression tree (the method body); ends with a return.
     public string Body { get; }
 
     public EmitResult(string body)

--- a/src/ExpressiveSharp.Generator/Emitter/ExpressionTreeEmitter.cs
+++ b/src/ExpressiveSharp.Generator/Emitter/ExpressionTreeEmitter.cs
@@ -9,16 +9,13 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace ExpressiveSharp.Generator.Emitter;
 
-/// <summary>
-/// Describes a parameter for expression tree emission.
-/// </summary>
 internal sealed class EmitterParameter
 {
     public string Name { get; }
     public string TypeFqn { get; }
-    /// <summary>Optional: the Roslyn parameter symbol, used to match <see cref="IParameterReferenceOperation"/>.</summary>
+    /// <summary>Optional: matched against <see cref="IParameterReferenceOperation"/>.</summary>
     public IParameterSymbol? Symbol { get; }
-    /// <summary>When true, this parameter is matched by <see cref="IInstanceReferenceOperation"/>.</summary>
+    /// <summary>When true, matched against <see cref="IInstanceReferenceOperation"/>.</summary>
     public bool IsThis { get; }
 
     public EmitterParameter(string name, string typeFqn, IParameterSymbol? symbol = null, bool isThis = false)
@@ -30,10 +27,6 @@ internal sealed class EmitterParameter
     }
 }
 
-/// <summary>
-/// Walks Roslyn <see cref="IOperation"/> nodes and emits C# code that builds
-/// an equivalent <c>System.Linq.Expressions.Expression</c> tree using factory methods.
-/// </summary>
 internal sealed class ExpressionTreeEmitter
 {
     private const string Expr = "global::System.Linq.Expressions.Expression";
@@ -55,11 +48,9 @@ internal sealed class ExpressionTreeEmitter
     private readonly string _varPrefix;
     private readonly string? _delegateVarName;
     /// <summary>
-    /// The fully-qualified return type of the outer lambda currently being emitted. Set by
-    /// <see cref="Emit"/> and <see cref="EmitConstructor"/>. Used by <see cref="EmitUnsupported"/>
-    /// to emit a type-compatible <c>Default</c> stub when an operation has no inferable type —
-    /// without this, unsupported top-level ops wrap <c>Default(object)</c> in a typed
-    /// <c>Lambda&lt;Func&lt;…, T&gt;&gt;</c> and blow up the registry's static initializer at load time.
+    /// Fully-qualified return type of the outer lambda. Used by <see cref="EmitUnsupported"/>
+    /// to emit a type-compatible <c>Default</c> stub — without this, top-level unsupported ops
+    /// wrap <c>Default(object)</c> in a typed lambda and crash the registry's static initializer.
     /// </summary>
     private string? _outerReturnTypeFqn;
 
@@ -77,22 +68,15 @@ internal sealed class ExpressionTreeEmitter
     }
 
     /// <summary>
-    /// Registers a type alias so that <paramref name="type"/> is emitted as <paramref name="alias"/>
-    /// (e.g., a generic type parameter name) instead of its fully qualified name.
-    /// Used for anonymous types that cannot be named in generated C# source.
+    /// Emits <paramref name="type"/> as <paramref name="alias"/>. Used for anonymous types,
+    /// which cannot be named in generated C# source.
     /// </summary>
     public void RegisterTypeAlias(ITypeSymbol type, string alias)
         => _typeAliases[type] = alias;
 
-    /// <summary>
-    /// Returns the fully qualified type name, substituting registered aliases for anonymous types.
-    /// </summary>
     private string ResolveTypeFqn(ITypeSymbol type)
         => _typeAliases.TryGetValue(type, out var alias) ? alias : type.ToDisplayString(_fqnFormat);
 
-    /// <summary>
-    /// Translates a lambda body expression into imperative <c>Expression.*</c> factory code.
-    /// </summary>
     public EmitResult Emit(
         SyntaxNode bodySyntax,
         IReadOnlyList<EmitterParameter> parameters,
@@ -101,7 +85,6 @@ internal sealed class ExpressionTreeEmitter
         string? assignToVariable = null)
     {
         _outerReturnTypeFqn = returnTypeFqn;
-        // Emit parameter declarations
         var paramVarNames = new List<string>();
         foreach (var param in parameters)
         {
@@ -115,11 +98,9 @@ internal sealed class ExpressionTreeEmitter
                 _thisVarName = varName;
         }
 
-        // Unwrap syntax wrappers that don't produce their own IOperation.
-        // Without this, GetOperation returns null and the entire expression is silently lost.
+        // Without unwrapping, GetOperation returns null on transparent syntax wrappers and the body is silently lost.
         bodySyntax = UnwrapTransparentSyntax(bodySyntax);
 
-        // Get IOperation for the body and emit it
         var operation = _semanticModel.GetOperation(bodySyntax);
         if (operation is null)
         {
@@ -141,8 +122,7 @@ internal sealed class ExpressionTreeEmitter
 
         var bodyVar = EmitOperation(operation);
 
-        // If the body's type doesn't match the delegate return type, insert an Expression.Convert.
-        // This handles cases like int → int? (Nullable<int>) in Join key selectors.
+        // Insert Expression.Convert for body/return type mismatch — e.g. int → int? in Join key selectors.
         if (operation.Type is not null)
         {
             var bodyTypeFqn = ResolveTypeFqn(operation.Type);
@@ -165,11 +145,6 @@ internal sealed class ExpressionTreeEmitter
         return BuildResult();
     }
 
-    /// <summary>
-    /// Translates a constructor body into a <c>MemberInit</c> expression tree.
-    /// Collects property assignments from the body and emits
-    /// <c>Expression.MemberInit(Expression.New(parameterless_ctor), bindings...)</c>.
-    /// </summary>
     public EmitResult EmitConstructor(
         SyntaxNode bodySyntax,
         IReadOnlyList<EmitterParameter> parameters,
@@ -180,7 +155,6 @@ internal sealed class ExpressionTreeEmitter
         IReadOnlyList<SyntaxNode>? chainedArgExpressions = null)
     {
         _outerReturnTypeFqn = returnTypeFqn;
-        // Emit parameter declarations
         var paramVarNames = new List<string>();
         foreach (var param in parameters)
         {
@@ -195,8 +169,7 @@ internal sealed class ExpressionTreeEmitter
         var newVar = NextVar();
         if (chainedTargetCtor is { Parameters.Length: > 0 } && chainedArgExpressions is not null)
         {
-            // `: this(args)` chain → invoke the target ctor directly so its bindings (including
-            // record primary-ctor positional parameters) flow through.
+            // `: this(args)` chain — invoke the target ctor so its bindings (incl. record primary-ctor params) flow through.
             var argVars = new List<string>();
             foreach (var argSyntax in chainedArgExpressions)
             {
@@ -218,7 +191,6 @@ internal sealed class ExpressionTreeEmitter
         }
         else
         {
-            // Parameterless ctor path (no chain, or `: this()` with no args).
             var parameterlessCtor = containingType.Constructors
                 .FirstOrDefault(c => !c.IsStatic && c.Parameters.IsEmpty);
             var ctorField = parameterlessCtor is not null
@@ -235,13 +207,9 @@ internal sealed class ExpressionTreeEmitter
             }
         }
 
-        // Accumulate property assignments: propName → (symbol, emitted value var)
         var propertyAssignments = new Dictionary<string, (ISymbol Symbol, string ValueVar)>();
 
-        // Process the constructor body, collecting property assignments.
-        // Block-bodied ctors produce an IBlockOperation; expression-bodied ctors produce the
-        // body's operation directly (e.g. a bare ISimpleAssignmentOperation or
-        // IDeconstructionAssignmentOperation).
+        // Block-bodied ctors yield an IBlockOperation; expression-bodied ctors yield the body's operation directly.
         var operation = _semanticModel.GetOperation(UnwrapTransparentSyntax(bodySyntax));
         if (operation is IBlockOperation block)
         {
@@ -252,7 +220,6 @@ internal sealed class ExpressionTreeEmitter
             ProcessConstructorStatement(operation, propertyAssignments);
         }
 
-        // Build MemberInit bindings from accumulated assignments
         var bindingVars = new List<string>();
         foreach (var kvp in propertyAssignments)
         {
@@ -295,11 +262,6 @@ internal sealed class ExpressionTreeEmitter
         return BuildResult();
     }
 
-    /// <summary>
-    /// Processes constructor statements, accumulating property assignments into the map.
-    /// Handles simple assignments, if/else (merges branches with ternary), local variables,
-    /// and early returns (ignored — assignments before the return are kept).
-    /// </summary>
     private void ProcessConstructorStatements(
         ImmutableArray<IOperation> operations,
         Dictionary<string, (ISymbol Symbol, string ValueVar)> assignments)
@@ -311,10 +273,7 @@ internal sealed class ExpressionTreeEmitter
         }
     }
 
-    /// <summary>
-    /// Processes a single constructor-body statement. Returns false when processing should stop
-    /// (e.g., after an early <c>return</c>).
-    /// </summary>
+    /// <summary>Returns false to halt further statements (e.g. after an early <c>return</c>).</summary>
     private bool ProcessConstructorStatement(
         IOperation op,
         Dictionary<string, (ISymbol Symbol, string ValueVar)> assignments)
@@ -330,12 +289,10 @@ internal sealed class ExpressionTreeEmitter
                 return true;
 
             case IDeconstructionAssignmentOperation deconRoot:
-                // Expression-bodied ctor: `public Ctor(X o) => (A, B) = (o.A, o.B);`
                 ProcessConstructorDeconstruction(deconRoot, assignments);
                 return true;
 
             case ISimpleAssignmentOperation bareAssignment:
-                // Expression-bodied ctor with a single `A = x` body.
                 ProcessConstructorAssignment(bareAssignment, assignments);
                 return true;
 
@@ -357,8 +314,6 @@ internal sealed class ExpressionTreeEmitter
                         if (declarator.Initializer is not null)
                         {
                             var initVar = EmitOperation(declarator.Initializer.Value);
-                            // For constructor local variables, store the value expression
-                            // so it can be referenced later (e.g. in conditions)
                             var assignVar = NextVar();
                             AppendLine($"var {assignVar} = {Expr}.Assign({localVar}, {initVar});");
                         }
@@ -367,16 +322,13 @@ internal sealed class ExpressionTreeEmitter
                 return true;
 
             case IReturnOperation:
-                // Early returns in constructors — stop processing further statements
                 return false;
 
             case IBlockOperation nestedBlock:
-                // Nested block scope (e.g. { if (...) { ... } })
                 ProcessConstructorStatements(nestedBlock.Operations, assignments);
                 return true;
 
             default:
-                // Skip other statement types
                 return true;
         }
     }
@@ -385,9 +337,7 @@ internal sealed class ExpressionTreeEmitter
         IDeconstructionAssignmentOperation decon,
         Dictionary<string, (ISymbol Symbol, string ValueVar)> assignments)
     {
-        // The walker has already validated the shape: both sides are tuple literals of equal
-        // arity and every left-side element is a property/field reference on `this`. We
-        // synthesize one assignment per pair.
+        // Walker has validated: both sides are equal-arity tuple literals; left elements are property/field refs on `this`.
         var target = UnwrapConversions(decon.Target);
         var value = UnwrapConversions(decon.Value);
         if (target is not ITupleOperation targetTuple || value is not ITupleOperation valueTuple
@@ -452,7 +402,6 @@ internal sealed class ExpressionTreeEmitter
         IConditionalOperation conditional,
         Dictionary<string, (ISymbol Symbol, string ValueVar)> assignments)
     {
-        // Collect assignments from both branches
         var trueAssignments = new Dictionary<string, (ISymbol Symbol, string ValueVar)>();
         var falseAssignments = new Dictionary<string, (ISymbol Symbol, string ValueVar)>();
 
@@ -467,24 +416,21 @@ internal sealed class ExpressionTreeEmitter
             ProcessConstructorAssignment(falseAssign, falseAssignments);
         else if (conditional.WhenFalse is IConditionalOperation elseIf)
         {
-            // else if chain
             ProcessConstructorConditional(elseIf, falseAssignments);
         }
 
         var conditionVar = EmitOperation(conditional.Condition);
 
-        // Merge: for each property assigned in either branch, produce a ternary
+        // For each property assigned in either branch, emit a ternary that picks the right value at construction time.
         var allProps = new HashSet<string>(trueAssignments.Keys.Union(falseAssignments.Keys));
         foreach (var propName in allProps)
         {
             trueAssignments.TryGetValue(propName, out var trueEntry);
             falseAssignments.TryGetValue(propName, out var falseEntry);
 
-            // Determine symbol (from whichever branch has it)
             var symbol = trueEntry.Symbol ?? falseEntry.Symbol;
             if (symbol is null) continue;
 
-            // Determine type for the ternary
             var typeFqn = symbol switch
             {
                 IPropertySymbol p => p.Type.ToDisplayString(_fqnFormat),
@@ -492,11 +438,10 @@ internal sealed class ExpressionTreeEmitter
                 _ => "object"
             };
 
-            // True value: from true branch, or fall back to previous assignment
+            // Missing branches fall back to the previously accumulated value (or default if none).
             var trueVal = trueEntry.ValueVar;
             if (trueVal is null)
             {
-                // Property not assigned in true branch — use the previously accumulated value
                 if (assignments.TryGetValue(propName, out var prev))
                     trueVal = prev.ValueVar;
                 else
@@ -506,7 +451,6 @@ internal sealed class ExpressionTreeEmitter
                 }
             }
 
-            // False value: from false branch, or fall back to previous assignment
             var falseVal = falseEntry.ValueVar;
             if (falseVal is null)
             {
@@ -524,8 +468,6 @@ internal sealed class ExpressionTreeEmitter
             assignments[propName] = (symbol, ternaryVar);
         }
     }
-
-    // ── Main dispatch ────────────────────────────────────────────────────────
 
     private string EmitOperation(IOperation operation)
     {
@@ -579,7 +521,6 @@ internal sealed class ExpressionTreeEmitter
             _ => EmitUnsupported(operation),
         };
 
-        // Annotate the first line emitted by this operation with the source syntax
         if (_lineCount > lineCountBefore && operation.Syntax is not null)
         {
             var syntaxText = operation.Syntax.ToString().Replace("\r", "").Replace("\n", " ");
@@ -590,8 +531,6 @@ internal sealed class ExpressionTreeEmitter
 
         return result;
     }
-
-    // ── Literals ─────────────────────────────────────────────────────────────
 
     private string EmitLiteral(ILiteralOperation literal)
     {
@@ -613,15 +552,12 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Parameter & instance references ──────────────────────────────────────
-
     private string EmitParameterReference(IParameterReferenceOperation paramRef)
     {
         if (_symbolToVar.TryGetValue(paramRef.Parameter, out var varName))
             return varName;
 
-        // Outer-scope parameter — captured variable from enclosing method.
-        // Extract its value from the delegate's closure at runtime.
+        // Outer-scope param — pull the captured value from the delegate's closure at runtime.
         if (_delegateVarName is not null)
         {
             var resultVar = EmitCapturedVariable(paramRef.Parameter.Name, paramRef.Parameter.Type);
@@ -629,7 +565,7 @@ internal sealed class ExpressionTreeEmitter
             return resultVar;
         }
 
-        // Fallback: parameter not in our map (non-interceptor path)
+        // Non-interceptor path — fresh ParameterExpression.
         var fallbackVar = NextVar();
         var typeFqn = paramRef.Parameter.Type.ToDisplayString(_fqnFormat);
         AppendLine($"var {fallbackVar} = {Expr}.Parameter(typeof({typeFqn}), \"{paramRef.Parameter.Name}\");");
@@ -642,7 +578,7 @@ internal sealed class ExpressionTreeEmitter
         if (_localToVar.TryGetValue(localRef.Local, out var varName))
             return varName;
 
-        // Outer-scope local — captured variable from enclosing method.
+        // Outer-scope local — pull from the delegate's closure.
         if (_delegateVarName is not null)
         {
             var resultVar = EmitCapturedVariable(localRef.Local.Name, localRef.Local.Type);
@@ -650,7 +586,6 @@ internal sealed class ExpressionTreeEmitter
             return resultVar;
         }
 
-        // Fallback: local not yet declared (shouldn't happen in well-formed code)
         var fallbackVar = NextVar();
         var typeFqn = localRef.Local.Type.ToDisplayString(_fqnFormat);
         AppendLine($"var {fallbackVar} = {Expr}.Variable(typeof({typeFqn}), \"{localRef.Local.Name}\");");
@@ -673,9 +608,7 @@ internal sealed class ExpressionTreeEmitter
         if (_thisVarName is not null)
             return _thisVarName;
 
-        // Outer-scope `this` — captured from the enclosing instance method.
-        // The compiler stores `this` under a generated field name (e.g. <>4__this),
-        // so we resolve it by type rather than by name.
+        // Captured `this` is stored under a compiler-generated field name (e.g. <>4__this), so resolve by type.
         if (_delegateVarName is not null && instanceType is not null)
         {
             _thisVarName = $"{_varPrefix}__this";
@@ -684,26 +617,19 @@ internal sealed class ExpressionTreeEmitter
             return _thisVarName;
         }
 
-        // Fallback (non-interceptor path, e.g. [Expressive] members)
         _thisVarName = "p___this";
         AppendLine($"var {_thisVarName} = {Expr}.Parameter(typeof(object), \"@this\");");
         return _thisVarName;
     }
 
-    // ── Member access ────────────────────────────────────────────────────────
-
     private string EmitPropertyReference(IPropertyReferenceOperation propRef)
     {
-        // In the interceptor path, instance property access (this.Property) may be captured
-        // directly by the C# compiler as a closure field with the backing field name,
-        // or indirectly through a captured `this`. Delegate to the closure helper which
-        // handles both cases.
+        // Interceptor path: this.Property may be captured as a closure field directly (auto-prop backing
+        // field) or via captured `this`. ResolveCapturedInstanceMember handles both.
         if (_delegateVarName is not null &&
             propRef.Instance is IInstanceReferenceOperation &&
             propRef.Property.GetMethod is { } getter)
         {
-            // Auto-properties have a backing field with the same name pattern;
-            // the closure may capture the property's backing field directly.
             var resultVar = NextVar();
             var propName = propRef.Property.Name;
             var enclosingTypeFqn = ResolveTypeFqn(propRef.Instance.Type!);
@@ -729,9 +655,7 @@ internal sealed class ExpressionTreeEmitter
 
     private string EmitFieldReference(IFieldReferenceOperation fieldRef)
     {
-        // In the interceptor path, instance field access (this._field) may be captured
-        // directly as a closure field, or indirectly through a captured `this`.
-        // Delegate to the closure helper which handles both cases.
+        // Interceptor path: this._field may be captured directly or via captured `this`. Helper handles both.
         if (_delegateVarName is not null && fieldRef.Instance is IInstanceReferenceOperation)
         {
             var resultVar = NextVar();
@@ -757,15 +681,13 @@ internal sealed class ExpressionTreeEmitter
         return fieldResultVar;
     }
 
-    // ── Invocations ──────────────────────────────────────────────────────────
-
     private bool TryEmitEnumMethodExpansion(IInvocationOperation invocation, out string resultVar)
     {
         resultVar = "";
 
         var method = invocation.TargetMethod;
 
-        // Determine the enum receiver — could be instance call or extension method (first arg)
+        // Receiver could be the instance call's instance, or the first arg of an extension method.
         ITypeSymbol? receiverType = null;
         IOperation? receiverOperation = null;
 
@@ -783,7 +705,6 @@ internal sealed class ExpressionTreeEmitter
         if (receiverType is null || receiverOperation is null)
             return false;
 
-        // Handle Nullable<EnumType>
         ITypeSymbol enumType;
         var isNullable = false;
         if (receiverType is INamedTypeSymbol { IsGenericType: true } nullableType &&
@@ -815,11 +736,10 @@ internal sealed class ExpressionTreeEmitter
         var returnTypeFqn = returnType.ToDisplayString(_fqnFormat);
         var enumTypeFqn = enumType.ToDisplayString(_fqnFormat);
 
-        // Resolve the original (unreduced) method for the static call
+        // Use unreduced method so the static call form has the correct signature for extension methods.
         var originalMethod = method.ReducedFrom ?? method;
         var methodField = _fieldCache.EnsureMethodInfo(originalMethod);
 
-        // Build default value
         string defaultVar;
         if (returnType.IsReferenceType || returnType.NullableAnnotation == NullableAnnotation.Annotated ||
             (returnType is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }))
@@ -833,16 +753,14 @@ internal sealed class ExpressionTreeEmitter
             AppendLine($"var {defaultVar} = {Expr}.Default(typeof({returnTypeFqn}));");
         }
 
-        // Build ternary chain for each enum value (reverse order)
+        // Build the ternary chain in reverse so the first member ends up as the outermost (and first-tested) branch.
         var currentVar = defaultVar;
         foreach (var member in enumMembers.AsEnumerable().Reverse())
         {
-            // Enum value constant
             var enumValueVar = NextVar();
             AppendLine($"var {enumValueVar} = {Expr}.Constant({enumTypeFqn}.{member.Name}, typeof({enumTypeFqn}));");
 
-            // Method call: static methods pass enum value as first arg,
-            // instance methods use enum value as the receiver
+            // Static path passes the enum value as the first arg; instance path uses it as the receiver.
             string callVar;
             if (originalMethod.IsStatic)
             {
@@ -870,17 +788,15 @@ internal sealed class ExpressionTreeEmitter
                 AppendLine($"var {callVar} = {Expr}.Call({enumValueVar}, {methodField}, {callArgsExpr});");
             }
 
-            // Condition: receiver == enumValue
             var condVar = NextVar();
             AppendLine($"var {condVar} = {Expr}.Equal({receiverVar}, {enumValueVar});");
 
-            // Ternary: condition ? call : current
             var ternaryVar = NextVar();
             AppendLine($"var {ternaryVar} = {Expr}.Condition({condVar}, {callVar}, {currentVar}, typeof({returnTypeFqn}));");
             currentVar = ternaryVar;
         }
 
-        // Nullable wrapper: receiver == null ? default : chain
+        // For Nullable<TEnum>, wrap in: receiver == null ? default : chain
         if (isNullable)
         {
             var nullConst = NextVar();
@@ -901,8 +817,6 @@ internal sealed class ExpressionTreeEmitter
 
     private string EmitInvocation(IInvocationOperation invocation)
     {
-        // Enum method expansion: when the receiver is an enum type, expand to ternary chain
-        // Always expand enum method calls to ternary chains
         if (TryEmitEnumMethodExpansion(invocation, out var enumResult))
         {
             return enumResult;
@@ -936,8 +850,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Binary operators ─────────────────────────────────────────────────────
-
     private string EmitBinary(IBinaryOperation binary)
     {
         var exprType = MapBinaryOperatorKind(binary.OperatorKind);
@@ -947,16 +859,13 @@ internal sealed class ExpressionTreeEmitter
             return EmitUnsupported(binary);
         }
 
-        // String concatenation via + uses string.Concat, not Expression.Add.
-        // Only matches the built-in compiler intrinsic (OperatorMethod is null).
-        // User-defined operator+ that returns string will have OperatorMethod set
-        // and is correctly handled by the existing MakeBinary path below.
+        // Built-in string + uses string.Concat, not Expression.Add. User-defined operator+ returning string
+        // has OperatorMethod set and falls through to MakeBinary.
         if (binary.OperatorKind == BinaryOperatorKind.Add
             && binary.OperatorMethod is null
             && binary.Type?.SpecialType == SpecialType.System_String)
             return EmitStringConcatenation(binary);
 
-        // Use checked variants when in a checked context
         if (binary.IsChecked)
         {
             exprType = exprType switch
@@ -991,9 +900,7 @@ internal sealed class ExpressionTreeEmitter
         var leftVar = EmitOperation(binary.LeftOperand);
         var rightVar = EmitOperation(binary.RightOperand);
 
-        // Choose the correct Concat overload based on operand types.
-        // If both operands are string, use Concat(string, string).
-        // Otherwise (e.g. object + string from implicit boxing), use Concat(object, object).
+        // Concat(string, string) vs Concat(object, object) — non-string operands (e.g. boxed via object+string) need the latter.
         var bothString = binary.LeftOperand.Type?.SpecialType == SpecialType.System_String
                       && binary.RightOperand.Type?.SpecialType == SpecialType.System_String;
 
@@ -1031,11 +938,9 @@ internal sealed class ExpressionTreeEmitter
         };
     }
 
-    // ── Unary operators ──────────────────────────────────────────────────────
-
     private string EmitUnary(IUnaryOperation unary)
     {
-        // Special case: ^ operator (Index from end) → new Index(operand, fromEnd: true)
+        // ^x is the Index-from-end operator; expression trees have no native form, so we synthesize a ctor call.
         if (unary.OperatorKind == UnaryOperatorKind.Hat)
         {
             return EmitIndexFromEnd(unary);
@@ -1048,7 +953,6 @@ internal sealed class ExpressionTreeEmitter
             return EmitUnsupported(unary);
         }
 
-        // Use checked variant when in a checked context
         if (unary.IsChecked && exprType == "Negate")
         {
             exprType = "NegateChecked";
@@ -1083,15 +987,12 @@ internal sealed class ExpressionTreeEmitter
         };
     }
 
-    // ── Type conversions ─────────────────────────────────────────────────────
-
     private string EmitConversion(IConversionOperation conversion)
     {
         if (conversion.Conversion.IsIdentity)
             return EmitOperation(conversion.Operand);
 
-        // Throw expressions are void-typed; Expression.Convert(void, T) is invalid.
-        // Emit Expression.Throw(exception, targetType) directly instead.
+        // Throw expressions are void-typed and Expression.Convert(void, T) is invalid; emit a typed Throw directly.
         if (conversion.Operand is IThrowOperation throwOp && throwOp.Exception is not null)
             return EmitThrowWithType(throwOp, conversion.Type);
 
@@ -1114,16 +1015,13 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Conditional (ternary) ────────────────────────────────────────────────
-
     private string EmitConditional(IConditionalOperation conditional)
     {
         var resultVar = NextVar();
         var testVar = EmitOperation(conditional.Condition);
         var ifTrueVar = EmitOperation(conditional.WhenTrue);
 
-        // Determine the result type. For statement-form if/else (not ternary),
-        // conditional.Type is null or void. Infer from the branch return types.
+        // Statement-form if/else gives null or void Type; infer from the branch return types.
         var condType = conditional.Type;
         if (condType is null || condType.SpecialType == SpecialType.System_Void
             || condType.SpecialType == SpecialType.System_Object)
@@ -1139,7 +1037,6 @@ internal sealed class ExpressionTreeEmitter
             var ifFalseVar = EmitOperation(conditional.WhenFalse);
             if (condType is null || condType.SpecialType == SpecialType.System_Void)
             {
-                // Statement-form if/else: use IfThenElse (returns void)
                 AppendLine($"var {resultVar} = {Expr}.IfThenElse({testVar}, {ifTrueVar}, {ifFalseVar});");
             }
             else
@@ -1151,7 +1048,6 @@ internal sealed class ExpressionTreeEmitter
         {
             if (condType is null || condType.SpecialType == SpecialType.System_Void)
             {
-                // Statement-form if (no else): use IfThen (returns void)
                 AppendLine($"var {resultVar} = {Expr}.IfThen({testVar}, {ifTrueVar});");
             }
             else
@@ -1162,8 +1058,6 @@ internal sealed class ExpressionTreeEmitter
 
         return resultVar;
     }
-
-    // ── Object creation ──────────────────────────────────────────────────────
 
     private string EmitObjectCreation(IObjectCreationOperation creation)
     {
@@ -1200,7 +1094,6 @@ internal sealed class ExpressionTreeEmitter
                     if (initializer is ISimpleAssignmentOperation assignment &&
                         assignment.Target is IMemberReferenceOperation memberRef)
                     {
-                        // Member binding: new T { Prop = value }
                         var valueVar = EmitOperation(assignment.Value);
                         var bindingVar = NextVar();
 
@@ -1225,7 +1118,6 @@ internal sealed class ExpressionTreeEmitter
                     }
                     else if (initializer is IInvocationOperation invocation)
                     {
-                        // Collection initializer: .Add(element) call
                         var addMethodField = _fieldCache.EnsureMethodInfo(invocation.TargetMethod);
                         var elemVars = new List<string>();
                         foreach (var arg in invocation.Arguments)
@@ -1247,13 +1139,11 @@ internal sealed class ExpressionTreeEmitter
 
                 if (elementInitVars.Count > 0)
                 {
-                    // Collection initializer: Expression.ListInit(new, elementInits)
                     var elementsExpr = string.Join(", ", elementInitVars);
                     AppendLine($"var {resultVar} = {Expr}.ListInit({newVar}, {elementsExpr});");
                 }
                 else
                 {
-                    // Member initializer: Expression.MemberInit(new, bindings)
                     var bindingsExpr = string.Join(", ", bindingVars);
                     AppendLine($"var {resultVar} = {Expr}.MemberInit({newVar}, {bindingsExpr});");
                 }
@@ -1280,22 +1170,18 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Anonymous object creation ───────────────────────────────────────────
-
     private string EmitAnonymousObjectCreation(IAnonymousObjectCreationOperation creation)
     {
         var anonType = creation.Type;
         if (anonType is null || !_typeAliases.ContainsKey(anonType))
         {
-            // No alias registered (e.g., nested anonymous type or [Expressive] path).
-            // Cannot generate valid C# — fall back to unsupported.
+            // No alias registered — anonymous type can't be named in generated source.
             return EmitUnsupported(creation);
         }
 
         var resultVar = NextVar();
         var typeFqn = ResolveTypeFqn(anonType);
 
-        // Emit each initializer value and collect property names.
         var valueVars = new List<string>();
         var propertyNames = new List<string>();
         foreach (var initializer in creation.Initializers)
@@ -1308,12 +1194,11 @@ internal sealed class ExpressionTreeEmitter
             }
             else
             {
-                // Direct value expression — property name comes from the type symbol.
                 valueVars.Add(EmitOperation(initializer));
             }
         }
 
-        // If property names weren't extracted from assignments, derive from the type symbol.
+        // Direct value-expression initializers don't surface property names; fall back to walking the type.
         if (propertyNames.Count < valueVars.Count && anonType is INamedTypeSymbol namedType)
         {
             propertyNames.Clear();
@@ -1324,9 +1209,8 @@ internal sealed class ExpressionTreeEmitter
             }
         }
 
-        // Inline runtime reflection — cannot use ReflectionFieldCache because the anonymous
-        // type is referenced via a generic type parameter (e.g., TResult) that is only
-        // available at the method level, not in static field initializers.
+        // Inline reflection rather than ReflectionFieldCache — the anon type is referenced via a generic
+        // parameter (e.g. TResult) that's only in scope at method level, not in static field initializers.
         var ctorVar = NextVar();
         AppendLine($"var {ctorVar} = typeof({typeFqn}).GetConstructors()[0];");
 
@@ -1342,8 +1226,6 @@ internal sealed class ExpressionTreeEmitter
         AppendLine($"var {resultVar} = {Expr}.New({ctorVar}, {argsArray}, {membersArray});");
         return resultVar;
     }
-
-    // ── Default & typeof ─────────────────────────────────────────────────────
 
     private string EmitDefault(IDefaultValueOperation defaultVal)
     {
@@ -1361,8 +1243,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Type checking ────────────────────────────────────────────────────────
-
     private string EmitIsType(IIsTypeOperation isType)
     {
         var resultVar = NextVar();
@@ -1372,8 +1252,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Null coalescing ──────────────────────────────────────────────────────
-
     private string EmitCoalesce(ICoalesceOperation coalesce)
     {
         var resultVar = NextVar();
@@ -1382,8 +1260,6 @@ internal sealed class ExpressionTreeEmitter
         AppendLine($"var {resultVar} = {Expr}.Coalesce({leftVar}, {rightVar});");
         return resultVar;
     }
-
-    // ── Throw expressions ─────────────────────────────────────────────────────
 
     private string EmitThrow(IThrowOperation throwOp)
     {
@@ -1410,8 +1286,6 @@ internal sealed class ExpressionTreeEmitter
 
         return resultVar;
     }
-
-    // ── Arrays ───────────────────────────────────────────────────────────────
 
     private string EmitArrayCreation(IArrayCreationOperation arrayCreate)
     {
@@ -1469,8 +1343,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Nested lambdas & delegates ───────────────────────────────────────────
-
     private string EmitNestedLambda(IAnonymousFunctionOperation lambda)
     {
         var lambdaSymbol = lambda.Symbol;
@@ -1501,8 +1373,6 @@ internal sealed class ExpressionTreeEmitter
         return EmitOperation(delegateCreate.Target);
     }
 
-    // ── Tuples ───────────────────────────────────────────────────────────────
-
     private string EmitTuple(ITupleOperation tuple)
     {
         var tupleType = tuple.Type as INamedTypeSymbol;
@@ -1514,8 +1384,7 @@ internal sealed class ExpressionTreeEmitter
 
     private string EmitTupleConstruction(INamedTypeSymbol tupleType, IReadOnlyList<IOperation> elements)
     {
-        // For 8+ element tuples, C# nests as ValueTuple<T1,...,T7, ValueTuple<T8,...>>.
-        // The underlying type strips tuple element names.
+        // 8+ element tuples nest as ValueTuple<T1..T7, ValueTuple<T8..>>; underlying type strips element names.
         var underlyingType = tupleType.TupleUnderlyingType ?? tupleType;
         var typeArgs = underlyingType.TypeArguments;
 
@@ -1524,7 +1393,6 @@ internal sealed class ExpressionTreeEmitter
             && restType.OriginalDefinition.ContainingNamespace?.ToDisplayString() == "System"
             && restType.OriginalDefinition.Name == "ValueTuple")
         {
-            // First 7 elements are direct, the 8th is a nested ValueTuple
             var first7 = new List<string>();
             for (var i = 0; i < 7; i++)
             {
@@ -1548,7 +1416,6 @@ internal sealed class ExpressionTreeEmitter
             return resultVar;
         }
 
-        // Standard case: ≤7 elements
         var elementVars = new List<string>();
         foreach (var element in elements)
         {
@@ -1573,8 +1440,6 @@ internal sealed class ExpressionTreeEmitter
 
         return result;
     }
-
-    // ── Tuple binary (== / !=) ────────────────────────────────────────────
 
     private string EmitTupleBinary(ITupleBinaryOperation tupleBinary)
     {
@@ -1606,7 +1471,6 @@ internal sealed class ExpressionTreeEmitter
 
         bool isEquality = tupleBinary.OperatorKind == BinaryOperatorKind.Equals;
 
-        // Build element-wise comparisons
         var comparisons = new List<string>();
         for (var i = 0; i < leftFields.Count; i++)
         {
@@ -1623,7 +1487,7 @@ internal sealed class ExpressionTreeEmitter
             comparisons.Add(cmpVar);
         }
 
-        // Fold: == uses AndAlso, != uses OrElse(NotEqual) but simpler to negate the whole thing
+        // For !=, fold with AndAlso then Not — equivalent to OrElse over NotEqual but simpler to emit.
         var resultVar = comparisons[0];
         for (var i = 1; i < comparisons.Count; i++)
         {
@@ -1641,8 +1505,6 @@ internal sealed class ExpressionTreeEmitter
 
         return resultVar;
     }
-
-    // ── Pattern matching ────────────────────────────────────────────────────
 
     private string EmitIsPattern(IIsPatternOperation isPattern)
     {
@@ -1685,9 +1547,7 @@ internal sealed class ExpressionTreeEmitter
 
     private string EmitDeclarationPattern(IDeclarationPatternOperation declaration, string operandVar)
     {
-        // Declaration patterns with named variables (e.g. `x is string s`) are not
-        // representable in expression trees — pattern variables don't exist.
-        // Discard designations (e.g. `x is string _`) are pure type checks.
+        // Pattern variables don't exist in expression trees, so emit a pure TypeIs even for `x is T name`.
         var resultVar = NextVar();
         var typeFqn = declaration.NarrowedType.ToDisplayString(_fqnFormat);
         AppendLine($"var {resultVar} = {Expr}.TypeIs({operandVar}, typeof({typeFqn}));");
@@ -1712,7 +1572,7 @@ internal sealed class ExpressionTreeEmitter
             ReportDiagnostic(Diagnostics.UnsupportedOperator,
                 relational.Syntax?.GetLocation() ?? Location.None,
                 relational.OperatorKind.ToString());
-            // Fall back to constant false (never matches) — safer than true (always matches)
+            // Fall back to constant false — never-matches is safer than always-matches when the operator is unknown.
             AppendLine($"var {resultVar} = {Expr}.Constant(false);");
             return resultVar;
         }
@@ -1750,11 +1610,9 @@ internal sealed class ExpressionTreeEmitter
     {
         var conditions = new List<string>();
 
-        // Find Count/Length property on the collection type
         var countProp = operandType?.GetMembers("Count").OfType<IPropertySymbol>().FirstOrDefault()
             ?? operandType?.GetMembers("Length").OfType<IPropertySymbol>().FirstOrDefault();
 
-        // Find indexer (this[int])
         var indexer = operandType?.GetMembers()
             .OfType<IPropertySymbol>()
             .FirstOrDefault(p => p.IsIndexer && p.Parameters.Length == 1
@@ -1770,12 +1628,11 @@ internal sealed class ExpressionTreeEmitter
 
         var countField = _fieldCache.EnsurePropertyInfo(countProp);
 
-        // Check if there's a slice pattern (.. rest) — determines exact vs minimum length
+        // A `..` slice means minimum-length match; otherwise exact-length.
         var hasSlice = listPattern.Patterns.Any(p => p is ISlicePatternOperation);
         var fixedPatterns = listPattern.Patterns.Where(p => p is not ISlicePatternOperation).ToList();
         var requiredCount = fixedPatterns.Count;
 
-        // Length check: exact match if no slice, minimum if slice present
         var countAccess = NextVar();
         AppendLine($"var {countAccess} = {Expr}.Property({operandVar}, {countField});");
         var countConst = NextVar();
@@ -1791,13 +1648,11 @@ internal sealed class ExpressionTreeEmitter
         }
         conditions.Add(lengthCheck);
 
-        // Element checks: pattern[i] against collection[i]
         var elementIndex = 0;
         foreach (var subPattern in listPattern.Patterns)
         {
             if (subPattern is ISlicePatternOperation)
             {
-                // Skip slice — it matches "the rest"
                 continue;
             }
 
@@ -1807,11 +1662,10 @@ internal sealed class ExpressionTreeEmitter
                 continue;
             }
 
-            // Access collection[elementIndex]
             var idxConst = NextVar();
             AppendLine($"var {idxConst} = {Expr}.Constant({elementIndex});");
-            var elementAccess = NextVar();
 
+            var elementAccess = NextVar();
             if (operandType is IArrayTypeSymbol)
             {
                 AppendLine($"var {elementAccess} = {Expr}.ArrayIndex({operandVar}, {idxConst});");
@@ -1828,7 +1682,6 @@ internal sealed class ExpressionTreeEmitter
             elementIndex++;
         }
 
-        // Combine all conditions with AndAlso
         if (conditions.Count == 0)
         {
             var trueVar = NextVar();
@@ -1851,7 +1704,7 @@ internal sealed class ExpressionTreeEmitter
     {
         var conditions = new List<string>();
 
-        // Null check for reference types and Nullable<T>
+        // Null-check anything that could be null at runtime: reference types and Nullable<T>.
         if (operandType is null
             || !operandType.IsValueType
             || operandType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
@@ -1863,7 +1716,7 @@ internal sealed class ExpressionTreeEmitter
             conditions.Add(nullCheck);
         }
 
-        // Type guard — MatchedType is set when the pattern has an explicit type (e.g. `is SomeType { ... }`)
+        // MatchedType is set for `is SomeType { ... }` shapes — emit a TypeIs guard plus a cast for member access.
         string memberBase = operandVar;
         if (recursive.MatchedType is not null && !SymbolEqualityComparer.Default.Equals(recursive.InputType, recursive.NarrowedType))
         {
@@ -1872,12 +1725,10 @@ internal sealed class ExpressionTreeEmitter
             AppendLine($"var {typeCheck} = {Expr}.TypeIs({operandVar}, typeof({narrowedTypeFqn}));");
             conditions.Add(typeCheck);
 
-            // Cast for member access
             memberBase = NextVar();
             AppendLine($"var {memberBase} = {Expr}.Convert({operandVar}, typeof({narrowedTypeFqn}));");
         }
 
-        // Property sub-patterns
         foreach (var prop in recursive.PropertySubpatterns)
         {
             if (prop.Member is not IMemberReferenceOperation memberRef)
@@ -1917,7 +1768,6 @@ internal sealed class ExpressionTreeEmitter
             conditions.Add(subCondition);
         }
 
-        // Positional sub-patterns (deconstruct)
         if (recursive.DeconstructionSubpatterns.Length > 0)
         {
             var targetType = recursive.NarrowedType as INamedTypeSymbol ?? operandType as INamedTypeSymbol;
@@ -1927,12 +1777,14 @@ internal sealed class ExpressionTreeEmitter
             {
                 var subPattern = recursive.DeconstructionSubpatterns[i];
                 if (subPattern is IDiscardPatternOperation)
+                {
                     continue;
+                }
 
                 string? propName = null;
                 ITypeSymbol? propType = null;
 
-                // Try to resolve via Deconstruct parameter name → property name
+                // Resolve positional element either via Deconstruct parameter name → matching property, or tuple ItemN.
                 if (deconstructSymbol is not null && i < deconstructSymbol.Parameters.Length)
                 {
                     var paramName = deconstructSymbol.Parameters[i].Name;
@@ -1946,7 +1798,6 @@ internal sealed class ExpressionTreeEmitter
                     }
                 }
 
-                // Fallback: tuple Item1, Item2, ...
                 if (propName is null && targetType is not null)
                 {
                     var itemName = $"Item{i + 1}";
@@ -1968,7 +1819,6 @@ internal sealed class ExpressionTreeEmitter
                     continue;
                 }
 
-                // Access the property/field on memberBase
                 var accessVar = NextVar();
                 var memberSymbol = targetType?.GetMembers(propName).FirstOrDefault();
                 if (memberSymbol is IPropertySymbol ps)
@@ -1994,7 +1844,6 @@ internal sealed class ExpressionTreeEmitter
             }
         }
 
-        // Combine all conditions with AndAlso
         if (conditions.Count == 0)
         {
             var resultVar = NextVar();
@@ -2013,14 +1862,10 @@ internal sealed class ExpressionTreeEmitter
         return combined;
     }
 
-    // ── Switch expressions ──────────────────────────────────────────────────
-
     /// <summary>
-    /// Translates a <c>switch (expr) { case X: return ...; default: return ...; }</c> statement
-    /// into a nested-ternary expression equivalent to the corresponding switch expression.
-    /// Each case clause must be a single-value constant pattern and each case body must be a
-    /// single <c>return</c> statement. Fall-through, <c>goto case</c>, and non-return bodies
-    /// are not supported and fall back to the default-stub behavior.
+    /// Lowers a switch statement to a ternary chain. Requires single-value constant patterns and
+    /// single-return case bodies; fall-through, <c>goto case</c>, and non-return bodies fall back
+    /// to the default-stub behavior.
     /// </summary>
     private string EmitSwitchStatement(ISwitchOperation switchStmt)
     {
@@ -2091,7 +1936,7 @@ internal sealed class ExpressionTreeEmitter
             AppendLine($"var {currentVar} = {Expr}.Default(typeof({typeFqn}));");
         }
 
-        // Fold arms in reverse so the first matching arm wins.
+        // Fold in reverse so the first matching arm ends up as the outermost (first-tested) ternary.
         for (var i = arms.Count - 1; i >= 0; i--)
         {
             var (condVar, valueVar, _) = arms[i];
@@ -2103,11 +1948,7 @@ internal sealed class ExpressionTreeEmitter
         return currentVar;
     }
 
-    /// <summary>
-    /// Returns the single <see cref="IReturnOperation"/> inside a switch case's body, or null
-    /// if the body does not reduce to a single return (e.g. multiple statements, break-only,
-    /// goto case, throw).
-    /// </summary>
+    /// <summary>Returns the single return operation in a case body, or null if the shape isn't supported.</summary>
     private static IReturnOperation? FindCaseReturn(ISwitchCaseOperation switchCase)
     {
         foreach (var op in switchCase.Body)
@@ -2119,8 +1960,10 @@ internal sealed class ExpressionTreeEmitter
                 case IBlockOperation block:
                     foreach (var inner in block.Operations)
                     {
-                        if (inner is IReturnOperation innerRet) return innerRet;
-                        // Anything other than the return means we don't support this shape.
+                        if (inner is IReturnOperation innerRet)
+                        {
+                            return innerRet;
+                        }
                         return null;
                     }
                     return null;
@@ -2136,7 +1979,6 @@ internal sealed class ExpressionTreeEmitter
         var governingVar = EmitOperation(switchExpr.Value);
         var typeFqn = switchExpr.Type?.ToDisplayString(_fqnFormat) ?? "object";
 
-        // Find default arm (discard pattern) or use Expression.Default as fallback
         string? currentVar = null;
         ISwitchExpressionArmOperation? defaultArm = null;
         foreach (var arm in switchExpr.Arms)
@@ -2158,17 +2000,18 @@ internal sealed class ExpressionTreeEmitter
             AppendLine($"var {currentVar} = {Expr}.Default(typeof({typeFqn}));");
         }
 
-        // Build ternary chain in reverse (skip default arm)
+        // Fold in reverse so earlier arms wrap later ones; default arm is the innermost fallback.
         var arms = switchExpr.Arms;
         for (var i = arms.Length - 1; i >= 0; i--)
         {
             var arm = arms[i];
             if (arm.Pattern is IDiscardPatternOperation)
+            {
                 continue;
+            }
 
             var conditionVar = EmitPattern(arm.Pattern, governingVar, switchExpr.Value.Type);
 
-            // Combine with when-clause if present
             if (arm.Guard is not null)
             {
                 var guardVar = EmitOperation(arm.Guard);
@@ -2186,15 +2029,13 @@ internal sealed class ExpressionTreeEmitter
         return currentVar;
     }
 
-    // ── Null-conditional access ─────────────────────────────────────────────
-
     private string EmitConditionalAccess(IConditionalAccessOperation condAccess)
     {
         var receiverVar = EmitOperation(condAccess.Operation);
         var receiverType = condAccess.Operation.Type;
         var typeFqn = condAccess.Type?.ToDisplayString(_fqnFormat) ?? "object";
 
-        // For Nullable<T>, member access needs .Value
+        // Member access on a Nullable<T> goes through .Value — unwrap before pushing onto the receiver stack.
         var accessVar = receiverVar;
         if (receiverType is { IsValueType: true } &&
             receiverType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
@@ -2204,14 +2045,13 @@ internal sealed class ExpressionTreeEmitter
             accessVar = valueVar;
         }
 
-        // Push receiver for IConditionalAccessInstanceOperation resolution
+        // The stack is read by IConditionalAccessInstanceOperation when emitting WhenNotNull.
         _conditionalAccessReceiverStack.Push((accessVar, receiverType));
 
         var whenNotNullVar = EmitOperation(condAccess.WhenNotNull);
 
-        // Always emit faithful null-check ternary: receiver != null ? whenNotNull : default(T)
-        // If the whenNotNull type differs from the overall type (e.g. int vs int?),
-        // insert Expression.Convert to match.
+        // Faithful null-check ternary: receiver != null ? whenNotNull : default(T). When whenNotNull
+        // differs from the result type (e.g. int vs int?), wrap it in a Convert to match.
         var whenNotNullType = condAccess.WhenNotNull.Type;
         var overallType = condAccess.Type;
         var needsConvert = whenNotNullType is not null && overallType is not null
@@ -2247,18 +2087,14 @@ internal sealed class ExpressionTreeEmitter
             return varName;
         }
 
-        // Should not happen if the IOperation tree is well-formed
         ReportDiagnostic(Diagnostics.UnsupportedOperation, Location.None, "ConditionalAccessInstance (empty receiver stack)");
         var resultVar = NextVar();
         AppendLine($"var {resultVar} = {Expr}.Default(typeof(object));");
         return resultVar;
     }
 
-    // ── Block bodies ─────────────────────────────────────────────────────────
-
     private string EmitBlock(IBlockOperation block)
     {
-        // Single return statement: just emit the return value directly (no Block needed)
         if (block.Operations.Length == 1 && block.Operations[0] is IReturnOperation singleReturn)
         {
             return EmitReturn(singleReturn);
@@ -2268,10 +2104,9 @@ internal sealed class ExpressionTreeEmitter
     }
 
     /// <summary>
-    /// Emits a flat sequence of statements as either a single expression (if trivially reducible)
-    /// or <c>Expression.Block(variables, statements)</c>. Handles early-return patterns by
-    /// restructuring into nested <c>Condition</c> expressions so the final value is the correct
-    /// branch value, not just the last statement.
+    /// Lowers a statement list to a single expression. Early-return shapes are restructured into
+    /// nested <c>Condition</c>s so every path yields a value (rather than appending the early
+    /// return as an unrelated statement).
     /// </summary>
     private string EmitStatementSequence(IReadOnlyList<IOperation> ops, ITypeSymbol? fallbackType)
     {
@@ -2292,7 +2127,6 @@ internal sealed class ExpressionTreeEmitter
             return empty;
         }
 
-        // If no variables, and only one statement, just return it directly.
         if (variables.Count == 0 && statements.Count == 1)
         {
             return statements[0];
@@ -2320,7 +2154,7 @@ internal sealed class ExpressionTreeEmitter
                     continue;
 
                 case IReturnOperation returnOp:
-                    // Return becomes the block's final value; subsequent ops are dead code.
+                    // Return is the block's final value; the rest of `ops` is dead code.
                     if (returnOp.ReturnedValue is not null)
                     {
                         statements.Add(EmitOperation(returnOp.ReturnedValue));
@@ -2328,7 +2162,7 @@ internal sealed class ExpressionTreeEmitter
                     return;
 
                 case IConditionalOperation cond when TryEmitEarlyReturnConditional(cond, ops, i + 1, statements):
-                    // The conditional consumed the remaining tail — stop processing.
+                    // Tail was folded into the conditional; nothing more to emit at this level.
                     return;
 
                 case IExpressionStatementOperation exprStmt:
@@ -2367,18 +2201,15 @@ internal sealed class ExpressionTreeEmitter
     }
 
     /// <summary>
-    /// Restructures an <c>if</c> statement whose branches contain early <c>return</c>s into
-    /// a nested <c>Condition</c> expression. Returning branches become the Condition's arms;
-    /// non-returning branches are merged with the tail (<paramref name="ops"/> from
-    /// <paramref name="tailStart"/>) so every path resolves to a value. Returns true when this
-    /// restructuring was performed (and thus the tail has been consumed).
+    /// Restructures `if (...) return X;` shapes into a nested <c>Condition</c>. Returning branches
+    /// become Condition arms; non-returning branches are merged with the tail so every path yields
+    /// a value. Returns true when the tail has been consumed.
     /// </summary>
     private bool TryEmitEarlyReturnConditional(IConditionalOperation cond, IReadOnlyList<IOperation> ops, int tailStart, List<string> statements)
     {
         var trueReturns = AlwaysReturns(cond.WhenTrue);
         var falseReturns = cond.WhenFalse is not null && AlwaysReturns(cond.WhenFalse);
 
-        // Only engage for early-return shapes; if/then without a return is handled by the normal path.
         if (!trueReturns && !falseReturns)
         {
             return false;
@@ -2389,7 +2220,7 @@ internal sealed class ExpressionTreeEmitter
             ?? (cond.WhenFalse is not null ? InferBranchType(cond.WhenFalse) : null);
         var typeFqn = resultType?.ToDisplayString(_fqnFormat) ?? _outerReturnTypeFqn ?? "object";
 
-        // Allocate result var first to keep snapshot numbering stable with the previous EmitConditional.
+        // Allocate result var before the test so snapshot numbering stays stable vs. EmitConditional.
         var resultVar = NextVar();
         var testVar = EmitOperation(cond.Condition);
 
@@ -2406,7 +2237,6 @@ internal sealed class ExpressionTreeEmitter
         }
         else
         {
-            // No else branch — the tail becomes the else.
             falseVar = EmitTail(ops, tailStart, resultType);
         }
 
@@ -2448,12 +2278,7 @@ internal sealed class ExpressionTreeEmitter
         return EmitStatementSequence(tail, expectedType);
     }
 
-    /// <summary>
-    /// Returns true when executing <paramref name="op"/> always transfers control via
-    /// <c>return</c> (so subsequent statements are unreachable). Used to detect early-return
-    /// shapes that must be restructured into nested <c>Condition</c> expressions rather than
-    /// appended as side-effect statements in a <c>Block</c>.
-    /// </summary>
+    /// <summary>True when every path through <paramref name="op"/> ends in a <c>return</c>.</summary>
     private static bool AlwaysReturns(IOperation? op)
     {
         if (op is null)
@@ -2485,8 +2310,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── String interpolation ────────────────────────────────────────────────
-
     private string EmitInterpolatedString(IInterpolatedStringOperation operation)
     {
         var partVars = new List<string>();
@@ -2508,8 +2331,7 @@ internal sealed class ExpressionTreeEmitter
                 {
                     if (interp.Alignment is not null)
                     {
-                        // Alignment specifiers have no expression tree equivalent.
-                        // Report diagnostic but continue emitting the interpolation without alignment.
+                        // Alignment specifiers have no expression tree equivalent — report and drop.
                         ReportDiagnostic(Diagnostics.IgnoredOperation,
                             interp.Alignment.Syntax?.GetLocation() ?? Location.None,
                             "Alignment specifier in string interpolation");
@@ -2520,7 +2342,6 @@ internal sealed class ExpressionTreeEmitter
 
                     if (interp.FormatString is not null)
                     {
-                        // Has format specifier: call ToString(format)
                         var formatValue = interp.FormatString.ConstantValue.Value?.ToString() ?? "";
                         var toStringMethod = FindToStringWithFormat(innerType);
                         if (toStringMethod is not null)
@@ -2534,7 +2355,6 @@ internal sealed class ExpressionTreeEmitter
                         }
                         else
                         {
-                            // Type doesn't have ToString(string) — format specifier is lost
                             ReportDiagnostic(Diagnostics.UnsupportedOperation,
                                 interp.FormatString.Syntax?.GetLocation() ?? Location.None,
                                 $"Format specifier '{formatValue}' on type without ToString(string)");
@@ -2543,12 +2363,10 @@ internal sealed class ExpressionTreeEmitter
                     }
                     else if (innerType is not null && innerType.SpecialType != SpecialType.System_String)
                     {
-                        // Non-string type: call ToString()
                         partVars.Add(EmitToStringCall(innerVar, innerType));
                     }
                     else
                     {
-                        // Already string-typed
                         partVars.Add(innerVar);
                     }
 
@@ -2557,7 +2375,6 @@ internal sealed class ExpressionTreeEmitter
             }
         }
 
-        // Reduce parts using optimal string.Concat overload
         if (partVars.Count == 0)
         {
             var emptyVar = NextVar();
@@ -2566,7 +2383,9 @@ internal sealed class ExpressionTreeEmitter
         }
 
         if (partVars.Count == 1)
+        {
             return partVars[0];
+        }
 
         if (partVars.Count == 2)
         {
@@ -2589,9 +2408,8 @@ internal sealed class ExpressionTreeEmitter
             return resultVar;
         }
 
-        // 5+ parts: use string.Concat(string[]) to faithfully represent the interpolation.
-        // Runtime transformers (e.g., FlattenConcatArrayCalls) rewrite this for providers
-        // like EF Core that cannot translate NewArrayInit to SQL.
+        // 5+ parts: emit string.Concat(string[]). FlattenConcatArrayCalls rewrites this for providers
+        // like EF Core that can't translate NewArrayInit to SQL.
         {
             var arrayVar = NextVar();
             AppendLine($"var {arrayVar} = {Expr}.NewArrayInit(typeof(string), {string.Join(", ", partVars)});");
@@ -2612,7 +2430,6 @@ internal sealed class ExpressionTreeEmitter
             return strVar;
         }
 
-        // Fallback: box to object and call object.ToString()
         var boxed = NextVar();
         AppendLine($"var {boxed} = {Expr}.Convert({innerVar}, typeof(object));");
         var result = NextVar();
@@ -2622,7 +2439,10 @@ internal sealed class ExpressionTreeEmitter
 
     private IMethodSymbol? FindParameterlessToString(ITypeSymbol? type)
     {
-        if (type is null) return null;
+        if (type is null)
+        {
+            return null;
+        }
         return type.GetMembers("ToString")
             .OfType<IMethodSymbol>()
             .FirstOrDefault(m => m.Parameters.Length == 0 && !m.IsStatic);
@@ -2630,7 +2450,10 @@ internal sealed class ExpressionTreeEmitter
 
     private IMethodSymbol? FindToStringWithFormat(ITypeSymbol? type)
     {
-        if (type is null) return null;
+        if (type is null)
+        {
+            return null;
+        }
         return type.GetMembers("ToString")
             .OfType<IMethodSymbol>()
             .FirstOrDefault(m => m.Parameters.Length == 1
@@ -2643,7 +2466,9 @@ internal sealed class ExpressionTreeEmitter
     private string EnsureStringConcatMethod()
     {
         if (_concatMethodField is not null)
+        {
             return _concatMethodField;
+        }
 
         var stringType = _semanticModel.Compilation.GetSpecialType(SpecialType.System_String);
         var concatMethod = stringType.GetMembers("Concat")
@@ -2757,8 +2582,6 @@ internal sealed class ExpressionTreeEmitter
         return _fieldCache.EnsureMethodInfo(methodDef.Construct(elementType));
     }
 
-    // ── Index from end (^ operator) ───────────────────────────────────────────
-
     private string EmitIndexFromEnd(IUnaryOperation unary)
     {
         var resultVar = NextVar();
@@ -2771,8 +2594,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Range (.. operator) ─────────────────────────────────────────────────
-
     private string EmitRange(IRangeOperation range)
     {
         var resultVar = NextVar();
@@ -2784,7 +2605,6 @@ internal sealed class ExpressionTreeEmitter
         }
         else
         {
-            // Implicit start: Index.Start (== new Index(0, fromEnd: false))
             startVar = NextVar();
             var zeroConst = NextVar();
             AppendLine($"var {zeroConst} = {Expr}.Constant(0);");
@@ -2802,7 +2622,6 @@ internal sealed class ExpressionTreeEmitter
         }
         else
         {
-            // Implicit end: Index.End (== new Index(0, fromEnd: true))
             endVar = NextVar();
             var zeroConst = NextVar();
             AppendLine($"var {zeroConst} = {Expr}.Constant(0);");
@@ -2819,8 +2638,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── With expressions ─────────────────────────────────────────────────────
-
     private string EmitWith(IWithOperation withOp)
     {
         var resultVar = NextVar();
@@ -2828,26 +2645,23 @@ internal sealed class ExpressionTreeEmitter
         var type = withOp.Type!;
         var typeFqn = type.ToDisplayString(_fqnFormat);
 
-        // Find the clone method (records have a <Clone>$ method)
+        // Records expose a synthesized <Clone>$ method that returns the base type (object).
         var cloneMethod = type.GetMembers("<Clone>$")
             .OfType<IMethodSymbol>()
             .FirstOrDefault();
 
         if (cloneMethod is not null)
         {
-            // Clone the original: clone = original.<Clone>$()
             var cloneField = _fieldCache.EnsureMethodInfo(cloneMethod);
             var cloneVar = NextVar();
             AppendLine($"var {cloneVar} = {Expr}.Call({operandVar}, {cloneField});");
 
-            // Cast to the target type (Clone returns object)
+            // <Clone>$ returns the base type — cast back to the record's concrete type.
             var typedClone = NextVar();
             AppendLine($"var {typedClone} = {Expr}.Convert({cloneVar}, typeof({typeFqn}));");
 
-            // Apply property modifications from the initializer
             if (withOp.Initializer is not null)
             {
-                // Store in a variable so we can modify properties
                 var tempVar = NextVar();
                 AppendLine($"var {tempVar} = {Expr}.Variable(typeof({typeFqn}), \"withTemp\");");
                 var assignTemp = NextVar();
@@ -2870,7 +2684,6 @@ internal sealed class ExpressionTreeEmitter
                     }
                 }
 
-                // Block: { var temp = clone; temp.Prop = value; temp }
                 statements.Add(tempVar);
                 AppendLine($"var {resultVar} = {Expr}.Block(new global::System.Linq.Expressions.ParameterExpression[] {{ {tempVar} }}, {string.Join(", ", statements)});");
             }
@@ -2889,8 +2702,6 @@ internal sealed class ExpressionTreeEmitter
 
         return resultVar;
     }
-
-    // ── Collection expressions ──────────────────────────────────────────────
 
     private string EmitCollectionExpression(ICollectionExpressionOperation collExpr)
     {
@@ -2912,8 +2723,6 @@ internal sealed class ExpressionTreeEmitter
             return EmitCollectionExpressionWithSpread(collExpr, resultVar);
         }
 
-        // ── No-spread path (unchanged) ──────────────────────────────────────
-
         var elementVars = new List<string>();
         foreach (var element in collExpr.Elements)
         {
@@ -2924,14 +2733,12 @@ internal sealed class ExpressionTreeEmitter
 
         if (type is IArrayTypeSymbol arrayType)
         {
-            // Array: Expression.NewArrayInit(typeof(T), elements)
             var elementTypeFqn = arrayType.ElementType.ToDisplayString(_fqnFormat);
             AppendLine($"var {resultVar} = {Expr}.NewArrayInit(typeof({elementTypeFqn}), {elementsExpr});");
         }
         else if (type is INamedTypeSymbol namedType && namedType.IsGenericType
             && namedType.OriginalDefinition.SpecialType == SpecialType.None)
         {
-            // List/Collection: Expression.ListInit(new T(), ElementInit(Add, element)...)
             var ctor = namedType.Constructors.FirstOrDefault(c => c.Parameters.Length == 0);
             if (ctor is not null)
             {
@@ -2957,7 +2764,7 @@ internal sealed class ExpressionTreeEmitter
                 }
                 else
                 {
-                    // No Add method — just return empty collection
+                    // No Add method — leave the collection empty.
                     AppendLine($"var {resultVar} = {newVar};");
                 }
             }
@@ -2978,7 +2785,6 @@ internal sealed class ExpressionTreeEmitter
     {
         var type = collExpr.Type!;
 
-        // Determine element type
         ITypeSymbol elementType;
         if (type is IArrayTypeSymbol arrayType)
         {
@@ -2995,7 +2801,6 @@ internal sealed class ExpressionTreeEmitter
 
         var elementTypeFqn = elementType.ToDisplayString(_fqnFormat);
 
-        // Resolve Enumerable.ToArray/ToList for materialization
         var materializeMethod = type is IArrayTypeSymbol ? "ToArray" : "ToList";
         var materializeField = ResolveEnumerableMethod(materializeMethod, 1, elementType);
 
@@ -3007,7 +2812,7 @@ internal sealed class ExpressionTreeEmitter
             return EmitUnsupported(collExpr);
         }
 
-        // Build segments: consecutive literals become NewArrayInit, spreads become their operand
+        // Group runs of literals into NewArrayInit segments; spread elements pass through as-is.
         var segments = new List<string>();
         var currentLiterals = new List<string>();
 
@@ -3015,7 +2820,6 @@ internal sealed class ExpressionTreeEmitter
         {
             if (element is ISpreadOperation spread)
             {
-                // Flush any accumulated literals as an array segment
                 if (currentLiterals.Count > 0)
                 {
                     var arrVar = NextVar();
@@ -3031,7 +2835,6 @@ internal sealed class ExpressionTreeEmitter
             }
         }
 
-        // Flush trailing literals
         if (currentLiterals.Count > 0)
         {
             var arrVar = NextVar();
@@ -3039,7 +2842,6 @@ internal sealed class ExpressionTreeEmitter
             segments.Add(arrVar);
         }
 
-        // Left-fold Concat (resolve Concat only when needed)
         var current = segments[0];
         if (segments.Count > 1)
         {
@@ -3060,12 +2862,9 @@ internal sealed class ExpressionTreeEmitter
             }
         }
 
-        // Materialize to target type
         AppendLine($"var {resultVar} = {Expr}.Call({materializeField}, {current});");
         return resultVar;
     }
-
-    // ── Assignments ─────────────────────────────────────────────────────────
 
     private string EmitSimpleAssignment(ISimpleAssignmentOperation assign)
     {
@@ -3091,7 +2890,7 @@ internal sealed class ExpressionTreeEmitter
             return EmitUnsupported(compoundAssign);
         }
 
-        // String += uses string.Concat, not Expression.Add
+        // String += compiles to string.Concat, not Expression.Add — same caveat as in EmitBinary.
         if (compoundAssign.OperatorKind == BinaryOperatorKind.Add
             && compoundAssign.OperatorMethod is null
             && compoundAssign.Type?.SpecialType == SpecialType.System_String)
@@ -3118,7 +2917,6 @@ internal sealed class ExpressionTreeEmitter
             };
         }
 
-        // sum += x → Expression.Assign(sum, Expression.MakeBinary(Add, sum, x))
         var binaryVar = NextVar();
         AppendLine($"var {binaryVar} = {Expr}.MakeBinary(global::System.Linq.Expressions.ExpressionType.{exprType}, {targetVar}, {valueVar});");
         AppendLine($"var {resultVar} = {Expr}.Assign({targetVar}, {binaryVar});");
@@ -3146,16 +2944,12 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Loops ───────────────────────────────────────────────────────────────
-
     private string EmitForEachLoop(IForEachLoopOperation forEach)
     {
         var resultVar = NextVar();
 
-        // Emit collection expression
         var collectionVar = EmitOperation(forEach.Collection);
 
-        // Determine element type and collection interface
         var elementType = forEach.LoopControlVariable switch
         {
             IVariableDeclaratorOperation declarator => declarator.Symbol.Type,
@@ -3168,19 +2962,17 @@ internal sealed class ExpressionTreeEmitter
 
         var elementTypeFqn = elementType?.ToDisplayString(_fqnFormat) ?? "object";
 
-        // Create iteration variable
         var iterVarName = forEach.LoopControlVariable is IVariableDeclaratorOperation decl
             ? decl.Symbol.Name : "item";
         var iterVar = NextVar();
         AppendLine($"var {iterVar} = {Expr}.Variable(typeof({elementTypeFqn}), \"{iterVarName}\");");
 
-        // Register the iteration variable so EmitLocalReference can find it
+        // Register the loop variable so its body references resolve to iterVar.
         if (forEach.LoopControlVariable is IVariableDeclaratorOperation varDecl)
         {
             _localToVar[varDecl.Symbol] = iterVar;
         }
 
-        // Create enumerator variable
         var collectionType = forEach.Collection.Type;
         var enumerableInterface = collectionType is INamedTypeSymbol nt
             ? nt.AllInterfaces.Concat(new[] { nt })
@@ -3203,7 +2995,7 @@ internal sealed class ExpressionTreeEmitter
                     .SelectMany(i => i.GetMembers("MoveNext").OfType<IMethodSymbol>())
                     .FirstOrDefault(m => m.Parameters.Length == 0);
 
-                // Prefer the generic Current (returns T) over the non-generic one (returns object)
+                // Prefer the generic Current (T) over the non-generic IEnumerator.Current (object).
                 currentProperty = enumeratorType.GetMembers("Current").OfType<IPropertySymbol>().FirstOrDefault()
                     ?? enumeratorType.AllInterfaces
                         .SelectMany(i => i.GetMembers("Current").OfType<IPropertySymbol>())
@@ -3225,7 +3017,6 @@ internal sealed class ExpressionTreeEmitter
         var currentField = _fieldCache.EnsurePropertyInfo(currentProperty);
         var enumeratorTypeFqn = getEnumeratorMethod.ReturnType.ToDisplayString(_fqnFormat);
 
-        // var enumerator = collection.GetEnumerator();
         var enumVar = NextVar();
         AppendLine($"var {enumVar} = {Expr}.Variable(typeof({enumeratorTypeFqn}), \"enumerator\");");
         var getEnumCall = NextVar();
@@ -3233,11 +3024,9 @@ internal sealed class ExpressionTreeEmitter
         var assignEnum = NextVar();
         AppendLine($"var {assignEnum} = {Expr}.Assign({enumVar}, {getEnumCall});");
 
-        // Break label
         var breakLabel = NextVar();
         AppendLine($"var {breakLabel} = {Expr}.Label(\"break\");");
 
-        // Body: assign Current to iteration variable, then execute loop body
         var getCurrent = NextVar();
         AppendLine($"var {getCurrent} = {Expr}.Property({enumVar}, {currentField});");
         var assignCurrent = NextVar();
@@ -3248,7 +3037,6 @@ internal sealed class ExpressionTreeEmitter
         var bodyBlock = NextVar();
         AppendLine($"var {bodyBlock} = {Expr}.Block({assignCurrent}, {bodyVar});");
 
-        // Loop: if (MoveNext()) { body } else { break }
         var moveNextCall = NextVar();
         AppendLine($"var {moveNextCall} = {Expr}.Call({enumVar}, {moveNextField});");
         var breakExpr = NextVar();
@@ -3258,7 +3046,6 @@ internal sealed class ExpressionTreeEmitter
         var loopExpr = NextVar();
         AppendLine($"var {loopExpr} = {Expr}.Loop({ifThenElse}, {breakLabel});");
 
-        // Wrap in block: { var enumerator = ...; var item; loop; }
         AppendLine($"var {resultVar} = {Expr}.Block(new global::System.Linq.Expressions.ParameterExpression[] {{ {enumVar}, {iterVar} }}, {assignEnum}, {loopExpr});");
         return resultVar;
     }
@@ -3267,7 +3054,6 @@ internal sealed class ExpressionTreeEmitter
     {
         var resultVar = NextVar();
 
-        // Emit initializers (Before)
         var initVars = new List<string>();
         var blockVariables = new List<string>();
         foreach (var beforeOp in forLoop.Before)
@@ -3301,26 +3087,21 @@ internal sealed class ExpressionTreeEmitter
             }
         }
 
-        // Break label
         var breakLabel = NextVar();
         AppendLine($"var {breakLabel} = {Expr}.Label(\"break\");");
 
-        // Condition
         var conditionVar = forLoop.Condition is not null
             ? EmitOperation(forLoop.Condition)
             : null;
 
-        // Body
         var bodyVar = EmitOperation(forLoop.Body);
 
-        // Increment (AtLoopBottom)
         var incrementVars = new List<string>();
         foreach (var bottomOp in forLoop.AtLoopBottom)
         {
             incrementVars.Add(EmitOperation(bottomOp));
         }
 
-        // Build loop body: if (condition) { body; increment; } else { break; }
         var loopBodyParts = new List<string> { bodyVar };
         loopBodyParts.AddRange(incrementVars);
         var loopBodyBlock = NextVar();
@@ -3344,7 +3125,6 @@ internal sealed class ExpressionTreeEmitter
         var loopExpr = NextVar();
         AppendLine($"var {loopExpr} = {Expr}.Loop({loopContent}, {breakLabel});");
 
-        // Wrap: { initializers; loop; }
         var allStatements = new List<string>();
         allStatements.AddRange(initVars);
         allStatements.Add(loopExpr);
@@ -3364,11 +3144,9 @@ internal sealed class ExpressionTreeEmitter
     {
         var resultVar = NextVar();
 
-        // Break label
         var breakLabel = NextVar();
         AppendLine($"var {breakLabel} = {Expr}.Label(\"break\");");
 
-        // Condition and body
         var conditionVar = whileLoop.Condition is not null
             ? EmitOperation(whileLoop.Condition)
             : null;
@@ -3379,14 +3157,12 @@ internal sealed class ExpressionTreeEmitter
 
         if (conditionVar is null)
         {
-            // Infinite loop (no condition) — unlikely in [Expressive] but handle gracefully
             var loopExpr = NextVar();
             AppendLine($"var {loopExpr} = {Expr}.Loop({bodyVar}, {breakLabel});");
             AppendLine($"var {resultVar} = {loopExpr};");
         }
         else if (whileLoop.ConditionIsTop)
         {
-            // while (cond) { body; } → Loop(IfThenElse(cond, body, break), label)
             var ifThenElse = NextVar();
             AppendLine($"var {ifThenElse} = {Expr}.IfThenElse({conditionVar}, {bodyVar}, {breakExpr});");
             var loopExpr = NextVar();
@@ -3395,7 +3171,7 @@ internal sealed class ExpressionTreeEmitter
         }
         else
         {
-            // do { body; } while (cond); → Loop(Block(body, IfThen(!cond, break)), label)
+            // do/while: cond is checked at the bottom, so we emit Block(body, IfThen(!cond, break)) inside the Loop.
             var negatedCond = NextVar();
             AppendLine($"var {negatedCond} = {Expr}.Not({conditionVar});");
             var ifBreak = NextVar();
@@ -3410,8 +3186,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Unsupported fallback ─────────────────────────────────────────────────
-
     private string EmitUnsupported(IOperation operation)
     {
         ReportDiagnostic(Diagnostics.UnsupportedOperation,
@@ -3419,10 +3193,9 @@ internal sealed class ExpressionTreeEmitter
             operation.Kind.ToString());
 
         var resultVar = NextVar();
-        // Prefer the operation's own type. For statements (switch, block, return, …) the
-        // IOperation type is either null or void — falling back to the enclosing lambda's
-        // declared return type avoids a Lambda<Func<T,R>>(Default(object), …) mismatch that
-        // would throw at ExpressionRegistry static-init time and poison the whole assembly.
+        // Statement-shaped ops (switch, block, return…) have null/void IOperation.Type; fall back to the
+        // outer lambda's return type to avoid a Lambda<Func<T,R>>(Default(object),…) mismatch that
+        // would throw at ExpressionRegistry static-init time and poison the assembly.
         var isUsableType = operation.Type is not null
             && operation.Type.SpecialType != SpecialType.System_Void;
         var typeFqn = isUsableType
@@ -3433,8 +3206,6 @@ internal sealed class ExpressionTreeEmitter
         return resultVar;
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
     private string NextVar() => $"{_varPrefix}expr_{_varCounter++}";
 
     private void AppendLine(string line)
@@ -3443,28 +3214,33 @@ internal sealed class ExpressionTreeEmitter
         _lineCount++;
     }
 
-    /// <summary>
-    /// Infers the effective type of a conditional branch (which may be a block with a return).
-    /// </summary>
+    /// <summary>Returns the effective branch type, looking through blocks-with-return.</summary>
     private static ITypeSymbol? InferBranchType(IOperation? branch)
     {
-        if (branch is null) return null;
+        if (branch is null)
+        {
+            return null;
+        }
         if (branch.Type is not null && branch.Type.SpecialType != SpecialType.System_Void)
+        {
             return branch.Type;
+        }
 
-        // Block containing a single return statement
         if (branch is IBlockOperation block)
         {
             foreach (var op in block.Operations)
             {
                 if (op is IReturnOperation ret && ret.ReturnedValue?.Type is { } retType)
+                {
                     return retType;
+                }
             }
         }
 
-        // Direct return
         if (branch is IReturnOperation directRet && directRet.ReturnedValue?.Type is { } directType)
+        {
             return directType;
+        }
 
         return null;
     }
@@ -3481,7 +3257,9 @@ internal sealed class ExpressionTreeEmitter
     {
         var capacity = 0;
         foreach (var line in _lines)
-            capacity += line.Length + 1; // +1 for newline
+        {
+            capacity += line.Length + 1;
+        }
         var sb = new StringBuilder(capacity);
         foreach (var line in _lines)
         {
@@ -3496,9 +3274,8 @@ internal sealed class ExpressionTreeEmitter
     }
 
     /// <summary>
-    /// Unwraps syntax nodes that are transparent to the IOperation model.
-    /// These wrappers (checked, unchecked, parenthesized, null-forgiving !)
-    /// cause <c>GetOperation</c> to return null if not stripped first.
+    /// Strips syntax wrappers (checked/unchecked, parens, null-forgiving <c>!</c>) that are
+    /// transparent to IOperation — without this, <c>GetOperation</c> returns null on them.
     /// </summary>
     private static SyntaxNode UnwrapTransparentSyntax(SyntaxNode node)
     {

--- a/src/ExpressiveSharp.Generator/Emitter/ReflectionFieldCache.cs
+++ b/src/ExpressiveSharp.Generator/Emitter/ReflectionFieldCache.cs
@@ -2,14 +2,6 @@ using Microsoft.CodeAnalysis;
 
 namespace ExpressiveSharp.Generator.Emitter;
 
-/// <summary>
-/// Returns inline reflection expressions for
-/// <see cref="System.Reflection.MethodInfo"/>, <see cref="System.Reflection.PropertyInfo"/>,
-/// <see cref="System.Reflection.ConstructorInfo"/>, and <see cref="System.Reflection.FieldInfo"/>
-/// needed by the emitted expression-tree-building code.
-/// Each method returns a C# expression string that evaluates to the
-/// reflection object at runtime.
-/// </summary>
 internal sealed class ReflectionFieldCache
 {
     private static readonly SymbolDisplayFormat _fullyQualifiedFormat =
@@ -25,18 +17,12 @@ internal sealed class ReflectionFieldCache
     private string ResolveTypeFqn(ITypeSymbol type)
         => _typeAliases.TryGetValue(type, out var alias) ? alias : type.ToDisplayString(_fullyQualifiedFormat);
 
-    /// <summary>
-    /// Returns an inline reflection expression for a <see cref="System.Reflection.PropertyInfo"/>.
-    /// </summary>
     public string EnsurePropertyInfo(IPropertySymbol property)
     {
         var typeFqn = ResolveTypeFqn(property.ContainingType);
         return $"typeof({typeFqn}).GetProperty(\"{property.Name}\")";
     }
 
-    /// <summary>
-    /// Returns an inline reflection expression for a <see cref="System.Reflection.FieldInfo"/>.
-    /// </summary>
     public string EnsureFieldInfo(IFieldSymbol field)
     {
         var typeFqn = ResolveTypeFqn(field.ContainingType);
@@ -46,9 +32,6 @@ internal sealed class ReflectionFieldCache
         return $"typeof({typeFqn}).GetField(\"{field.Name}\", {flags})";
     }
 
-    /// <summary>
-    /// Returns an inline reflection expression for a <see cref="System.Reflection.MethodInfo"/>.
-    /// </summary>
     public string EnsureMethodInfo(IMethodSymbol method)
     {
         var typeFqn = ResolveTypeFqn(method.ContainingType);
@@ -96,9 +79,6 @@ internal sealed class ReflectionFieldCache
         }
     }
 
-    /// <summary>
-    /// Returns an inline reflection expression for a <see cref="System.Reflection.ConstructorInfo"/>.
-    /// </summary>
     public string EnsureConstructorInfo(IMethodSymbol constructor)
     {
         var typeFqn = ResolveTypeFqn(constructor.ContainingType);

--- a/src/ExpressiveSharp.Generator/Emitter/SynthesizedPropertyEmitter.cs
+++ b/src/ExpressiveSharp.Generator/Emitter/SynthesizedPropertyEmitter.cs
@@ -6,10 +6,9 @@ using Microsoft.CodeAnalysis.Text;
 namespace ExpressiveSharp.Generator.Emitter;
 
 /// <summary>
-/// Emits the user-visible partial-class declaration with the synthesized property when
-/// <c>[ExpressiveProperty]</c> is applied. The property caches materialized values (set by
-/// projection middleware / EF Core / HotChocolate) and otherwise delegates to the stub for
-/// the formula.
+/// Emits the partial-class declaration for <c>[ExpressiveProperty]</c>. The property caches
+/// materialized values (set by projection middleware / EF Core / HotChocolate) and otherwise
+/// delegates to the stub for the formula.
 /// </summary>
 static internal class SynthesizedPropertyEmitter
 {
@@ -19,10 +18,7 @@ static internal class SynthesizedPropertyEmitter
         context.AddSource(generatedFileName, SourceText.From(source, Encoding.UTF8));
     }
 
-    /// <summary>
-    /// Produces the synthesized partial-class C# source as a string. Pure function of the spec —
-    /// safe to call from incremental pipeline transforms (no <see cref="SourceProductionContext"/> required).
-    /// </summary>
+    // Pure function of the spec — safe to call from incremental pipeline transforms.
     public static string BuildSource(SynthesizedPropertySpec spec)
     {
         var sb = new StringBuilder();
@@ -40,7 +36,6 @@ static internal class SynthesizedPropertyEmitter
         var baseIndent = hasNamespace ? "    " : "";
         var nestingDepth = spec.ContainingTypePath.Count;
 
-        // Emit partial wrappers for any enclosing (nested) types, from outermost in.
         // Each level uses its actual type keyword so a struct/record container doesn't get
         // emitted as `partial class`.
         for (var i = 0; i < nestingDepth; i++)

--- a/src/ExpressiveSharp.Generator/ExpressiveGenerator.cs
+++ b/src/ExpressiveSharp.Generator/ExpressiveGenerator.cs
@@ -22,15 +22,11 @@ public class ExpressiveGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // Snapshot global MSBuild defaults once per generator run.
         var globalOptions = context.AnalyzerConfigOptionsProvider
             .Select(static (opts, _) => new ExpressiveGlobalOptions(opts.GlobalOptions));
 
-        // ── [Expressive] pipeline ──────────────────────────────────────────────
-
-        // Extract only pure stable data from the attribute in the transform.
-        // No live Roslyn objects (no AttributeData, SemanticModel, Compilation, ISymbol) —
-        // those are always new instances and defeat incremental caching entirely.
+        // No live Roslyn objects (AttributeData, SemanticModel, Compilation, ISymbol) in the
+        // transform — they're always new instances and defeat incremental caching entirely.
         var memberDeclarations = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 ExpressiveAttributeName,
@@ -40,7 +36,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
                     Attribute: new ExpressiveAttributeData(c.Attributes[0])
                 ));
 
-        // Flatten (Member, Attribute) + GlobalOptions into a single named tuple.
         var memberDeclarationsWithGlobalOptions = memberDeclarations
             .Combine(globalOptions)
             .Select(static (pair, _) => (
@@ -68,7 +63,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
                 Execute(member, semanticModel, memberSymbol, attribute, globalOptions, compilation, spc);
             });
 
-        // Build the expression registry: collect all entries and emit a single registry file
         var registryEntries = compilationAndMemberPairs.Select(
             static (source, cancellationToken) => {
                 var ((member, _, _), compilation) = source;
@@ -84,28 +78,21 @@ public class ExpressiveGenerator : IIncrementalGenerator
                 return ExtractRegistryEntry(memberSymbol);
             });
 
-        // ── [ExpressiveFor] / [ExpressiveForConstructor] pipelines ──────────────
-
         var expressiveForDeclarations = CreateExpressiveForPipeline(
             context, globalOptions, ExpressiveForAttributeName, ExpressiveForMemberKind.MethodOrProperty);
 
         var expressiveForConstructorDeclarations = CreateExpressiveForPipeline(
             context, globalOptions, ExpressiveForConstructorAttributeName, ExpressiveForMemberKind.Constructor);
 
-        // Collect registry entries from [ExpressiveFor] pipelines
         var expressiveForRegistryEntries = expressiveForDeclarations.Select(
             static (source, _) => ExtractRegistryEntryForExternal(source));
         var expressiveForConstructorRegistryEntries = expressiveForConstructorDeclarations.Select(
             static (source, _) => ExtractRegistryEntryForExternal(source));
 
-        // ── [ExpressiveProperty] pipeline ───────────────────────────────────────
-
         var expressivePropertyDeclarations = CreateExpressivePropertyPipeline(context);
 
         var expressivePropertyRegistryEntries = expressivePropertyDeclarations.Select(
             static (source, _) => ExtractRegistryEntryForExpressiveProperty(source));
-
-        // ── Merged registry ─────────────────────────────────────────────────────
 
         var allRegistryEntries = registryEntries.Collect()
             .Combine(expressiveForRegistryEntries.Collect())
@@ -123,18 +110,11 @@ public class ExpressiveGenerator : IIncrementalGenerator
                 return builder.ToImmutable();
             });
 
-        // Delegate registry file emission to the dedicated ExpressionRegistryEmitter,
-        // which uses a string-based CodeWriter instead of SyntaxFactory.
         context.RegisterImplementationSourceOutput(
             allRegistryEntries,
             static (spc, entries) => ExpressionRegistryEmitter.Emit(entries, spc));
     }
 
-    /// <summary>
-    /// Creates the incremental pipeline for an [ExpressiveFor*] attribute type.
-    /// Discovers, interprets, emits expression factory source, and returns the pipeline
-    /// for registry entry extraction.
-    /// </summary>
     private static IncrementalValuesProvider<((MemberDeclarationSyntax Member, ExpressiveForAttributeData Attribute, ExpressiveGlobalOptions GlobalOptions), Compilation)>
         CreateExpressiveForPipeline(
             IncrementalGeneratorInitializationContext context,
@@ -210,7 +190,7 @@ public class ExpressiveGenerator : IIncrementalGenerator
             throw new InvalidOperationException("Expected a memberName here");
         }
 
-        // Report EXP0012 when an [Expressive] method is a factory that could be a constructor.
+        // EXP0012: factory method that could be a constructor.
         if (member is MethodDeclarationSyntax factoryCandidate && SyntaxHelpers.TryGetFactoryMethodPattern(factoryCandidate, out _))
         {
             context.ReportDiagnostic(Diagnostic.Create(
@@ -234,8 +214,7 @@ public class ExpressiveGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Emits the generated source file using raw text when <see cref="Emitter.EmitResult"/> is available.
-    /// Each file declares the same <c>static partial class</c> — one per declaring type — and adds
+    /// Each file declares the same <c>static partial class</c> (one per declaring type) and adds
     /// a uniquely-named <c>{methodSuffix}_Expression()</c> method for this member.
     /// </summary>
     private static void EmitExpressionTreeSource(
@@ -254,7 +233,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
         sb.AppendLine("#nullable disable");
         sb.AppendLine();
 
-        // Usings
         foreach (var usingDirective in expressive.UsingDirectives!)
         {
             sb.AppendLine(usingDirective.NormalizeWhitespace().ToFullString());
@@ -282,7 +260,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
         var funcType = $"global::System.Func<{string.Join(", ", paramTypesList)}>";
         var returnType = $"global::System.Linq.Expressions.Expression<{funcType}>";
 
-        // Type parameters
         var typeParamList = expressive.ClassTypeParameterList?.NormalizeWhitespace().ToFullString() ?? "";
         var constraintClauses = expressive.ClassConstraintClauses is not null
             ? string.Join(" ", expressive.ClassConstraintClauses.Value.Select(c => c.NormalizeWhitespace().ToFullString()))
@@ -296,7 +273,7 @@ public class ExpressiveGenerator : IIncrementalGenerator
         sb.AppendLine($"    static partial class {generatedClassName}{typeParamList} {constraintClauses}");
         sb.AppendLine("    {");
 
-        // Source comment showing the original C# member
+        // Emit the original C# member as a comment in the generated file for readability.
         var sourceText = member.NormalizeWhitespace().ToFullString();
         foreach (var line in sourceText.Split('\n'))
         {
@@ -304,13 +281,11 @@ public class ExpressiveGenerator : IIncrementalGenerator
             sb.AppendLine($"        // {trimmed}");
         }
 
-        // {methodSuffix}_Expression() method
         sb.AppendLine($"        static {returnType} {methodSuffix}_Expression{methodTypeParamList}() {methodConstraintClauses}");
         sb.AppendLine("        {");
         sb.Append(emission.Body);
         sb.AppendLine("        }");
 
-        // Transformers (when declared via attribute)
         if (expressive.DeclaredTransformerTypeNames.Count > 0)
         {
             sb.AppendLine();
@@ -325,41 +300,35 @@ public class ExpressiveGenerator : IIncrementalGenerator
         context.AddSource(generatedFileName, SourceText.From(sb.ToString(), Encoding.UTF8));
     }
 
-    /// <summary>
-    /// Extracts a <see cref="ExpressionRegistryEntry"/> from a member declaration.
-    /// Returns null when the member does not have [Expressive], is an extension member,
-    /// or cannot be represented in the registry (e.g. a generic class member or generic method).
-    /// </summary>
     private static ExpressionRegistryEntry? ExtractRegistryEntry(ISymbol memberSymbol)
     {
         var containingType = memberSymbol.ContainingType;
 
-        // Determine whether this entry is metadata-only (excluded from runtime registry
-        // but still used for [EditorBrowsable] attribute-only partial file emission).
+        // Metadata-only entries are excluded from the runtime registry but still emit
+        // [EditorBrowsable] attribute-only partial files.
         var isMetadataOnly = false;
         string? classTypeParameters = null;
 
-        // C# 14 extension type members — metadata-only (fall back to reflection at runtime)
+        // C# 14 extension type members — fall back to reflection at runtime.
         if (containingType is { IsExtension: true })
         {
             isMetadataOnly = true;
         }
 
-        // Generic classes — metadata-only (registry can't represent open generic types)
+        // Generic classes — registry can't represent open generic types.
         if (containingType.TypeParameters.Length > 0)
         {
             isMetadataOnly = true;
             classTypeParameters = "<" + string.Join(", ", containingType.TypeParameters.Select(tp => tp.Name)) + ">";
         }
 
-        // Determine member kind and lookup name
         ExpressionRegistryMemberType memberKind;
         string memberLookupName;
         var parameterTypeNames = ImmutableArray<string>.Empty;
 
         if (memberSymbol is IMethodSymbol methodSymbol)
         {
-            // Generic methods — metadata-only (same reason as generic classes)
+            // Generic methods — same reason as generic classes.
             if (methodSymbol.TypeParameters.Length > 0)
             {
                 isMetadataOnly = true;
@@ -386,7 +355,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
             memberLookupName = memberSymbol.Name;
         }
 
-        // Build the generated class name and method name using the same logic as Execute
         var classNamespace = containingType.ContainingNamespace.IsGlobalNamespace
             ? null
             : containingType.ContainingNamespace.ToDisplayString();
@@ -416,10 +384,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
             ClassTypeParameters: classTypeParameters);
     }
 
-    /// <summary>
-    /// Processes an [ExpressiveFor] / [ExpressiveForConstructor] stub: resolves the target member,
-    /// validates the stub, and emits the expression tree factory source file.
-    /// </summary>
     private static void ExecuteFor(
         MemberDeclarationSyntax stubMember,
         SemanticModel semanticModel,
@@ -456,7 +420,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Extracts a <see cref="ExpressionRegistryEntry"/> for an [ExpressiveFor] stub.
     /// The entry points to the external target member, not the stub itself.
     /// </summary>
     private static ExpressionRegistryEntry? ExtractRegistryEntryForExternal(
@@ -529,8 +492,8 @@ public class ExpressiveGenerator : IIncrementalGenerator
                 memberKind = ExpressionRegistryMemberType.Method;
                 memberLookupName = memberName;
 
-                // Signature matching via the shared matcher so the registry entry can never
-                // disagree with what ExpressiveForInterpreter accepted.
+                // Use the shared matcher so the registry entry can never disagree with
+                // what ExpressiveForInterpreter accepted.
                 var stubParams = stubMethodSymbol!.Parameters;
                 var targetMethod = targetType.GetMembers(memberName).OfType<IMethodSymbol>()
                     .Where(m => m.MethodKind is not (MethodKind.PropertyGet or MethodKind.PropertySet))
@@ -547,7 +510,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
             }
         }
 
-        // Build generated class name using the target type's path (matching main's new API)
         var classNamespace = targetType.ContainingNamespace.IsGlobalNamespace
             ? null
             : targetType.ContainingNamespace.ToDisplayString();
@@ -563,7 +525,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
 
         var expressionMethodName = methodSuffix + "_Expression";
 
-        // Capture stub location for duplicate detection diagnostics
         var stubLocation = member switch
         {
             MethodDeclarationSyntax m => m.Identifier.GetLocation(),
@@ -594,11 +555,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
         yield return typeSymbol.Name;
     }
 
-    /// <summary>
-    /// Incremental pipeline for <c>[ExpressiveProperty]</c>. Discovers property stubs, runs the
-    /// interpreter, and emits both the expression-tree factory and the synthesized partial-class
-    /// declaration.
-    /// </summary>
     private static IncrementalValuesProvider<((PropertyDeclarationSyntax Stub, ExpressivePropertyAttributeData Attribute), Compilation)>
         CreateExpressivePropertyPipeline(IncrementalGeneratorInitializationContext context)
     {
@@ -631,10 +587,6 @@ public class ExpressiveGenerator : IIncrementalGenerator
         return compilationAndPairs;
     }
 
-    /// <summary>
-    /// Runs the <c>[ExpressiveProperty]</c> interpreter and emits both the expression-tree factory
-    /// file and the user-facing partial-class declaration with the synthesized property.
-    /// </summary>
     private static void ExecuteExpressiveProperty(
         PropertyDeclarationSyntax stub,
         IPropertySymbol stubSymbol,
@@ -671,9 +623,8 @@ public class ExpressiveGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Extracts a registry entry for an <c>[ExpressiveProperty]</c> stub. The entry is always
-    /// property-kind and keyed on the synthesized target name (which doesn't exist on the target
-    /// type yet — the synthesized partial declaration fills it in).
+    /// Keyed on the synthesized target name, which doesn't exist on the target type yet —
+    /// the synthesized partial declaration fills it in.
     /// </summary>
     private static ExpressionRegistryEntry? ExtractRegistryEntryForExpressiveProperty(
         ((PropertyDeclarationSyntax Stub, ExpressivePropertyAttributeData Attribute), Compilation) source)

--- a/src/ExpressiveSharp.Generator/Infrastructure/Diagnostics.cs
+++ b/src/ExpressiveSharp.Generator/Infrastructure/Diagnostics.cs
@@ -4,8 +4,6 @@ namespace ExpressiveSharp.Generator.Infrastructure;
 
 static internal class Diagnostics
 {
-    // ── Errors ──────────────────────────────────────────────────────────────
-
     public readonly static DiagnosticDescriptor RequiresBodyDefinition = new DiagnosticDescriptor(
         id: "EXP0001",
         title: "Method or property should expose a body definition",
@@ -45,8 +43,6 @@ static internal class Diagnostics
         category: "Design",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
-
-    // ── Warnings ────────────────────────────────────────────────────────────
 
     public readonly static DiagnosticDescriptor UnsupportedStatementInBlockBody = new DiagnosticDescriptor(
         id: "EXP0006",
@@ -96,10 +92,8 @@ static internal class Diagnostics
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
-    // NOTE: EXP0013 (MemberCouldBeExpressive) is now emitted by MissingExpressiveAnalyzer
-    // in ExpressiveSharp.CodeFixers, so VS can pair it with the code fix provider.
-
-    // ── Info ────────────────────────────────────────────────────────────────
+    // EXP0013 (MemberCouldBeExpressive) is emitted by MissingExpressiveAnalyzer
+    // in ExpressiveSharp.CodeFixers so VS can pair it with the code fix provider.
 
     public readonly static DiagnosticDescriptor FactoryMethodShouldBeConstructor = new DiagnosticDescriptor(
         id: "EXP0012",
@@ -108,8 +102,6 @@ static internal class Diagnostics
         category: "Design",
         DiagnosticSeverity.Info,
         isEnabledByDefault: true);
-
-    // ── [ExpressiveFor] Diagnostics ─────────────────────────────────────────
 
     public readonly static DiagnosticDescriptor ExpressiveForTargetTypeNotFound = new DiagnosticDescriptor(
         id: "EXP0014",
@@ -127,7 +119,7 @@ static internal class Diagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    // NOTE: EXP0016 (ExpressiveForStubMustBeStatic) is retired. Instance stubs are now permitted
+    // EXP0016 (ExpressiveForStubMustBeStatic) is retired — instance stubs are now permitted
     // on the target type itself. Constructor stubs remain static-only; signature mismatches fall
     // back to EXP0015 (ExpressiveForMemberNotFound).
 
@@ -163,11 +155,9 @@ static internal class Diagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    // NOTE: EXP0021–EXP0030 (Projectable diagnostics) were retired when the
+    // EXP0021–EXP0030 (Projectable diagnostics) were retired when the
     // [Expressive(Projectable = true)] feature was superseded by [ExpressiveProperty].
     // The codes are not reused.
-
-    // ── [ExpressiveProperty] Diagnostics ─────────────────────────────────────
 
     public readonly static DiagnosticDescriptor ExpressivePropertyTargetExists = new DiagnosticDescriptor(
         id: "EXP0031",

--- a/src/ExpressiveSharp.Generator/Infrastructure/SyntaxHelpers.cs
+++ b/src/ExpressiveSharp.Generator/Infrastructure/SyntaxHelpers.cs
@@ -6,17 +6,9 @@ namespace ExpressiveSharp.Generator.Infrastructure;
 
 static internal class SyntaxHelpers
 {
-    /// <summary>
-    /// Returns <see langword="true"/> when <paramref name="method"/> matches the
-    /// factory-method pattern:
-    /// <list type="bullet">
-    ///   <item><description>Expression body of the form <c>=> new ContainingType { … }</c>
-    ///       (object initializer only, no constructor arguments in the <c>new</c>
-    ///       expression).</description></item>
-    ///   <item><description>Static method.</description></item>
-    ///   <item><description>Return type simple name equals the containing class name.</description></item>
-    /// </list>
-    /// </summary>
+    // Matches: static method with expression body `=> new ContainingType { ... }`
+    // (object initializer only, no constructor arguments) whose return type name
+    // equals the containing type name.
     static internal bool TryGetFactoryMethodPattern(
         MethodDeclarationSyntax method,
         out TypeDeclarationSyntax? containingType)

--- a/src/ExpressiveSharp.Generator/Interpretation/ExpressiveForInterpreter.cs
+++ b/src/ExpressiveSharp.Generator/Interpretation/ExpressiveForInterpreter.cs
@@ -8,11 +8,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ExpressiveSharp.Generator.Interpretation;
 
-/// <summary>
-/// Interprets [ExpressiveFor] and [ExpressiveForConstructor] stubs:
-/// resolves the target member on the external type, validates the signature,
-/// and builds an <see cref="ExpressiveDescriptor"/> with the stub's body as the expression source.
-/// </summary>
 static internal class ExpressiveForInterpreter
 {
     public static ExpressiveDescriptor? GetDescriptor(
@@ -31,9 +26,7 @@ static internal class ExpressiveForInterpreter
             _ => stubMember.GetLocation()
         };
 
-        // Resolve target type. Two cases:
-        //  - Two-arg form: [ExpressiveFor(typeof(T), "Name")] — resolve T from metadata name.
-        //  - Single-arg form: [ExpressiveFor("Name")] — default to the stub's containing type.
+        // Two-arg form [ExpressiveFor(typeof(T), "Name")] resolves T; single-arg form defaults to the stub's containing type.
         INamedTypeSymbol? targetType;
         if (attributeData.TargetTypeMetadataName is not null)
         {
@@ -53,8 +46,6 @@ static internal class ExpressiveForInterpreter
         }
 
         // Property stubs can only target properties (no parameter list to carry method args).
-        // Only the ExpressiveFor (MethodOrProperty) pipeline reaches this branch; the constructor
-        // attribute is method-target-only at the AttributeUsage level.
         if (stubMember is PropertyDeclarationSyntax stubProperty && stubSymbol is IPropertySymbol stubPropertySymbol)
         {
             if (attributeData.MemberKind == ExpressiveForMemberKind.Constructor)
@@ -93,11 +84,9 @@ static internal class ExpressiveForInterpreter
         if (memberName is null)
             return null;
 
-        // Try to find a property first
         var property = FindTargetProperty(targetType, memberName, stubSymbol);
         if (property is not null)
         {
-            // Check for [Expressive] conflict
             if (HasExpressiveAttribute(property, compilation))
             {
                 ReportConflict(context, stubMethod, memberName, targetType);
@@ -108,11 +97,9 @@ static internal class ExpressiveForInterpreter
                 globalOptions, context, targetType, property);
         }
 
-        // Try to find a method
         var method = FindTargetMethod(targetType, memberName, stubSymbol);
         if (method is not null)
         {
-            // Check for [Expressive] conflict
             if (HasExpressiveAttribute(method, compilation))
             {
                 ReportConflict(context, stubMethod, memberName, targetType);
@@ -123,7 +110,6 @@ static internal class ExpressiveForInterpreter
                 globalOptions, context, targetType, method);
         }
 
-        // Neither found
         context.ReportDiagnostic(Diagnostic.Create(
             Diagnostics.ExpressiveForMemberNotFound,
             stubMethod.Identifier.GetLocation(),
@@ -142,7 +128,6 @@ static internal class ExpressiveForInterpreter
         Compilation compilation,
         INamedTypeSymbol targetType)
     {
-        // For constructors, all stub params map to constructor params
         var ctor = FindTargetConstructor(targetType, stubSymbol);
         if (ctor is null)
         {
@@ -154,14 +139,12 @@ static internal class ExpressiveForInterpreter
             return null;
         }
 
-        // Check for [Expressive] conflict
         if (HasExpressiveAttribute(ctor, compilation))
         {
             ReportConflict(context, stubMethod, ".ctor", targetType);
             return null;
         }
 
-        // Return type must match the target type
         var stubReturnType = stubSymbol.ReturnType;
         if (!SymbolEqualityComparer.Default.Equals(stubReturnType, targetType))
         {
@@ -255,8 +238,8 @@ static internal class ExpressiveForInterpreter
     private static IMethodSymbol? FindTargetConstructor(
         INamedTypeSymbol targetType, IMethodSymbol stubSymbol)
     {
-        // Constructor stubs remain static-only: an instance stub producing a new instance of its
-        // own containing type has no natural `this` semantics and would produce incoherent code.
+        // Constructor stubs are static-only: an instance stub producing a new instance of its own
+        // containing type has no natural `this` semantics.
         if (!stubSymbol.IsStatic)
             return null;
 
@@ -294,7 +277,6 @@ static internal class ExpressiveForInterpreter
         INamedTypeSymbol targetType,
         IPropertySymbol targetProperty)
     {
-        // Validate return type
         if (!SymbolEqualityComparer.Default.Equals(stubSymbol.ReturnType, targetProperty.Type))
         {
             context.ReportDiagnostic(Diagnostic.Create(
@@ -306,7 +288,6 @@ static internal class ExpressiveForInterpreter
             return null;
         }
 
-        // For properties, the registry uses the getter's parameters (none for regular properties)
         var targetParams = System.Collections.Immutable.ImmutableArray<IParameterSymbol>.Empty;
 
         return BuildDescriptorFromStub(semanticModel, stubMethod, stubSymbol, attributeData,
@@ -324,7 +305,6 @@ static internal class ExpressiveForInterpreter
         INamedTypeSymbol targetType,
         IMethodSymbol targetMethod)
     {
-        // Validate return type
         if (!SymbolEqualityComparer.Default.Equals(stubSymbol.ReturnType, targetMethod.ReturnType))
         {
             context.ReportDiagnostic(Diagnostic.Create(
@@ -341,10 +321,6 @@ static internal class ExpressiveForInterpreter
             targetMethod.Parameters, isInstanceMember: !targetMethod.IsStatic);
     }
 
-    /// <summary>
-    /// Builds the <see cref="ExpressiveDescriptor"/> from a method stub's body,
-    /// using the target type's namespace/class path for generated class naming.
-    /// </summary>
     private static ExpressiveDescriptor? BuildDescriptorFromStub(
         SemanticModel semanticModel,
         MethodDeclarationSyntax stubMethod,
@@ -360,7 +336,6 @@ static internal class ExpressiveForInterpreter
         var rewriter = new DeclarationSyntaxRewriter(semanticModel);
         var allowBlockBody = attributeData.AllowBlockBody ?? globalOptions.AllowBlockBody;
 
-        // Extract body from the stub method.
         SyntaxNode bodySyntax;
         if (stubMethod.ExpressionBody is not null)
         {
@@ -389,7 +364,6 @@ static internal class ExpressiveForInterpreter
 
         var returnTypeName = rewriter.Visit(stubMethod.ReturnType).ToString();
 
-        // Explicit stub params (after syntax rewriting for default values / modifiers).
         var rewrittenParamList = (ParameterListSyntax)rewriter.Visit(stubMethod.ParameterList);
         var explicitSyntax = rewrittenParamList.Parameters.ToList();
         var explicitEmitterParams = stubSymbol.Parameters
@@ -405,9 +379,7 @@ static internal class ExpressiveForInterpreter
     }
 
     /// <summary>
-    /// Builds the <see cref="ExpressiveDescriptor"/> from a property stub's body.
-    /// Property stubs are always parameterless; an instance stub's <c>this</c> becomes a synthetic
-    /// receiver on the generated factory method.
+    /// Property stubs are parameterless; an instance stub's <c>this</c> becomes a synthetic receiver on the generated factory.
     /// </summary>
     private static ExpressiveDescriptor? BuildDescriptorFromPropertyStub(
         SemanticModel semanticModel,
@@ -422,7 +394,6 @@ static internal class ExpressiveForInterpreter
         var rewriter = new DeclarationSyntaxRewriter(semanticModel);
         var allowBlockBody = attributeData.AllowBlockBody ?? globalOptions.AllowBlockBody;
 
-        // Extract body: prefer the expression-bodied form, otherwise fall back to the get accessor.
         SyntaxNode? bodySyntax = null;
         if (stubProperty.ExpressionBody is not null)
         {
@@ -473,11 +444,6 @@ static internal class ExpressiveForInterpreter
             returnTypeName, bodySyntax);
     }
 
-    /// <summary>
-    /// Shared scaffolding for both method-stub and property-stub descriptor construction.
-    /// Builds the descriptor shell, synthesizes <c>@this</c> for instance stubs, appends the
-    /// caller-supplied explicit stub parameters, assembles the delegate type, and emits the body.
-    /// </summary>
     private static ExpressiveDescriptor BuildDescriptorCore(
         SemanticModel semanticModel,
         SourceProductionContext context,
@@ -512,8 +478,7 @@ static internal class ExpressiveForInterpreter
         foreach (var typeName in attributeData.TransformerTypeNames)
             descriptor.DeclaredTransformerTypeNames.Add(typeName);
 
-        // Target member's parameter types disambiguate method overloads in the registry;
-        // properties and parameterless targets keep ParameterTypeNames null.
+        // Parameter types disambiguate method overloads in the registry; properties and parameterless targets keep ParameterTypeNames null.
         if (!targetParameters.IsEmpty)
         {
             descriptor.ParameterTypeNames = targetParameters
@@ -523,7 +488,7 @@ static internal class ExpressiveForInterpreter
 
         var emitterParams = new List<EmitterParameter>();
 
-        // For instance stubs, prepend `@this` so IInstanceReferenceOperation in the body binds to it.
+        // Prepend `@this` so IInstanceReferenceOperation in the body binds to it.
         if (!stubSymbol.IsStatic)
         {
             var thisTypeFqn = stubSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);

--- a/src/ExpressiveSharp.Generator/Interpretation/ExpressiveForSignatureMatcher.cs
+++ b/src/ExpressiveSharp.Generator/Interpretation/ExpressiveForSignatureMatcher.cs
@@ -3,24 +3,16 @@ using Microsoft.CodeAnalysis;
 
 namespace ExpressiveSharp.Generator.Interpretation;
 
-/// <summary>
-/// Shared signature-matching rules for <c>[ExpressiveFor]</c> stubs.
-/// Kept central so the interpreter (which validates + emits) and the registry extractor
-/// (which builds the runtime lookup entry) can never disagree about which target member
-/// a stub maps to — a divergence here produces either silently-missing bodies or
-/// orphaned registry entries.
-/// </summary>
+// Kept central so the interpreter (validates + emits) and the registry extractor (builds
+// the runtime lookup entry) can never disagree about which target member a stub maps to —
+// divergence produces silently-missing bodies or orphaned registry entries.
 static internal class ExpressiveForSignatureMatcher
 {
-    /// <summary>
-    /// Four-quadrant matrix for method-target ↔ method-stub matching:
-    /// <list type="bullet">
-    ///   <item>static target + static stub: stub params = target params</item>
-    ///   <item>instance target + static stub: stub params = [receiver] + target params (receiver type = targetType)</item>
-    ///   <item>instance target + instance stub on targetType: stub params = target params (<c>this</c> is receiver)</item>
-    ///   <item>static target + instance stub: never matches (no way to receive a non-null instance)</item>
-    /// </list>
-    /// </summary>
+    // Four-quadrant matrix for method-target ↔ method-stub matching:
+    //   static target + static stub: stub params = target params
+    //   instance target + static stub: stub params = [receiver] + target params (receiver = targetType)
+    //   instance target + instance stub on targetType: stub params = target params (`this` is receiver)
+    //   static target + instance stub: never matches (no way to receive a non-null instance)
     public static bool MatchesMethodSignature(
         IMethodSymbol target,
         INamedTypeSymbol targetType,
@@ -41,7 +33,6 @@ static internal class ExpressiveForSignatureMatcher
         }
         else
         {
-            // Either both static, or both instance (receiver implicit via `this`).
             expectedStubParamCount = target.Parameters.Length;
             offset = 0;
         }
@@ -67,16 +58,12 @@ static internal class ExpressiveForSignatureMatcher
         return true;
     }
 
-    /// <summary>
-    /// Matching rules for property-target ↔ method-stub (the parameter-count encoding is the
-    /// same matrix but restricted to zero target parameters):
-    /// <list type="bullet">
-    ///   <item>static property + static stub (0 params): match.</item>
-    ///   <item>instance property + static stub (1 param of targetType): match.</item>
-    ///   <item>instance property + instance stub on targetType (0 params): match (<c>this</c> is receiver).</item>
-    ///   <item>static property + instance stub: never matches.</item>
-    /// </list>
-    /// </summary>
+    // Property-target ↔ method-stub matching (same matrix as MatchesMethodSignature, but
+    // target has zero parameters):
+    //   static property + static stub (0 params): match.
+    //   instance property + static stub (1 param of targetType): match.
+    //   instance property + instance stub on targetType (0 params): match (`this` is receiver).
+    //   static property + instance stub: never matches.
     public static bool MatchesPropertyFromMethodStub(
         IPropertySymbol target,
         INamedTypeSymbol targetType,
@@ -102,9 +89,7 @@ static internal class ExpressiveForSignatureMatcher
                SymbolEqualityComparer.Default.Equals(stubContainingType, targetType);
     }
 
-    /// <summary>
-    /// Matching rules for property-target ↔ property-stub (parameterless stub, <c>this</c> as receiver).
-    /// </summary>
+    // Property-target ↔ property-stub: parameterless stub, `this` as receiver.
     public static bool MatchesPropertyFromPropertyStub(
         IPropertySymbol target,
         INamedTypeSymbol targetType,

--- a/src/ExpressiveSharp.Generator/Interpretation/ExpressiveInterpreter.BodyProcessors.cs
+++ b/src/ExpressiveSharp.Generator/Interpretation/ExpressiveInterpreter.BodyProcessors.cs
@@ -11,10 +11,6 @@ namespace ExpressiveSharp.Generator.Interpretation;
 
 static internal partial class ExpressiveInterpreter
 {
-    /// <summary>
-    /// Fills <paramref name="descriptor"/> from a method declaration body.
-    /// Returns <c>false</c> and reports diagnostics on failure.
-    /// </summary>
     private static bool TryApplyMethodBody(
         MethodDeclarationSyntax methodDeclarationSyntax,
         ISymbol memberSymbol,
@@ -65,10 +61,6 @@ static internal partial class ExpressiveInterpreter
         return true;
     }
 
-    /// <summary>
-    /// Fills <paramref name="descriptor"/> from a property declaration body.
-    /// Returns <c>false</c> and reports diagnostics on failure.
-    /// </summary>
     private static bool TryApplyPropertyBody(
         PropertyDeclarationSyntax propertyDeclarationSyntax,
         ISymbol memberSymbol,
@@ -129,10 +121,7 @@ static internal partial class ExpressiveInterpreter
         return true;
     }
 
-    /// <summary>
-    /// Fills <paramref name="descriptor"/> from a constructor declaration body.
-    /// Constructors produce <c>Expression.MemberInit</c> (object initializer) for EF Core projections.
-    /// </summary>
+    // Constructors produce Expression.MemberInit (object initializer) for EF Core projections.
     private static bool TryApplyConstructorBody(
         ConstructorDeclarationSyntax constructorDeclarationSyntax,
         ISymbol memberSymbol,
@@ -172,7 +161,7 @@ static internal partial class ExpressiveInterpreter
             }
         }
 
-        // Verify parameterless constructor exists — skip when chaining to a parameterized ctor.
+        // Skip the parameterless-ctor check when chaining to a parameterized ctor.
         if (chainedTargetCtor is null)
         {
             var hasAccessibleParameterlessConstructor = containingType.Constructors
@@ -210,10 +199,9 @@ static internal partial class ExpressiveInterpreter
                 memberSymbol.Name));
         }
 
-        // Pass the constructor body to the emitter — it will emit the block as-is.
         // The constructor body contains property assignments (this.Prop = expr) which
-        // the IOperation tree represents as ISimpleAssignmentOperation nodes.
-        // We use EmitConstructorBody which wraps the result in Expression.MemberInit.
+        // the IOperation tree represents as ISimpleAssignmentOperation nodes; the emitter
+        // wraps the result in Expression.MemberInit.
         var bodySyntax = (SyntaxNode?)constructorDeclarationSyntax.Body
             ?? constructorDeclarationSyntax.ExpressionBody?.Expression;
 
@@ -230,7 +218,7 @@ static internal partial class ExpressiveInterpreter
 
         var emitter = new ExpressionTreeEmitter(semanticModel, context);
 
-        // Build emitter parameters (constructor params, no @this)
+        // Constructor params, no @this.
         var emitterParams = new List<EmitterParameter>();
         foreach (var param in methodSymbol.Parameters)
         {
@@ -251,9 +239,6 @@ static internal partial class ExpressiveInterpreter
         return true;
     }
 
-    /// <summary>
-    /// Shared helper: emits expression tree building code for a method body.
-    /// </summary>
     private static EmitResult EmitExpressionTree(
         SyntaxNode bodyExpression,
         SemanticModel semanticModel,
@@ -272,10 +257,7 @@ static internal partial class ExpressiveInterpreter
             descriptor.ReturnTypeName!, delegateTypeFqn);
     }
 
-    /// <summary>
-    /// Shared helper: emits expression tree building code for a property body.
-    /// Properties always have a single @this parameter.
-    /// </summary>
+    // Properties always have a single @this parameter.
     private static EmitResult EmitExpressionTreeForProperty(
         SyntaxNode bodyExpression,
         SemanticModel semanticModel,
@@ -286,7 +268,6 @@ static internal partial class ExpressiveInterpreter
         var emitter = new ExpressionTreeEmitter(semanticModel, context);
         var emitterParams = new List<EmitterParameter>();
 
-        // Properties always have the implicit @this parameter
         if (descriptor.ParametersList?.Parameters.Count > 0)
         {
             var thisParam = descriptor.ParametersList.Parameters[0];
@@ -302,18 +283,13 @@ static internal partial class ExpressiveInterpreter
             descriptor.ReturnTypeName!, delegateTypeFqn);
     }
 
-    /// <summary>
-    /// Builds the list of <see cref="EmitterParameter"/> for the emitter,
-    /// including the implicit @this parameter when applicable.
-    /// </summary>
     private static List<EmitterParameter> BuildEmitterParameters(
         ExpressiveDescriptor descriptor,
         IMethodSymbol methodSymbol)
     {
         var result = new List<EmitterParameter>();
 
-        // Check if the descriptor has more parameters than the method
-        // (the extra one is the implicit @this)
+        // An extra parameter on the descriptor (vs. the method symbol) is the implicit @this.
         var hasThisParam = descriptor.ParametersList?.Parameters.Count > methodSymbol.Parameters.Length;
         if (hasThisParam && descriptor.ParametersList is not null)
         {
@@ -333,11 +309,8 @@ static internal partial class ExpressiveInterpreter
         return result;
     }
 
-    /// <summary>
-    /// Walks a block body's IOperation tree and reports diagnostics for constructs
-    /// that cannot be translated to expression trees. Called at interpretation time
-    /// (before emission) so users get early compile-time feedback.
-    /// </summary>
+    // Reports diagnostics at interpretation time (before emission) so users get early
+    // compile-time feedback for constructs that cannot be translated to expression trees.
     private static void ValidateBlockBody(
         SemanticModel semanticModel,
         SyntaxNode bodySyntax,
@@ -428,19 +401,14 @@ static internal partial class ExpressiveInterpreter
                 return;
         }
 
-        // Recurse into child operations
         foreach (var child in operation.ChildOperations)
         {
             WalkOperations(child, memberName, context);
         }
     }
 
-    /// <summary>
-    /// Returns true when the deconstruction has the shape
-    /// <c>(member, member, ...) = (value, value, ...)</c> — two tuple literals of equal arity
-    /// with the left side referencing only properties or fields of <c>this</c>. Only this shape
-    /// is supported by the constructor-body emitter.
-    /// </summary>
+    // Accepts only `(member, member, ...) = (value, value, ...)` where the left side
+    // references properties or fields of `this` — the shape the ctor-body emitter handles.
     private static bool IsSimpleTupleLiteralDeconstruction(IDeconstructionAssignmentOperation decon)
     {
         var target = UnwrapConversions(decon.Target);

--- a/src/ExpressiveSharp.Generator/Interpretation/ExpressiveInterpreter.Helpers.cs
+++ b/src/ExpressiveSharp.Generator/Interpretation/ExpressiveInterpreter.Helpers.cs
@@ -9,10 +9,6 @@ namespace ExpressiveSharp.Generator.Interpretation;
 
 static internal partial class ExpressiveInterpreter
 {
-    /// <summary>
-    /// Visits <paramref name="parameterList"/> through <paramref name="rewriter"/> and appends
-    /// all resulting parameters to <see cref="ExpressiveDescriptor.ParametersList"/>.
-    /// </summary>
     private static void ApplyParameterList(
         ParameterListSyntax parameterList,
         DeclarationSyntaxRewriter rewriter,
@@ -24,10 +20,6 @@ static internal partial class ExpressiveInterpreter
         }
     }
 
-    /// <summary>
-    /// Visits the type-parameter list and constraint clauses of <paramref name="methodDecl"/>
-    /// through <paramref name="rewriter"/> and stores them on <paramref name="descriptor"/>.
-    /// </summary>
     private static void ApplyTypeParameters(
         MethodDeclarationSyntax methodDecl,
         DeclarationSyntaxRewriter rewriter,
@@ -50,12 +42,8 @@ static internal partial class ExpressiveInterpreter
         }
     }
 
-    /// <summary>
-    /// Returns the readable getter expression from a property declaration, trying in order:
-    /// the property-level expression-body, the getter's expression-body, then the first
-    /// <see langword="return"/> expression in a block-bodied getter.
-    /// Returns <c>null</c> when none of these are present.
-    /// </summary>
+    // Tries in order: property-level expression body, getter's expression body, then the
+    // first `return` in a block-bodied getter.
     private static ExpressionSyntax? TryGetPropertyGetterExpression(PropertyDeclarationSyntax prop)
     {
         if (prop.ExpressionBody?.Expression is { } exprBody)
@@ -82,10 +70,6 @@ static internal partial class ExpressiveInterpreter
         return null;
     }
 
-    /// <summary>
-    /// Reports <see cref="Diagnostics.RequiresBodyDefinition"/> for <paramref name="node"/>
-    /// and returns <c>false</c> so callers can write <c>return ReportRequiresBodyAndFail(…)</c>.
-    /// </summary>
     private static bool ReportRequiresBodyAndFail(
         SourceProductionContext context,
         SyntaxNode node,

--- a/src/ExpressiveSharp.Generator/Interpretation/ExpressiveInterpreter.cs
+++ b/src/ExpressiveSharp.Generator/Interpretation/ExpressiveInterpreter.cs
@@ -18,7 +18,6 @@ static internal partial class ExpressiveInterpreter
         SourceProductionContext context,
         Compilation? compilation = null)
     {
-        // Detect C# 14 extension member context
         var isExtensionMember = memberSymbol.ContainingType is { IsExtension: true };
         IParameterSymbol? extensionParameter = null;
         ITypeSymbol? extensionReceiverType = null;
@@ -31,20 +30,17 @@ static internal partial class ExpressiveInterpreter
 
         var declarationSyntaxRewriter = new DeclarationSyntaxRewriter(semanticModel);
 
-        // Build base descriptor (class names, namespaces, @this parameter, target class)
         var methodSymbol = memberSymbol as IMethodSymbol;
         var descriptor = BuildBaseDescriptor(
             member, memberSymbol, methodSymbol,
             isExtensionMember, extensionParameter, extensionReceiverType);
 
-        // Populate declared transformers from attribute
         foreach (var typeName in expressiveAttribute.TransformerTypeNames)
             descriptor.DeclaredTransformerTypeNames.Add(typeName);
 
-        // Resolve AllowBlockBody: attribute value takes precedence, then MSBuild default
+        // Attribute value takes precedence over the MSBuild default.
         var allowBlockBody = expressiveAttribute.AllowBlockBody ?? globalOptions.AllowBlockBody;
 
-        // Fill descriptor from the body
         var success = member switch
         {
             MethodDeclarationSyntax methodDecl =>
@@ -65,12 +61,7 @@ static internal partial class ExpressiveInterpreter
         return success ? descriptor : null;
     }
 
-    /// <summary>
-    /// Builds a <see cref="ExpressiveDescriptor"/> with all fields populated except
-    /// <see cref="ExpressiveDescriptor.ReturnTypeName"/> and
-    /// <see cref="ExpressiveDescriptor.ExpressionTreeEmission"/>
-    /// (those are filled by the body processors).
-    /// </summary>
+    // ReturnTypeName and ExpressionTreeEmission are filled in by the body processors.
     private static ExpressiveDescriptor BuildBaseDescriptor(
         MemberDeclarationSyntax member,
         ISymbol memberSymbol,
@@ -79,12 +70,12 @@ static internal partial class ExpressiveInterpreter
         IParameterSymbol? extensionParameter,
         ITypeSymbol? extensionReceiverType)
     {
-        // For extension members, use the outer class for naming
+        // Extension members use the outer class for naming.
         var classForNaming = isExtensionMember && memberSymbol.ContainingType.ContainingType is not null
             ? memberSymbol.ContainingType.ContainingType
             : memberSymbol.ContainingType;
 
-        // Sanitize constructor name (.ctor / .cctor are not valid C# identifiers, use _ctor)
+        // .ctor / .cctor are not valid C# identifiers; substitute _ctor.
         var memberName = methodSymbol?.MethodKind is MethodKind.Constructor or MethodKind.StaticConstructor
             ? "_ctor"
             : memberSymbol.Name;
@@ -103,15 +94,14 @@ static internal partial class ExpressiveInterpreter
             ParametersList = SyntaxFactory.ParameterList()
         };
 
-        // Collect parameter type names for method overload disambiguation
         if (methodSymbol is not null)
         {
             var parameterTypeNames = methodSymbol.Parameters
                 .Select(p => p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
                 .ToList();
 
-            // For extension members, prepend the extension receiver type to match how the
-            // runtime sees the method (receiver is the first implicit parameter).
+            // Prepend the extension receiver type to match how the runtime sees the method
+            // (receiver is the first implicit parameter).
             if (isExtensionMember && extensionReceiverType is not null)
             {
                 parameterTypeNames.Insert(0,
@@ -121,13 +111,11 @@ static internal partial class ExpressiveInterpreter
             descriptor.ParameterTypeNames = parameterTypeNames;
         }
 
-        // Set up generic type parameters and constraints for the containing class
         if (classForNaming is { IsGenericType: true })
         {
             SetupGenericTypeParameters(descriptor, classForNaming);
         }
 
-        // Add the implicit @this parameter
         if (isExtensionMember && extensionReceiverType is not null)
         {
             descriptor.ParametersList = descriptor.ParametersList.AddParameters(
@@ -143,7 +131,7 @@ static internal partial class ExpressiveInterpreter
                         memberSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))));
         }
 
-        // Resolve target class info (used by the registry to associate the projection)
+        // Target class info is used by the registry to associate the projection.
         if (isExtensionMember && extensionReceiverType is not null)
         {
             descriptor.TargetClassNamespace = extensionReceiverType.ContainingNamespace.IsGlobalNamespace

--- a/src/ExpressiveSharp.Generator/Interpretation/ExpressivePropertyInterpreter.cs
+++ b/src/ExpressiveSharp.Generator/Interpretation/ExpressivePropertyInterpreter.cs
@@ -8,19 +8,10 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ExpressiveSharp.Generator.Interpretation;
 
-/// <summary>
-/// Interprets <c>[ExpressiveProperty]</c> stubs: validates placement rules, builds an
-/// <see cref="ExpressiveDescriptor"/> keyed on the synthesized target property, and attaches a
-/// <see cref="SynthesizedPropertySpec"/> so the generator emits the partial-class declaration.
-/// </summary>
-/// <remarks>
-/// Rules (v1):
-/// <list type="number">
-///   <item>Stub must be a property with a top-level expression body (<c>=&gt; expr</c>).</item>
-///   <item>Stub must be an instance member (static stubs rejected).</item>
-///   <item>Target property name must be supplied explicitly as a string literal.</item>
-/// </list>
-/// </remarks>
+// Rules (v1):
+//   1. Stub must be a property with a top-level expression body (=> expr).
+//   2. Stub must be an instance member (static stubs rejected).
+//   3. Target property name must be supplied explicitly as a string literal.
 static internal class ExpressivePropertyInterpreter
 {
     private static readonly SymbolDisplayFormat FullyQualifiedNullableFormat =
@@ -47,7 +38,6 @@ static internal class ExpressivePropertyInterpreter
             return null;
         }
 
-        // Rule 2: instance only.
         if (stubSymbol.IsStatic)
         {
             context.ReportDiagnostic(Diagnostic.Create(
@@ -57,8 +47,8 @@ static internal class ExpressivePropertyInterpreter
             return null;
         }
 
-        // Rule 1: expression body required (top-level `=> expr` form). Reject any accessor list —
-        // even a `{ get => expr; }` that's semantically equivalent — to keep the surface minimal.
+        // Reject any accessor list — even a `{ get => expr; }` that's semantically equivalent —
+        // to keep the supported surface minimal.
         if (stubProperty.ExpressionBody is null)
         {
             context.ReportDiagnostic(Diagnostic.Create(
@@ -68,7 +58,6 @@ static internal class ExpressivePropertyInterpreter
             return null;
         }
 
-        // Containing type must be partial (class / struct / record / record struct).
         if (!IsPartialType(containingType))
         {
             context.ReportDiagnostic(Diagnostic.Create(
@@ -78,7 +67,6 @@ static internal class ExpressivePropertyInterpreter
             return null;
         }
 
-        // Target name must not collide with an existing declared or inherited member on the type.
         // Declared members first (EXP0031) because that's the more common mistake and deserves the
         // dedicated "use [ExpressiveFor] instead" steering.
         if (containingType.GetMembers(targetName!).Any(m =>
@@ -103,13 +91,11 @@ static internal class ExpressivePropertyInterpreter
             return null;
         }
 
-        // Build the descriptor from the stub's expression body.
         var descriptor = BuildDescriptor(
             semanticModel, context, stubProperty, stubSymbol,
             attributeData, containingType, targetName!);
         if (descriptor is null) return null;
 
-        // Synthesis spec for the partial-class emitter.
         var returnType = stubSymbol.Type;
         var useTernary = IsNullablePropertyType(returnType);
         var propertyTypeFqn = returnType.ToDisplayString(FullyQualifiedNullableFormat);
@@ -139,13 +125,9 @@ static internal class ExpressivePropertyInterpreter
         return (descriptor, spec);
     }
 
-    /// <summary>
-    /// Builds the <see cref="SynthesizedPropertySpec"/> for a stub if it passes the same validation
-    /// rules as <see cref="GetDescriptor"/>, but reports no diagnostics. Used by
-    /// <c>PolyfillInterceptorGenerator</c> to compute the synthesized partial-class source for
-    /// in-memory compilation augmentation; diagnostic ownership stays with <see cref="GetDescriptor"/>
-    /// inside <c>ExpressiveGenerator</c>.
-    /// </summary>
+    // Same validation rules as GetDescriptor but reports no diagnostics — used by
+    // PolyfillInterceptorGenerator for in-memory compilation augmentation. Diagnostic
+    // ownership stays with GetDescriptor inside ExpressiveGenerator.
     public static SynthesizedPropertySpec? TryBuildSpec(
         PropertyDeclarationSyntax stubProperty,
         IPropertySymbol stubSymbol,
@@ -200,7 +182,6 @@ static internal class ExpressivePropertyInterpreter
         INamedTypeSymbol containingType,
         string targetName)
     {
-        // Rule 1 guaranteed us an expression body.
         var bodySyntax = stubProperty.ExpressionBody!.Expression;
 
         var rewriter = new DeclarationSyntaxRewriter(semanticModel);
@@ -244,8 +225,6 @@ static internal class ExpressivePropertyInterpreter
 
         return descriptor;
     }
-
-    // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static bool IsNullablePropertyType(ITypeSymbol type)
     {
@@ -348,8 +327,6 @@ static internal class ExpressivePropertyInterpreter
 
     private static INamedTypeSymbol? FindInheritedMember(INamedTypeSymbol type, string memberName)
     {
-        // Walk the base chain — System.Object itself is not interesting for user-defined collisions
-        // but we include it for completeness (e.g. `ToString` as a target name).
         var current = type.BaseType;
         while (current is not null)
         {

--- a/src/ExpressiveSharp.Generator/Models/ExpressiveAttributeData.cs
+++ b/src/ExpressiveSharp.Generator/Models/ExpressiveAttributeData.cs
@@ -2,14 +2,10 @@ using Microsoft.CodeAnalysis;
 
 namespace ExpressiveSharp.Generator.Models;
 
-/// <summary>
-/// Plain-data snapshot of the [Expressive] attribute arguments.
-/// </summary>
 readonly internal record struct ExpressiveAttributeData
 {
     public bool? AllowBlockBody { get; }
 
-    // Custom transformer type names (fully qualified)
     public IReadOnlyList<string> TransformerTypeNames { get; }
 
     public ExpressiveAttributeData(AttributeData attribute)

--- a/src/ExpressiveSharp.Generator/Models/ExpressiveDescriptor.cs
+++ b/src/ExpressiveSharp.Generator/Models/ExpressiveDescriptor.cs
@@ -34,21 +34,11 @@ internal class ExpressiveDescriptor
 
     public SyntaxList<TypeParameterConstraintClauseSyntax>? ConstraintClauses { get; set; }
 
-    /// <summary>
-    /// Contains the imperative <c>Expression.*</c> factory code
-    /// that builds the expression tree.
-    /// </summary>
     public EmitResult? ExpressionTreeEmission { get; set; }
 
-    /// <summary>
-    /// Fully qualified type names of transformers to apply at runtime,
-    /// declared via the [Expressive] attribute's built-in flags and Transformers property.
-    /// </summary>
+    // Fully qualified, declared via the [Expressive] attribute's Transformers property.
     public List<string> DeclaredTransformerTypeNames { get; } = new();
 
-    /// <summary>
-    /// When <c>[ExpressiveProperty]</c> is applied, this carries the instructions for
-    /// emitting the synthesized property on the stub's containing type.
-    /// </summary>
+    // Set by [ExpressiveProperty] — carries instructions for the synthesized property.
     public SynthesizedPropertySpec? SynthesisSpec { get; set; }
 }

--- a/src/ExpressiveSharp.Generator/Models/ExpressiveForAttributeData.cs
+++ b/src/ExpressiveSharp.Generator/Models/ExpressiveForAttributeData.cs
@@ -2,30 +2,18 @@ using Microsoft.CodeAnalysis;
 
 namespace ExpressiveSharp.Generator.Models;
 
-/// <summary>
-/// Plain-data snapshot of an [ExpressiveFor] or [ExpressiveForConstructor] attribute's arguments.
-/// Immutable record struct — safe for incremental generator caching.
-/// </summary>
+// Plain-data snapshot of an [ExpressiveFor] or [ExpressiveForConstructor] attribute's
+// arguments. Immutable record struct — safe for incremental generator caching.
 readonly internal record struct ExpressiveForAttributeData
 {
-    /// <summary>
-    /// Fully qualified name of the target type (using <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/>).
-    /// </summary>
     public string TargetTypeFullName { get; }
 
-    /// <summary>
-    /// Metadata name of the target type (for <see cref="Compilation.GetTypeByMetadataName"/>).
-    /// </summary>
+    // For Compilation.GetTypeByMetadataName.
     public string? TargetTypeMetadataName { get; }
 
-    /// <summary>
-    /// The target member name. Null for constructors.
-    /// </summary>
+    // Null for constructors.
     public string? MemberName { get; }
 
-    /// <summary>
-    /// The kind of target member this mapping represents.
-    /// </summary>
     public ExpressiveForMemberKind MemberKind { get; }
 
     public bool? AllowBlockBody { get; }
@@ -38,9 +26,7 @@ readonly internal record struct ExpressiveForAttributeData
         bool? allowBlockBody = null;
         var transformerTypeNames = new List<string>();
 
-        // Extract target type from first constructor argument.
-        // ExpressiveFor has two constructors: (Type, string) and (string).
-        // ExpressiveForConstructor has a single (Type) constructor.
+        // ExpressiveFor has two ctors: (Type, string) and (string). ExpressiveForConstructor has (Type).
         if (attribute.ConstructorArguments.Length > 0 &&
             attribute.ConstructorArguments[0].Value is INamedTypeSymbol targetTypeSymbol)
         {
@@ -55,21 +41,20 @@ readonly internal record struct ExpressiveForAttributeData
 
         if (memberKind != ExpressiveForMemberKind.Constructor)
         {
+            // [ExpressiveFor(typeof(T), "Name")]
             if (attribute.ConstructorArguments.Length > 1 &&
                 attribute.ConstructorArguments[1].Value is string memberNameTwoArg)
             {
-                // Two-argument form: [ExpressiveFor(typeof(T), "Name")]
                 MemberName = memberNameTwoArg;
             }
+            // [ExpressiveFor("Name")] — target defaults to the stub's containing type.
             else if (attribute.ConstructorArguments.Length == 1 &&
                      attribute.ConstructorArguments[0].Value is string memberNameOneArg)
             {
-                // Single-argument form: [ExpressiveFor("Name")] — target defaults to stub's containing type
                 MemberName = memberNameOneArg;
             }
         }
 
-        // Extract named arguments
         foreach (var namedArgument in attribute.NamedArguments)
         {
             var key = namedArgument.Key;
@@ -101,7 +86,6 @@ readonly internal record struct ExpressiveForAttributeData
 
     private static string? GetMetadataName(INamedTypeSymbol symbol)
     {
-        // Build the metadata name by traversing containing types and namespace
         var parts = new List<string>();
         var current = symbol;
 
@@ -126,9 +110,7 @@ readonly internal record struct ExpressiveForAttributeData
 
 internal enum ExpressiveForMemberKind
 {
-    /// <summary>Method or property — determined by resolving the target member.</summary>
+    // Determined by resolving the target member.
     MethodOrProperty,
-
-    /// <summary>Constructor.</summary>
     Constructor,
 }

--- a/src/ExpressiveSharp.Generator/Models/ExpressiveGlobalOptions.cs
+++ b/src/ExpressiveSharp.Generator/Models/ExpressiveGlobalOptions.cs
@@ -2,16 +2,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace ExpressiveSharp.Generator.Models;
 
-/// <summary>
-/// Plain-data snapshot of the MSBuild global defaults for [Expressive] options.
-/// Read from <c>build_property.*</c> entries in <c>AnalyzerConfigOptions.GlobalOptions</c>.
-/// </summary>
 readonly internal record struct ExpressiveGlobalOptions
 {
-    /// <summary>
-    /// Global default for <see cref="ExpressiveAttribute.AllowBlockBody"/>.
-    /// Set via MSBuild property <c>Expressive_AllowBlockBody</c>. Defaults to <c>false</c>.
-    /// </summary>
+    // Set via MSBuild property `Expressive_AllowBlockBody`. Defaults to false.
     public bool AllowBlockBody { get; }
 
     public ExpressiveGlobalOptions(AnalyzerConfigOptions globalOptions)

--- a/src/ExpressiveSharp.Generator/Models/ExpressivePropertyAttributeData.cs
+++ b/src/ExpressiveSharp.Generator/Models/ExpressivePropertyAttributeData.cs
@@ -2,13 +2,9 @@ using Microsoft.CodeAnalysis;
 
 namespace ExpressiveSharp.Generator.Models;
 
-/// <summary>
-/// Plain-data snapshot of an <c>[ExpressiveProperty]</c> attribute's arguments.
-/// Immutable record struct — safe for incremental generator caching.
-/// </summary>
+// Immutable record struct — safe for incremental generator caching.
 readonly internal record struct ExpressivePropertyAttributeData
 {
-    /// <summary>The target property name passed to the attribute constructor.</summary>
     public string? TargetName { get; }
 
     public IReadOnlyList<string> TransformerTypeNames { get; }

--- a/src/ExpressiveSharp.Generator/Models/SynthesizedPropertySpec.cs
+++ b/src/ExpressiveSharp.Generator/Models/SynthesizedPropertySpec.cs
@@ -1,61 +1,40 @@
 namespace ExpressiveSharp.Generator.Models;
 
-/// <summary>
-/// Side-information attached to an <see cref="ExpressiveDescriptor"/> when
-/// <c>[ExpressiveProperty]</c> is applied. Instructs the generator to emit an additional
-/// partial-class file declaring the synthesized property on the containing type.
-/// </summary>
 internal sealed class SynthesizedPropertySpec
 {
-    /// <summary>Fully-qualified property type (e.g. <c>decimal</c>, <c>string?</c>, <c>global::System.Nullable&lt;decimal&gt;</c>).</summary>
     public string PropertyTypeFqn { get; set; } = "";
 
-    /// <summary>The synthesized property's name (the first argument of <c>[ExpressiveFor(nameof(X))]</c>).</summary>
     public string PropertyName { get; set; } = "";
 
-    /// <summary>Name of the stub member whose body produces the formula (called from the getter's fallback branch).</summary>
+    // Stub member whose body produces the formula (called from the getter's fallback branch).
     public string StubMemberName { get; set; } = "";
 
-    /// <summary><c>true</c> when the stub is a method (<c>AmountExpression()</c>); <c>false</c> when it is a property (<c>AmountExpression</c>).</summary>
+    // True when the stub is a method (`AmountExpression()`), false for a property (`AmountExpression`).
     public bool StubIsMethod { get; set; }
 
-    /// <summary>When <c>true</c>, emit the ternary+flag shape. When <c>false</c>, emit the coalesce shape.</summary>
+    // True → ternary+flag shape; false → coalesce shape.
     public bool UseTernaryShape { get; set; }
 
-    /// <summary>
-    /// Type to use for the backing field. For coalesce: nullable form of <see cref="PropertyTypeFqn"/>.
-    /// For ternary: same as <see cref="PropertyTypeFqn"/>.
-    /// </summary>
+    // For coalesce: nullable form of PropertyTypeFqn. For ternary: same as PropertyTypeFqn.
     public string BackingFieldTypeFqn { get; set; } = "";
 
-    /// <summary>Name of the containing class (e.g. <c>Account</c>).</summary>
     public string ContainingTypeName { get; set; } = "";
 
-    /// <summary>Containing class's namespace, or null for the global namespace.</summary>
+    // Null for the global namespace.
     public string? ContainingTypeNamespace { get; set; }
 
-    /// <summary>Containing type path from outermost to target (for nested types).</summary>
+    // Outermost to target (for nested types).
     public IReadOnlyList<string> ContainingTypePath { get; set; } = System.Array.Empty<string>();
 
-    /// <summary>
-    /// Type keyword (<c>class</c>, <c>struct</c>, <c>record</c>, <c>record struct</c>) for each entry in
-    /// <see cref="ContainingTypePath"/>. Same length and ordering as <see cref="ContainingTypePath"/>.
-    /// The last element equals <see cref="ContainingTypeKeyword"/>.
-    /// </summary>
+    // Keyword (class/struct/record/record struct) for each entry in ContainingTypePath, same
+    // length and ordering. The last element equals ContainingTypeKeyword.
     public IReadOnlyList<string> ContainingTypeKeywords { get; set; } = System.Array.Empty<string>();
 
-    /// <summary>Keyword for the innermost containing type declaration (<c>class</c>, <c>record</c>, <c>struct</c>, etc.).</summary>
     public string ContainingTypeKeyword { get; set; } = "class";
 
-    /// <summary>
-    /// Name of the backing field for the materialized value. Chosen at interpret time to avoid
-    /// collisions with user-declared members on the containing type.
-    /// </summary>
+    // Chosen at interpret time to avoid collisions with user-declared members.
     public string BackingFieldName { get; set; } = "";
 
-    /// <summary>
-    /// Name of the "has value" flag field (ternary shape only). Chosen at interpret time to
-    /// avoid collisions with user-declared members on the containing type.
-    /// </summary>
+    // Ternary shape only; chosen at interpret time to avoid collisions.
     public string HasValueFlagName { get; set; } = "";
 }

--- a/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
+++ b/src/ExpressiveSharp.Generator/PolyfillInterceptorGenerator.cs
@@ -12,16 +12,6 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace ExpressiveSharp.Generator;
 
-/// <summary>
-/// Source generator that intercepts calls to <c>IExpressiveQueryable&lt;T&gt;</c> extension methods
-/// that take <c>Func&lt;T,…&gt;</c> delegates (instead of <c>Expression&lt;Func&lt;T,…&gt;&gt;</c>).
-/// For each such call-site it emits a <c>[InterceptsLocation]</c> method that rewrites the
-/// lambda body through <see cref="ExpressionSyntaxRewriter"/> and forwards the result to the
-/// matching <c>Queryable.*</c> overload.
-///
-/// Any extension method on <c>IExpressiveQueryable&lt;T&gt;</c> that takes a <c>Func&lt;&gt;</c> is
-/// intercepted by convention — including library-provided stubs and user-defined ones.
-/// </summary>
 [Generator]
 public class PolyfillInterceptorGenerator : IIncrementalGenerator
 {
@@ -99,22 +89,16 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 }
         """;
 
-    // ── IIncrementalGenerator ────────────────────────────────────────────────
-
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // One pipeline item per SOURCE FILE (CompilationUnitSyntax = root node of each file).
-        // The syntactic scan filters out files that have no candidate invocations at all.
-        // This gives us one generated file per user source file — clean and predictable.
+        // One pipeline item per source file; drop files with no lambda-bearing invocations
+        // before semantic binding (every intercepted call site has at least one lambda arg).
         var candidateFiles = context.SyntaxProvider.CreateSyntaxProvider(
             predicate: static (node, _) => node is CompilationUnitSyntax,
             transform: static (ctx, ct) =>
             {
                 ct.ThrowIfCancellationRequested();
                 var unit = (CompilationUnitSyntax)ctx.Node;
-                // Every intercepted call site (Polyfill.Create + IExpressiveQueryable stubs)
-                // takes at least one lambda argument. Files with no lambda-bearing invocations
-                // can't contain anything we'd intercept, so drop them before semantic binding.
                 foreach (var descendant in unit.DescendantNodes())
                 {
                     if (descendant is InvocationExpressionSyntax inv &&
@@ -127,29 +111,16 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             .Where(static x => x is not null)
             .Select(static (x, _) => x!);
 
-        // Combine with the compilation so ProcessFileAndEmit can build a SemanticModel.
-        //
-        // WithComparer uses REFERENCE equality on the CompilationUnitSyntax root node:
-        //   • Roslyn syntax trees are immutable — editing a noise file creates a new
-        //     Compilation but keeps every other file's syntax tree root as the EXACT
-        //     SAME object reference across incremental runs.
-        //   • All untouched source files compare as "equal" → RegisterSourceOutput
-        //     skipped entirely → O(1) incremental cost for noise-file edits.
-        //   • Only files that were actually edited get a new root reference → re-run.
+        // Reference equality on the CompilationUnitSyntax root: Roslyn keeps unchanged files'
+        // syntax tree roots as the same object across incremental runs, so editing a noise
+        // file leaves all other (file, compilation) pairs equal and skips re-emission.
         var filesWithCompilation = candidateFiles
             .Combine(context.CompilationProvider)
             .WithComparer(CompilationUnitAndCompilationComparer.Instance);
 
-        // ── Synthesized-property sources for compilation augmentation ─────────────
-        //
-        // [ExpressiveProperty]-decorated stubs cause ExpressiveGenerator to emit a partial-class
-        // file declaring the synthesized property (e.g. Rectangle.IsSquareProp). Roslyn source
-        // generators all run against the SAME input compilation — one generator never sees
-        // another's AddSource output — so without help, the SemanticModel below cannot bind
-        // references to synthesized properties inside intercepted lambdas. We mirror the
-        // synthesis pipeline here, producing the same partial-class source strings, and use
-        // them to augment the in-memory compilation just for binding (we do NOT call AddSource
-        // — ExpressiveGenerator owns the user-visible emission).
+        // Source generators don't see each other's AddSource output, so SemanticModel can't bind
+        // references to ExpressiveGenerator's synthesized [ExpressiveProperty] partials. Mirror
+        // its synthesis here and augment our local compilation for binding only — never AddSource.
         var synthesizedDeclarations = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 ExpressivePropertyAttributeName,
@@ -184,21 +155,10 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             .Combine(synthesizedSources)
             .WithComparer(FileAndSynthesizedSourcesComparer.Instance);
 
-        // All semantic analysis, code emission, and EXP_EMIT_FAILED diagnostic reporting
-        // happen inside ProcessFileAndEmit. One output file is produced per source file,
-        // containing all interceptors for that file.
         context.RegisterSourceOutput(filesWithCompilationAndSynth,
             static (spc, pair) => ProcessFileAndEmit(pair.Left.Left, pair.Left.Right, pair.Right, spc));
     }
 
-    // ── Per-file processing and emission ────────────────────────────────────
-
-    /// <summary>
-    /// Processes all candidate call sites in one source file and emits a single
-    /// interceptor file containing all generated methods for that file.
-    /// Called from <c>RegisterSourceOutput</c>; Roslyn replays cached output when
-    /// <see cref="CompilationUnitAndCompilationComparer"/> signals the file is unchanged.
-    /// </summary>
     private static void ProcessFileAndEmit(
         CompilationUnitSyntax unit,
         Compilation compilation,
@@ -207,11 +167,8 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     {
         var ct = spc.CancellationToken;
 
-        // Augment the compilation in-memory with the synthesized partial-class declarations
-        // (one per [ExpressiveProperty] stub). The augmented Compilation is local to this
-        // emitter — it never escapes via AddSource — so there is no double-emission. Without
-        // this, the SemanticModel below cannot bind references like `Rectangle { IsSquareProp: ... }`
-        // because ExpressiveGenerator's synthesized property is invisible to this generator.
+        // Augment in-memory only so SemanticModel can bind to synthesized [ExpressiveProperty]
+        // members — the augmented Compilation never escapes via AddSource.
         var modelCompilation = compilation;
         if (synthesizedSources.Length > 0)
         {
@@ -244,15 +201,11 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             ct.ThrowIfCancellationRequested();
             try
             {
-                // Use the METHOD NAME token position for stable, unique naming.
-                // Using the invocation's span-start would collide in chained calls
-                // (e.g. query.AsExpressive().Where(…) — both start at 'query').
+                // Method-name token position (not invocation span start, which collides on chained calls).
                 var nameLineSpan = ma.Name.GetLocation().GetLineSpan();
                 var line = nameLineSpan.StartLinePosition.Line;
                 var col  = nameLineSpan.StartLinePosition.Character;
 
-                // Exclusive dispatch: ExpressionPolyfill.Create<T> takes the polyfill path,
-                // everything else takes the IExpressiveQueryable path.
                 if (model.GetSymbolInfo(inv).Symbol is not IMethodSymbol method) continue;
 
                 string? methodCode;
@@ -311,11 +264,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             SourceText.From(source, Encoding.UTF8));
     }
 
-    /// <summary>
-    /// Computes a stable output file name for a given source file.
-    /// One interceptor file is generated per source file, keyed by the full 32-bit
-    /// FNV-1a hash of the source path.
-    /// </summary>
     private static string ComputeOutputFileName(string sourcePath)
     {
         unchecked
@@ -330,11 +278,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         }
     }
 
-    /// <summary>
-    /// Returns a short (4-char hex) tag derived from the source file path hash.
-    /// Used as a prefix in interceptor method names to prevent collisions between
-    /// files that have call sites at identical line/col positions.
-    /// </summary>
+    /// <summary>4-char hex tag from source path hash; disambiguates same-line/col call sites across files.</summary>
     private static string GetFileTag(string sourcePath)
     {
         unchecked
@@ -349,14 +293,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         }
     }
 
-
-    // ── ExpressionPolyfill.Create() interception ──────────────────────────
-
-    /// <summary>
-    /// Detects calls to <c>ExpressionPolyfill.Polyfill&lt;TDelegate&gt;(lambda)</c> and emits
-    /// an interceptor that returns a literal <c>Expression&lt;TDelegate&gt;</c> with the
-    /// rewritten lambda body.
-    /// </summary>
     private static string? TryEmitPolyfill(InvocationExpressionSyntax inv,
         SemanticModel model,
         IMethodSymbol method,
@@ -365,11 +301,10 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         string fileTag,
         SourceProductionContext spc)
     {
-        // Caller guarantees method is ExpressionPolyfill.Create.
         if (method.TypeArguments.Length != 1)
             return null;
 
-        // First argument must be a lambda; optional second is params transformers
+        // First arg is the lambda; optional second is params transformers.
         if (inv.ArgumentList.Arguments.Count < 1)
             return null;
         if (inv.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lam)
@@ -381,24 +316,16 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             return null;
         var interceptAttr = interceptableLocation.GetInterceptsLocationAttributeSyntax();
 
-        // Extract the delegate type — e.g., Func<Order, bool>
         var delegateType = method.TypeArguments[0];
         var delegateFqn = delegateType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
-        // Default to Rewrite (the whole point of Polyfill is enabling expression tree features),
-        // but allow MSBuild global property to override.
-        
-        // Get the parameter types from the delegate to build Expression<TDelegate>
-        // For Func<T1, T2, ..., TResult>, the lambda parameters map to T1..Tn
         if (delegateType is not INamedTypeSymbol delegateNamed || delegateNamed.TypeArguments.IsEmpty)
             return null;
 
-        // Use the first type argument as the "element" type for the rewriter
         var elemType = delegateNamed.TypeArguments[0];
         if (elemType is not INamedTypeSymbol elemSymbol)
             return null;
 
-        // Use ExpressionTreeEmitter to build the expression tree
         var emitResult = EmitLambdaBody(lam, elemSymbol, model, spc, delegateFqn,
             varPrefix: $"i{fileTag}{line}c{col}_", delegateVarName: "__func");
         if (emitResult is null)
@@ -431,8 +358,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         """;
     }
 
-    // ── Per-invocation dispatch (IExpressiveQueryable) ───────────────────────
-
     private static string? TryEmit(InvocationExpressionSyntax inv,
         MemberAccessExpressionSyntax ma,
         SemanticModel model,
@@ -442,19 +367,14 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         string fileTag,
         SourceProductionContext spc)
     {
-        // Receiver must be or implement IExpressiveQueryable<T>.
         if (model.GetTypeInfo(ma.Expression).Type is not INamedTypeSymbol receiverType)
             return null;
 
-        // Check both the type itself and its implemented interfaces
         if (!IsExpressiveQueryable(receiverType))
             return null;
 
-        // The stub convention: at least one non-receiver parameter must be a Func<> delegate,
-        // not an Expression<Func<>>. This distinguishes user/library IExpressiveQueryable<T> stubs
-        // from regular IQueryable<T> extension methods.
-        // For most methods, Func<> is Parameters[0]. For Join/GroupJoin/Zip/ExceptBy etc.,
-        // it may be at a later position (e.g., Parameters[1]) after an IEnumerable<> arg.
+        // Stub convention: at least one Func<> param distinguishes our stubs from regular IQueryable
+        // extensions. The Func<> may not be Parameters[0] (e.g. Join/Zip/ExceptBy).
         if (method.Parameters.IsEmpty) return null;
         var funcParamIndices = new List<int>();
         for (int i = 0; i < method.Parameters.Length; i++)
@@ -468,8 +388,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         }
         if (funcParamIndices.Count == 0) return null;
 
-        // Get the interceptable location using the Roslyn 5.0+ API.
-        // This produces the correct [InterceptsLocation(version, data)] attribute text.
         var interceptableLocation = model.GetInterceptableLocation(inv, spc.CancellationToken);
 
         if (interceptableLocation is null)
@@ -477,8 +395,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
         var interceptAttr = interceptableLocation.GetInterceptsLocationAttributeSyntax();
 
-        // Element type T of IExpressiveQueryable<T>.
-        // The receiver may be IExpressiveQueryable<T> directly, or a type that implements it.
         var rewritableInterface = GetExpressiveQueryableInterface(receiverType);
         if (rewritableInterface is null)
             return null;
@@ -488,10 +404,7 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         var elementFqn = elementType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var methodName = ma.Name.Identifier.Text;
 
-        // Per-call AsExpressive() → MSBuild global → hardcoded Ignore fallback.
-
-        // Resolve the target type for the Queryable.* call. Defaults to System.Linq.Queryable
-        // unless overridden by [PolyfillTarget(typeof(...))] on the stub method.
+        // Defaults to System.Linq.Queryable unless overridden by [PolyfillTarget(typeof(...))].
         var targetTypeFqn = "global::System.Linq.Queryable";
         var polyfillAttr = method.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.Name == "PolyfillTargetAttribute");
@@ -505,12 +418,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             methodName, elementSymbol, elementFqn, method, funcParamIndices, targetTypeFqn);
     }
 
-    // ── Lambda helpers ───────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Uses <see cref="Emitter.ExpressionTreeEmitter"/> to build the expression tree for a lambda body.
-    /// Returns the emitter result containing imperative Expression.* factory code, or null on failure.
-    /// </summary>
     private static Emitter.EmitResult? EmitLambdaBody(
         LambdaExpressionSyntax lambda,
         INamedTypeSymbol elementSymbol,
@@ -522,17 +429,12 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         IReadOnlyDictionary<ITypeSymbol, string>? typeAliases = null,
         string? delegateVarName = null)
     {
-        // For expression-bodied lambdas, use the expression directly.
-        // For block-bodied lambdas, use the block.
         var bodyNode = lambda.Body is ExpressionSyntax expr ? (SyntaxNode)expr : lambda.Body;
         if (bodyNode is null) return null;
 
-        // Pre-check: if Roslyn can't bind something in the body (e.g. a synthesized member that
-        // isn't visible to this generator's compilation), the IOperation tree contains
-        // IInvalidOperation nodes and the emitted expression tree would be garbage. Surface
-        // EXP0010 so the user notices instead of silently falling back to the delegate stub.
-        // We don't fail on a null IOperation — that can mean transparent syntax that the
-        // emitter unwraps separately, not a binding failure.
+        // If binding failed (e.g. a synthesized member invisible to this generator), the IOperation
+        // tree has IInvalidOperation nodes and emission would produce garbage; surface a diagnostic
+        // instead. Null IOperation is fine — that's transparent syntax the emitter unwraps separately.
         var bodyOperation = model.GetOperation(bodyNode);
         if (bodyOperation is not null && ContainsInvalidOperation(bodyOperation))
         {
@@ -577,11 +479,10 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             }
         }
 
-        // Determine return type from delegate type args, resolving through aliases for anonymous types.
+        // Return type from delegate args, resolved through aliases for anonymous types.
         var returnTypeFqn = "object";
         if (elementSymbol.ContainingNamespace is not null)
         {
-            // Try to get the return type from the lambda's actual type info
             var typeInfo = model.GetTypeInfo(lambda);
             if (typeInfo.ConvertedType is INamedTypeSymbol convertedType &&
                 convertedType.TypeArguments.Length > 0)
@@ -597,26 +498,16 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         var result = emitter.Emit(bodyNode, emitterParams, returnTypeFqn, delegateTypeFqn,
             assignToVariable: assignToVariable);
 
-        // Prepend source comment showing the original lambda
+        // Prepend the original lambda source as a comment in the generated output.
         var sourceText = lambda.NormalizeWhitespace().ToFullString()
             .Replace("\r", "").Replace("\n", " ");
         var commentLine = $"            // Source: {sourceText}\n";
         return new Emitter.EmitResult(commentLine + result.Body);
     }
 
-    // ── Type helpers ─────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Returns true if <paramref name="type"/> is an anonymous type, which cannot be
-    /// named in C# source and requires a generic type parameter in the interceptor signature.
-    /// </summary>
     private static bool IsAnonymousType(ITypeSymbol type)
         => type is INamedTypeSymbol { IsAnonymousType: true };
 
-    /// <summary>
-    /// Walks an <see cref="IOperation"/> tree looking for any <c>IInvalidOperation</c>, which
-    /// Roslyn produces when binding fails (unknown member, malformed reference, etc.).
-    /// </summary>
     private static bool ContainsInvalidOperation(IOperation op)
     {
         if (op is IInvalidOperation) return true;
@@ -626,8 +517,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         }
         return false;
     }
-
-    // ── Formatting helpers ───────────────────────────────────────────────────
 
     private static bool HasLambdaArgument(InvocationExpressionSyntax inv)
     {
@@ -640,33 +529,15 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         return false;
     }
 
-    /// <summary>
-    /// Produces a unique, stable interceptor method name based on the call site's
-    /// source file hash + method-name-token position (line/col).
-    /// The file hash disambiguates call sites across different source files that happen
-    /// to share the same line/col (e.g., two files both have an <c>OrderBy</c> at 44:13).
-    /// The position component disambiguates multiple call sites within the same file.
-    /// Adding/removing methods in other files never shifts these identifiers.
-    /// </summary>
     private static string MethodId(string op, string fileTag, int line, int col)
         => $"__Polyfill_{op}_{fileTag}_{line}_{col}";
 
-    /// <summary>
-    /// Generic lambda emitter for all LINQ operators and user-defined stubs.
-    /// Handles any number of Func&lt;&gt; parameters (single or multi-lambda).
-    /// Convention: the interceptor calls <c>Queryable.{methodName}</c> with the same name.
-    /// The return type is taken from the stub's declared return type.
-    /// Supports methods where the Func&lt;&gt; parameters are not necessarily at position 0
-    /// (e.g., ExceptBy, Zip, AggregateBy where non-lambda args are interleaved).
-    /// Non-lambda parameters are forwarded directly to the Queryable.* call.
-    /// </summary>
     private static string? EmitGenericLambda(
         InvocationExpressionSyntax inv, SemanticModel model, SourceProductionContext spc,
         string interceptAttr, int line, int col, string fileTag,
         string methodName, INamedTypeSymbol elemSym, string elemFqn,
         IMethodSymbol method, List<int> funcParamIndices, string targetTypeFqn)
     {
-        // ── Extract all lambda expressions from the Func<> argument positions ──
         var lambdas = new List<LambdaExpressionSyntax>(funcParamIndices.Count);
         for (int i = 0; i < funcParamIndices.Count; i++)
         {
@@ -677,7 +548,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
         bool single = funcParamIndices.Count == 1;
 
-        // ── Detect anonymous types across all Func<> type args ──
         var hasAnyAnon = elemSym.IsAnonymousType;
         for (int i = 0; i < funcParamIndices.Count; i++)
         {
@@ -686,14 +556,13 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 hasAnyAnon = hasAnyAnon || IsAnonymousType(fta[j]);
         }
 
-        // Also check non-Func parameter types (e.g., anonymous seed in AggregateBy).
+        // Non-Func params can also be anonymous (e.g. AggregateBy seed).
         for (int i = 0; i < method.Parameters.Length; i++)
         {
             if (!funcParamIndices.Contains(i))
                 hasAnyAnon = hasAnyAnon || IsAnonymousType(method.Parameters[i].Type);
         }
 
-        // Determine if the stub returns IExpressiveQueryable<X> (queryable) or a scalar type.
         var isRewritableReturn = method.ReturnType is INamedTypeSymbol rqType
             && rqType.ConstructedFrom.ToDisplayString() == IExpressiveQueryableOpenTypeName;
 
@@ -704,17 +573,15 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             hasAnyAnon = hasAnyAnon || IsAnonymousType(returnElemType);
         }
 
-        // For scalar returns, the FQN of the return type itself.
         var scalarReturnFqn = method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
         // ThenBy/ThenByDescending require IOrderedQueryable<T>.
         var isOrdered = methodName is "ThenBy" or "ThenByDescending";
 
-        // ── Build type aliases, per-lambda delegate FQNs, param lists ──
         var methodTypeArgs = method.TypeArguments;
         var typeAliases = new Dictionary<ITypeSymbol, string>(SymbolEqualityComparer.Default);
         var delegateFqns = new string[funcParamIndices.Count];
-        string elemRef; // element type reference (alias or FQN)
+        string elemRef;
         string castFqn;
         string typeParams;
         string returnRef;
@@ -723,16 +590,13 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
 
         if (hasAnyAnon)
         {
-            // ALL method type args become generic params (T0, T1, …) to match interceptor arity.
-            // Anonymous types get aliases for EmitLambdaBody; concrete types still appear as
-            // generic params in the interceptor signature so the C# compiler can infer them.
+            // All method type args become generic params (T0, T1, …) so the C# compiler can infer
+            // anonymous types — they have no nameable form in the interceptor signature.
             var typeParamNames = new string[methodTypeArgs.Length];
             for (int i = 0; i < methodTypeArgs.Length; i++)
                 typeParamNames[i] = $"T{i}";
             typeParams = $"<{string.Join(", ", typeParamNames)}>";
 
-            // Register ALL method type args as aliases so EmitLambdaBody and the
-            // Queryable.* forwarding call use consistent generic param references.
             if (!typeAliases.ContainsKey(elemSym))
                 typeAliases[elemSym] = typeParamNames[0];
             for (int i = 0; i < methodTypeArgs.Length; i++)
@@ -741,15 +605,11 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                     typeAliases[methodTypeArgs[i]] = typeParamNames[i];
             }
 
-            // Element reference: use alias (all method type args are aliased).
             if (typeAliases.TryGetValue(elemSym, out var ep))
                 elemRef = ep;
             else
                 elemRef = elemFqn;
 
-            // Build per-lambda delegate FQN strings.
-            // Interceptor signature form: ALL types as generic params (ensures inference).
-            // EmitLambdaBody form: anonymous → alias, concrete → FQN.
             var funcFqnGenerics = new string[funcParamIndices.Count];
             for (int fi = 0; fi < funcParamIndices.Count; fi++)
             {
@@ -757,14 +617,12 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 var sigParts = new string[funcTypeArgs.Length];
                 for (int i = 0; i < funcTypeArgs.Length; i++)
                 {
-                    // Use alias if the type is registered; concrete FQN otherwise.
                     if (typeAliases.TryGetValue(funcTypeArgs[i], out var gp))
                         sigParts[i] = gp;
                     else
                         sigParts[i] = funcTypeArgs[i].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 }
                 funcFqnGenerics[fi] = "global::System.Func<" + string.Join(", ", sigParts) + ">";
-                // Use same generic form for EmitLambdaBody so lambda types match the Queryable.* call.
                 delegateFqns[fi] = funcFqnGenerics[fi];
             }
 
@@ -772,15 +630,13 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 ? $"global::System.Linq.IOrderedQueryable<{elemRef}>"
                 : $"global::System.Linq.IQueryable<{elemRef}>";
 
-            // Return type: use alias if available.
             if (isRewritableReturn)
             {
                 if (typeAliases.TryGetValue(returnElemType!, out var retParam))
                     returnRef = retParam;
                 else
-                    // Use ResolveTypeFqn so that composite return types like IGrouping<TKey, AnonType>
-                    // are resolved through the type aliases (e.g. IGrouping<T1, T0> instead of the
-                    // compiler-generated anonymous type name which is not valid C#).
+                    // Composite return types like IGrouping<TKey, AnonType> need alias substitution
+                    // (anonymous types have no nameable form in C# source).
                     returnRef = ResolveTypeFqn(returnElemType!, typeAliases);
             }
             else
@@ -788,7 +644,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 returnRef = scalarReturnFqn;
             }
 
-            // Build parameter and argument lists, replacing each Func<> position.
             var interceptorParams = new List<string>();
             var queryableArgs = new List<string>();
             int funcOrdinal = 0;
@@ -818,7 +673,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             typeParams = "";
             elemRef = elemFqn;
 
-            // Build per-lambda delegate FQN strings with concrete types.
             for (int fi = 0; fi < funcParamIndices.Count; fi++)
             {
                 var funcTypeArgs = ((INamedTypeSymbol)method.Parameters[funcParamIndices[fi]].Type).TypeArguments;
@@ -835,7 +689,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
                 ? returnElemType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                 : scalarReturnFqn;
 
-            // Build parameter and argument lists with concrete Func<> types.
             var interceptorParams = new List<string>();
             var queryableArgs = new List<string>();
             int funcOrdinal = 0;
@@ -860,11 +713,8 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             queryableArgList = string.Join(",\n                        ", queryableArgs);
         }
 
-        // ── Emit all lambda bodies ──
-        // For simple (single-parameter) lambdas, EmitLambdaBody uses the elementSymbol
-        // to determine the parameter type. For the first Func<> that's the source element,
-        // but for subsequent Func<> params (e.g., AggregateBy's seedSelector Func<TKey, TAcc>)
-        // the first type arg is NOT the source element. Derive the correct symbol per-lambda.
+        // For multi-Func methods (e.g. AggregateBy seedSelector Func<TKey, TAcc>), the source
+        // element is NOT necessarily the first type arg of every Func<>; derive per-lambda.
         var emitBodies = new List<string>(funcParamIndices.Count);
         for (int j = 0; j < funcParamIndices.Count; j++)
         {
@@ -882,7 +732,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         }
         var allBodies = string.Concat(emitBodies);
 
-        // ── Templates ──
         if (!hasAnyAnon)
         {
             if (isRewritableReturn)
@@ -948,9 +797,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         """;
     }
 
-    /// <summary>
-    /// Returns true if <paramref name="type"/> is or implements <c>IExpressiveQueryable&lt;T&gt;</c>.
-    /// </summary>
     private static bool IsExpressiveQueryable(INamedTypeSymbol type)
     {
         if (type.ConstructedFrom.ToDisplayString() == IExpressiveQueryableOpenTypeName)
@@ -960,10 +806,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             i.ConstructedFrom.ToDisplayString() == IExpressiveQueryableOpenTypeName);
     }
 
-    /// <summary>
-    /// Finds the <c>IExpressiveQueryable&lt;T&gt;</c> interface on <paramref name="type"/>,
-    /// or returns <paramref name="type"/> itself if it is <c>IExpressiveQueryable&lt;T&gt;</c>.
-    /// </summary>
     private static INamedTypeSymbol? GetExpressiveQueryableInterface(INamedTypeSymbol type)
     {
         if (type.ConstructedFrom.ToDisplayString() == IExpressiveQueryableOpenTypeName)
@@ -979,11 +821,9 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
     /// </summary>
     private static string ResolveTypeFqn(ITypeSymbol type, Dictionary<ITypeSymbol, string> typeAliases)
     {
-        // Direct match (e.g., the type itself is aliased).
         if (typeAliases.TryGetValue(type, out var alias))
             return alias;
 
-        // Constructed generic type: resolve each type argument.
         if (type is INamedTypeSymbol named && named.TypeArguments.Length > 0)
         {
             bool anyResolved = false;
@@ -1003,7 +843,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             if (anyResolved)
             {
                 var openType = named.ConstructedFrom.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                // Remove the existing type args from the FQN (everything from the last '<').
                 var idx = openType.LastIndexOf('<');
                 if (idx >= 0)
                     openType = openType.Substring(0, idx);
@@ -1014,24 +853,11 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         return type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
     }
 
-    // ── CompilationUnitAndCompilationComparer ─────────────────────────────────
-
     /// <summary>
-    /// Compares <c>(CompilationUnitSyntax, Compilation)</c> pairs using REFERENCE
-    /// equality on the syntax root only, completely ignoring the <c>Compilation</c>.
-    ///
-    /// <para>
-    /// Roslyn's incremental pipeline rebuilds the <see cref="Compilation"/> on every
-    /// file edit — even for files unrelated to our call sites. However, it keeps every
-    /// unchanged file's <see cref="SyntaxTree"/> root as the exact same object reference
-    /// across incremental runs.
-    /// </para>
-    /// <para>
-    /// By using reference equality on the <see cref="CompilationUnitSyntax"/>, editing
-    /// a noise file makes all untouched source-file pairs compare as "equal" → their
-    /// <c>RegisterSourceOutput</c> actions are skipped entirely → O(1) incremental cost
-    /// for noise-file edits, matching the pattern used by EntityFrameworkCore.Projectables.
-    /// </para>
+    /// Reference equality on the CompilationUnitSyntax root, ignoring Compilation.
+    /// Roslyn keeps unchanged files' syntax tree roots as the same object across incremental
+    /// runs, so noise-file edits leave untouched (file, compilation) pairs equal and skip
+    /// re-emission — O(1) incremental cost.
     /// </summary>
     private sealed class CompilationUnitAndCompilationComparer
         : IEqualityComparer<(CompilationUnitSyntax Left, Compilation Right)>
@@ -1050,14 +876,6 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
             => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj.Left);
     }
 
-    // ── SynthesizedSourceArrayComparer ─────────────────────────────────────────
-
-    /// <summary>
-    /// Sequence-equality on the collected (HintName, Source) pairs from the synthesized-property
-    /// pipeline. ImmutableArray's default equality is reference, so without this comparer Roslyn
-    /// would treat every regenerated array as distinct and invalidate every downstream consumer
-    /// on every input edit.
-    /// </summary>
     private sealed class SynthesizedSourceArrayComparer
         : IEqualityComparer<ImmutableArray<(string HintName, string Source)>>
     {
@@ -1093,18 +911,11 @@ public class PolyfillInterceptorGenerator : IIncrementalGenerator
         }
     }
 
-    // ── FileAndSynthesizedSourcesComparer ──────────────────────────────────────
 
     /// <summary>
-    /// Combined comparer for the per-file pipeline + synthesized-source array. ANDs the existing
-    /// <see cref="CompilationUnitAndCompilationComparer"/> reference-equality on the file root with
-    /// sequence-equality on the synthesized array.
-    ///
-    /// <para>
-    /// Editing a file with no <c>[ExpressiveProperty]</c> change → file ref unchanged AND array
-    /// unchanged → skip. Editing an <c>[ExpressiveProperty]</c> attribute → array changes → all
-    /// files re-emit (correct: synthesized binding may affect any file's lambdas).
-    /// </para>
+    /// ANDs <see cref="CompilationUnitAndCompilationComparer"/> with sequence equality on the
+    /// synthesized array — editing an [ExpressiveProperty] attribute correctly re-emits all
+    /// files since synthesized binding can affect any file's lambdas.
     /// </summary>
     private sealed class FileAndSynthesizedSourcesComparer
         : IEqualityComparer<((CompilationUnitSyntax Left, Compilation Right) Left, ImmutableArray<(string HintName, string Source)> Right)>

--- a/src/ExpressiveSharp.Generator/Registry/ExpressionRegistryEmitter.cs
+++ b/src/ExpressiveSharp.Generator/Registry/ExpressionRegistryEmitter.cs
@@ -6,23 +6,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace ExpressiveSharp.Generator.Registry;
 
-/// <summary>
-/// Emits the <c>ExpressionRegistry.g.cs</c> source file that aggregates all expressive
-/// members into a single static dictionary keyed by <see cref="System.RuntimeMethodHandle.Value"/>.
-///
-/// <para>
-/// Code is generated using <see cref="IndentedTextWriter"/> rather than Roslyn's
-/// <c>SyntaxFactory</c>: the output has a fixed template shape that never changes, so
-/// string-based generation is simpler, more readable, and easier to maintain.
-/// </para>
-/// </summary>
+// Aggregates all expressive members into a single static dictionary keyed by
+// System.RuntimeMethodHandle.Value (emitted as ExpressionRegistry.g.cs).
 static internal class ExpressionRegistryEmitter
 {
-    /// <summary>
-    /// Builds and adds <c>ExpressionRegistry.g.cs</c> to the compilation output.
-    /// The file is only emitted when at least one non-generic, non-extension expressive
-    /// member is present (i.e. when <paramref name="entries"/> yields at least one representable entry).
-    /// </summary>
     public static void Emit(ImmutableArray<ExpressionRegistryEntry?> entries, SourceProductionContext context)
     {
         var allEntries = entries
@@ -35,13 +22,11 @@ static internal class ExpressionRegistryEmitter
             return;
         }
 
-        // Report EXP0020 for duplicate [ExpressiveFor] mappings targeting the same member
         ReportDuplicateMappings(allEntries, context);
 
-        // Emit [EditorBrowsable] attribute-only partial files for each unique generated class.
         EmitEditorBrowsablePartialFiles(allEntries, context);
 
-        // Filter to registry-eligible entries (exclude metadata-only entries for generic/extension classes).
+        // Metadata-only entries (generic/extension classes) are not registry-eligible.
         var registryEntries = allEntries.Where(e => !e.IsMetadataOnly).ToList();
 
         if (registryEntries.Count == 0)
@@ -49,8 +34,6 @@ static internal class ExpressionRegistryEmitter
             return;
         }
 
-        // IndentedTextWriter wraps a TextWriter; keep a reference to the StringWriter
-        // so we can read the result back with .ToString() after all writes are done.
         var sw = new StringWriter();
         var writer = new IndentedTextWriter(sw, "    ");
 
@@ -88,11 +71,6 @@ static internal class ExpressionRegistryEmitter
             SourceText.From(sw.ToString(), Encoding.UTF8));
     }
 
-    /// <summary>
-    /// Emits the private <c>Build()</c> method that populates the runtime registry.
-    /// Each expressive member is registered via the shared <c>Register(...)</c> helper to keep
-    /// the method body compact — null-safety and the reflection lookup are handled once, centrally.
-    /// </summary>
     private static void EmitBuildMethod(IndentedTextWriter writer, List<ExpressionRegistryEntry> entries)
     {
         writer.WriteLine("private static Dictionary<nint, LambdaExpression> Build()");
@@ -114,24 +92,16 @@ static internal class ExpressionRegistryEmitter
         writer.WriteLine("}");
     }
 
-    /// <summary>
-    /// Emits a single <c>Register(map, typeof(T).GetXxx(...), "ClassName")</c> call
-    /// for one expressive entry inside <c>Build()</c>.
-    /// </summary>
     private static void WriteRegistryEntryStatement(IndentedTextWriter writer, ExpressionRegistryEntry entry)
     {
-        // Build the reflection-lookup expression for the member, switching on its kind.
         string? memberCallExpr = entry.MemberKind switch
         {
-            // typeof(T).GetProperty("Name", allFlags)?.GetMethod
             ExpressionRegistryMemberType.Property =>
                 $"typeof({entry.DeclaringTypeFullName}).GetProperty(\"{entry.MemberLookupName}\", allFlags)?.GetMethod",
 
-            // typeof(T).GetMethod("Name", allFlags, null, new Type[] { typeof(P1), … }, null)
             ExpressionRegistryMemberType.Method =>
                 $"typeof({entry.DeclaringTypeFullName}).GetMethod(\"{entry.MemberLookupName}\", allFlags, null, {BuildTypeArrayExpr(entry.ParameterTypeNames)}, null)",
 
-            // typeof(T).GetConstructor(allFlags, null, new Type[] { typeof(P1), … }, null)
             ExpressionRegistryMemberType.Constructor =>
                 $"typeof({entry.DeclaringTypeFullName}).GetConstructor(allFlags, null, {BuildTypeArrayExpr(entry.ParameterTypeNames)}, null)",
 
@@ -144,12 +114,8 @@ static internal class ExpressionRegistryEmitter
         }
     }
 
-    /// <summary>
-    /// Emits the <c>_map</c> field plus a <c>ResetMap</c> entry point used by the hot-reload
-    /// handler to rebuild the map after a metadata update has patched the factory-method IL.
-    /// <c>volatile</c> ensures the new <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>
-    /// is safely published to concurrent readers on weak-memory architectures.
-    /// </summary>
+    // ResetMap is invoked by the hot-reload handler after a metadata update has patched
+    // factory-method IL. `volatile` publishes the new Dictionary safely to concurrent readers.
     private static void EmitMapField(IndentedTextWriter writer)
     {
         writer.WriteLine("private static volatile Dictionary<nint, LambdaExpression> _map = Build();");
@@ -157,12 +123,6 @@ static internal class ExpressionRegistryEmitter
         writer.WriteLine("internal static void ResetMap() => _map = Build();");
     }
 
-    /// <summary>
-    /// Emits the public <c>TryGet</c> method.
-    /// It resolves the runtime <see cref="System.RuntimeMethodHandle.Value"/> for any
-    /// <see cref="System.Reflection.MemberInfo"/> subtype via a switch expression,
-    /// then looks it up in <c>_map</c>.
-    /// </summary>
     private static void EmitTryGetMethod(IndentedTextWriter writer)
     {
         writer.WriteLine("public static LambdaExpression TryGet(MemberInfo member)");
@@ -185,11 +145,6 @@ static internal class ExpressionRegistryEmitter
         writer.WriteLine("}");
     }
 
-    /// <summary>
-    /// Emits the private <c>Register</c> static helper shared by all per-entry calls in <c>Build()</c>.
-    /// Centralises the null-check and the common reflection-to-expression lookup so that
-    /// each entry only needs one compact call site.
-    /// </summary>
     private static void EmitRegisterHelper(IndentedTextWriter writer)
     {
         writer.WriteLine("private static void Register(Dictionary<nint, LambdaExpression> map, MethodBase m, string exprClass, string exprMethodName)");
@@ -224,10 +179,6 @@ static internal class ExpressionRegistryEmitter
         writer.WriteLine("}");
     }
 
-    /// <summary>
-    /// Returns the C# expression for a <c>Type[]</c> used in reflection method/constructor lookups.
-    /// Returns <c>global::System.Type.EmptyTypes</c> when <paramref name="parameterTypeNames"/> is empty.
-    /// </summary>
     private static string BuildTypeArrayExpr(ImmutableArray<string> parameterTypeNames)
     {
         if (parameterTypeNames.IsEmpty)
@@ -239,15 +190,11 @@ static internal class ExpressionRegistryEmitter
         return $"new global::System.Type[] {{ {typeofExprs} }}";
     }
 
-    /// <summary>
-    /// Emits a single <c>[EditorBrowsable(Never)]</c> attribute-only partial class file
-    /// for each unique generated class. This ensures the attribute appears exactly once
-    /// per class, avoiding CS0579 (duplicate attribute) across per-member partial files.
-    /// </summary>
+    // Emits one [EditorBrowsable(Never)] attribute-only partial class file per unique generated
+    // class so the attribute appears exactly once, avoiding CS0579 across per-member partials.
     private static void EmitEditorBrowsablePartialFiles(List<ExpressionRegistryEntry> allEntries, SourceProductionContext context)
     {
-        // Group by class full name to emit one file per unique class.
-        // Use the first entry per class to get type parameter info.
+        // First entry per class supplies the type parameter info.
         var seenClasses = new Dictionary<string, ExpressionRegistryEntry>();
         foreach (var entry in allEntries)
         {
@@ -262,7 +209,6 @@ static internal class ExpressionRegistryEmitter
             var classFullName = kvp.Key;
             var entry = kvp.Value;
 
-            // Extract the simple class name from the full name (after the last '.')
             var className = classFullName;
             var lastDot = classFullName.LastIndexOf('.');
             if (lastDot >= 0)
@@ -286,10 +232,6 @@ static internal class ExpressionRegistryEmitter
         }
     }
 
-    /// <summary>
-    /// Reports EXP0020 on each stub when multiple [ExpressiveFor] stubs in the same project
-    /// target the same member (same <see cref="ExpressionRegistryEntry.GeneratedClassFullName"/>).
-    /// </summary>
     private static void ReportDuplicateMappings(List<ExpressionRegistryEntry> entries, SourceProductionContext context)
     {
         var duplicateGroups = entries

--- a/src/ExpressiveSharp.Generator/Registry/ExpressionRegistryEntry.cs
+++ b/src/ExpressiveSharp.Generator/Registry/ExpressionRegistryEntry.cs
@@ -4,11 +4,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace ExpressiveSharp.Generator.Registry;
 
-/// <summary>
-/// Incremental-pipeline-safe representation of a single expressive member.
-/// Contains only primitive types and an equatable wrapper around <see cref="ImmutableArray{T}"/>
-/// so that structural value equality works correctly across incremental generation steps.
-/// </summary>
+// Primitive-only fields plus EquatableImmutableArray — safe for incremental generator caching.
 sealed internal record ExpressionRegistryEntry(
     string DeclaringTypeFullName,
     ExpressionRegistryMemberType MemberKind,
@@ -18,25 +14,19 @@ sealed internal record ExpressionRegistryEntry(
     EquatableImmutableArray ParameterTypeNames,
     bool IsMetadataOnly = false,
     string? ClassTypeParameters = null,
-    /// <summary>Source location of the [ExpressiveFor] stub, or null for [Expressive] entries.</summary>
+    // Source location of the [ExpressiveFor] stub, or null for [Expressive] entries.
     SourceLocation? StubLocation = null
 );
 
-/// <summary>
-/// Serialized source location using only value types — safe for incremental generator caching.
-/// </summary>
+// Value-typed source location — safe for incremental generator caching.
 readonly internal record struct SourceLocation(string FilePath, TextSpan TextSpan, LinePositionSpan LineSpan)
 {
     public Location ToLocation() => Location.Create(FilePath, TextSpan, LineSpan);
 }
 
-/// <summary>
-/// A structural-equality wrapper around <see cref="ImmutableArray{T}"/> of strings.
-/// <see cref="ImmutableArray{T}"/> uses reference equality by default, which breaks
-/// Roslyn's incremental-source-generator caching when the same logical array is
-/// produced by two different steps. This wrapper provides element-wise equality so
-/// that incremental steps are correctly cached and skipped.
-/// </summary>
+// ImmutableArray<T> uses reference equality by default, which breaks Roslyn's incremental
+// caching when the same logical array is produced by two different steps. Element-wise
+// equality lets incremental steps be correctly cached and skipped.
 readonly internal struct EquatableImmutableArray(ImmutableArray<string> array) : IEquatable<EquatableImmutableArray>
 {
     private readonly ImmutableArray<string> _array = array;

--- a/src/ExpressiveSharp.Generator/SyntaxRewriters/DeclarationSyntaxRewriter.cs
+++ b/src/ExpressiveSharp.Generator/SyntaxRewriters/DeclarationSyntaxRewriter.cs
@@ -19,21 +19,19 @@ internal class DeclarationSyntaxRewriter : CSharpSyntaxRewriter
 
         if (visitedNode is ParameterSyntax visitedParameterSyntax)
         {
-            // Strip the this keyword of any parameter
             var thisKeywordIndex = visitedParameterSyntax.Modifiers.IndexOf(SyntaxKind.ThisKeyword);
             if (thisKeywordIndex != -1)
             {
                 visitedNode = visitedParameterSyntax.WithModifiers(node.Modifiers.RemoveAt(thisKeywordIndex));
             }
 
-            // Strip the params keyword of any parameter
             var paramsKeywordIndex = ((ParameterSyntax)visitedNode).Modifiers.IndexOf(SyntaxKind.ParamsKeyword);
             if (paramsKeywordIndex != -1)
             {
                 visitedNode = ((ParameterSyntax)visitedNode).WithModifiers(node.Modifiers.RemoveAt(paramsKeywordIndex));
             }
 
-            // Remove default values from parameters as this is not accepted in an expression tree
+            // Default values are not accepted in expression trees.
             if (visitedParameterSyntax.Default is not null)
             {
                 visitedNode = ((ParameterSyntax)visitedNode).WithDefault(null);

--- a/src/ExpressiveSharp.MongoDB/ExpressiveMongoCollection.cs
+++ b/src/ExpressiveSharp.MongoDB/ExpressiveMongoCollection.cs
@@ -6,58 +6,28 @@ using MongoDB.Driver;
 namespace ExpressiveSharp.MongoDB;
 
 /// <summary>
-/// A wrapper around <see cref="IMongoCollection{TDocument}"/> that provides an
-/// <see cref="IExpressiveMongoQueryable{T}"/> for delegate-based LINQ queries
-/// with automatic <c>[Expressive]</c> member expansion.
-/// </summary>
-/// <remarks>
+/// Wraps an <see cref="IMongoCollection{TDocument}"/> to expose an
+/// <see cref="IExpressiveMongoQueryable{T}"/> with automatic <c>[Expressive]</c> expansion.
 /// Analogous to <c>ExpressiveDbSet&lt;TEntity&gt;</c> in the EF Core integration.
-/// CRUD operations delegate directly to the inner collection.
-/// </remarks>
-/// <example>
-/// <code>
-/// var orders = new ExpressiveMongoCollection&lt;Order&gt;(collection);
-/// var results = await orders.AsQueryable()
-///     .Where(o => o.Customer?.Name == "Alice")
-///     .ToListAsync();
-/// </code>
-/// </example>
+/// </summary>
 public class ExpressiveMongoCollection<TDocument>
 {
     private readonly IMongoCollection<TDocument> _inner;
     private readonly ExpressiveOptions _options;
 
-    /// <summary>
-    /// Creates a new <see cref="ExpressiveMongoCollection{TDocument}"/> wrapping the specified collection.
-    /// </summary>
-    /// <param name="inner">The underlying MongoDB collection.</param>
-    /// <param name="options">
-    /// Optional <see cref="ExpressiveOptions"/> controlling the transformer pipeline.
-    /// When <c>null</c>, <see cref="MongoExpressiveOptions.CreateDefault"/> is used.
-    /// </param>
     public ExpressiveMongoCollection(IMongoCollection<TDocument> inner, ExpressiveOptions? options = null)
     {
         _inner = inner ?? throw new ArgumentNullException(nameof(inner));
         _options = options ?? MongoExpressiveOptions.CreateDefault();
 
-        // Idempotent registration; belt-and-braces for code paths that access
-        // `Inner` directly for writes (InsertOne/ReplaceOne/…) without ever
-        // going through `AsQueryable`. The `AsExpressive` extension registers
-        // the convention on the query path.
+        // Belt-and-braces for code paths that access `Inner` directly for writes
+        // (InsertOne/ReplaceOne/…) without ever going through `AsQueryable`.
+        // The `AsExpressive` extension registers the convention on the query path.
         ExpressiveMongoIgnoreConvention.EnsureRegistered();
     }
 
-    /// <summary>
-    /// Gets the underlying <see cref="IMongoCollection{TDocument}"/> for direct access
-    /// to non-LINQ operations (inserts, updates, deletes, aggregation pipeline, etc.).
-    /// </summary>
     public IMongoCollection<TDocument> Inner => _inner;
 
-    /// <summary>
-    /// Returns an <see cref="IExpressiveMongoQueryable{T}"/> that supports delegate-based
-    /// LINQ with modern C# syntax and automatic <c>[Expressive]</c> expansion.
-    /// </summary>
-    /// <param name="aggregateOptions">Optional MongoDB aggregation options.</param>
     public IExpressiveMongoQueryable<TDocument> AsQueryable(AggregateOptions? aggregateOptions = null)
         => _inner.AsExpressive(_options, aggregateOptions);
 }

--- a/src/ExpressiveSharp.MongoDB/Extensions/ExpressiveQueryableMongoExtensions.cs
+++ b/src/ExpressiveSharp.MongoDB/Extensions/ExpressiveQueryableMongoExtensions.cs
@@ -8,9 +8,7 @@ using MongoDB.Driver.Linq;
 namespace MongoDB.Driver;
 
 /// <summary>
-/// Delegate-based async method stubs on <see cref="IExpressiveQueryable{T}"/> for MongoDB
-/// async operations. These stubs are intercepted at compile time by the ExpressiveSharp
-/// source generator via <see cref="PolyfillTargetAttribute"/> and forwarded to
+/// Delegate-based async stubs intercepted at compile time and forwarded to
 /// <see cref="MongoQueryable"/> extension methods with expression tree arguments.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
@@ -20,8 +18,6 @@ public static class ExpressiveQueryableMongoExtensions
         "This method must be intercepted by the ExpressiveSharp source generator. " +
         "Ensure the generator package is installed and the InterceptorsNamespaces MSBuild property is configured.";
 
-    // ── AnyAsync ────────────────────────────────────────────────────────
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
     public static Task<bool> AnyAsync<T>(
@@ -29,8 +25,6 @@ public static class ExpressiveQueryableMongoExtensions
         Func<T, bool> predicate,
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
-
-    // ── CountAsync ──────────────────────────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
@@ -40,8 +34,6 @@ public static class ExpressiveQueryableMongoExtensions
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
 
-    // ── LongCountAsync ─────────────────────────────────────────────────
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
     public static Task<long> LongCountAsync<T>(
@@ -49,8 +41,6 @@ public static class ExpressiveQueryableMongoExtensions
         Func<T, bool> predicate,
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
-
-    // ── FirstAsync / FirstOrDefaultAsync ────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
@@ -68,8 +58,6 @@ public static class ExpressiveQueryableMongoExtensions
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
 
-    // ── SingleAsync / SingleOrDefaultAsync ──────────────────────────────
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
     public static Task<T> SingleAsync<T>(
@@ -86,8 +74,6 @@ public static class ExpressiveQueryableMongoExtensions
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
 
-    // ── MinAsync / MaxAsync ─────────────────────────────────────────────
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
     public static Task<TResult> MinAsync<T, TResult>(
@@ -103,8 +89,6 @@ public static class ExpressiveQueryableMongoExtensions
         Func<T, TResult> selector,
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
-
-    // ── SumAsync (int) ──────────────────────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
@@ -146,8 +130,6 @@ public static class ExpressiveQueryableMongoExtensions
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
 
-    // ── SumAsync (nullable int) ─────────────────────────────────────────
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
     public static Task<int?> SumAsync<T>(
@@ -187,8 +169,6 @@ public static class ExpressiveQueryableMongoExtensions
         Func<T, float?> selector,
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
-
-    // ── AverageAsync (double) ───────────────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
@@ -230,8 +210,6 @@ public static class ExpressiveQueryableMongoExtensions
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
 
-    // ── AverageAsync (nullable) ─────────────────────────────────────────
-
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
     public static Task<double?> AverageAsync<T>(
@@ -271,8 +249,6 @@ public static class ExpressiveQueryableMongoExtensions
         Func<T, float?> selector,
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
-
-    // ── StandardDeviationPopulationAsync ─────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]
@@ -353,8 +329,6 @@ public static class ExpressiveQueryableMongoExtensions
         Func<T, decimal?> selector,
         CancellationToken cancellationToken = default)
         => throw new UnreachableException(InterceptedMessage);
-
-    // ── StandardDeviationSampleAsync ─────────────────────────────────────
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [PolyfillTarget(typeof(MongoQueryable))]

--- a/src/ExpressiveSharp.MongoDB/Extensions/MongoExpressiveExtensions.cs
+++ b/src/ExpressiveSharp.MongoDB/Extensions/MongoExpressiveExtensions.cs
@@ -5,10 +5,6 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.Extensions;
 
-/// <summary>
-/// Entry-point extension methods for wrapping MongoDB queryables and collections
-/// with ExpressiveSharp expression expansion.
-/// </summary>
 public static class MongoExpressiveExtensions
 {
     /// <summary>
@@ -16,17 +12,11 @@ public static class MongoExpressiveExtensions
     /// <see cref="IExpressiveMongoQueryable{T}"/> that automatically expands
     /// <c>[Expressive]</c> members before query execution.
     /// </summary>
-    /// <param name="source">The MongoDB queryable source (typically from <c>collection.AsQueryable()</c>).</param>
-    /// <param name="options">
-    /// Optional <see cref="ExpressiveOptions"/> controlling the transformer pipeline.
-    /// When <c>null</c>, <see cref="MongoExpressiveOptions.CreateDefault"/> is used.
-    /// </param>
     public static IExpressiveMongoQueryable<T> AsExpressive<T>(
         this IQueryable<T> source,
         ExpressiveOptions? options = null)
     {
-        // Idempotent; cheap on subsequent calls via an Interlocked.Exchange guard.
-        // Registering here (rather than in ExpressiveMongoCollection's constructor)
+        // Registering here (rather than only in ExpressiveMongoCollection's constructor)
         // guarantees the BSON class-map convention fires on the common
         // `collection.AsExpressive()` entry point too.
         ExpressiveMongoIgnoreConvention.EnsureRegistered();
@@ -44,25 +34,17 @@ public static class MongoExpressiveExtensions
 
     /// <summary>
     /// Creates an <see cref="IExpressiveMongoQueryable{T}"/> directly from an
-    /// <see cref="IMongoCollection{TDocument}"/>, combining <c>AsQueryable()</c>
-    /// with ExpressiveSharp expression expansion.
+    /// <see cref="IMongoCollection{TDocument}"/>.
     /// </summary>
-    /// <param name="collection">The MongoDB collection.</param>
-    /// <param name="options">
-    /// Optional <see cref="ExpressiveOptions"/> controlling the transformer pipeline.
-    /// When <c>null</c>, <see cref="MongoExpressiveOptions.CreateDefault"/> is used.
-    /// </param>
-    /// <param name="aggregateOptions">Optional MongoDB aggregation options.</param>
     public static IExpressiveMongoQueryable<T> AsExpressive<T>(
         this IMongoCollection<T> collection,
         ExpressiveOptions? options = null,
         AggregateOptions? aggregateOptions = null)
     {
-        // MongoDB's AsQueryable() builds the BSON class map eagerly to prepare the
-        // aggregation pipeline. We must register our ignore convention *before* that
-        // call, otherwise the class map for T is constructed with the default auto-map
-        // behavior that includes writable [Expressive] properties as BSON fields —
-        // persisting backing-field state to the document.
+        // MongoDB's AsQueryable() builds the BSON class map eagerly. We must register our
+        // ignore convention *before* that call, otherwise the class map for T is constructed
+        // with the default auto-map behavior that includes writable [Expressive] properties
+        // as BSON fields — persisting backing-field state to the document.
         ExpressiveMongoIgnoreConvention.EnsureRegistered();
 
         var queryable = aggregateOptions is not null

--- a/src/ExpressiveSharp.MongoDB/IExpressiveMongoQueryable.cs
+++ b/src/ExpressiveSharp.MongoDB/IExpressiveMongoQueryable.cs
@@ -1,17 +1,9 @@
 namespace ExpressiveSharp.MongoDB;
 
 /// <summary>
-/// Represents a MongoDB queryable with expression-rewrite support. Extends
-/// <see cref="IExpressiveQueryable{T}"/> to enable delegate-based LINQ methods
-/// with modern C# syntax (e.g., <c>?.</c>, switch expressions, pattern matching)
-/// when querying MongoDB collections.
-/// </summary>
-/// <remarks>
-/// In MongoDB.Driver v3, the driver's LINQ provider works through standard
-/// <see cref="IQueryable{T}"/> with an <see cref="MongoDB.Driver.Linq.IMongoQueryProvider"/>.
-/// This interface marks a queryable whose provider is an <see cref="Infrastructure.ExpressiveMongoQueryProvider"/>
+/// Marks a queryable whose provider is an <see cref="Infrastructure.ExpressiveMongoQueryProvider"/>
 /// that automatically expands <c>[Expressive]</c> members before MongoDB translates the query.
-/// </remarks>
+/// </summary>
 public interface IExpressiveMongoQueryable<T> : IExpressiveQueryable<T>
 {
 }

--- a/src/ExpressiveSharp.MongoDB/Infrastructure/ExpressiveMongoIgnoreConvention.cs
+++ b/src/ExpressiveSharp.MongoDB/Infrastructure/ExpressiveMongoIgnoreConvention.cs
@@ -9,55 +9,32 @@ namespace ExpressiveSharp.MongoDB.Infrastructure;
 /// <summary>
 /// Mongo <see cref="IClassMapConvention"/> that unmaps every property marked with
 /// <see cref="ExpressiveAttribute"/> (and every property synthesized by
-/// <c>[ExpressiveProperty]</c>) from its containing class map. This is the Mongo
-/// counterpart of the EF Core <c>ExpressivePropertiesNotMappedConvention</c>: without it,
+/// <c>[ExpressiveProperty]</c>) from its containing class map. Without it,
 /// a synthesized property would be serialized to its BSON document as a real field
 /// (because the generated property has a writable accessor) and the backing field's
-/// default value would leak into storage.
+/// default value would leak into storage. Mongo counterpart of the EF Core
+/// <c>ExpressivePropertiesNotMappedConvention</c>.
 /// </summary>
-/// <remarks>
-/// <para>
-/// The convention fires when a class map is built — typically the first time a given
-/// document type participates in a Mongo query or serialization. It runs once per type
-/// (Mongo caches the resulting class map).
-/// </para>
-/// <para>
-/// Read-only computed <c>[Expressive]</c> properties are also unmapped defensively.
-/// Mongo would skip them anyway in most cases (there's no setter), but matching the EF
-/// convention's behavior keeps the two providers consistent.
-/// </para>
-/// </remarks>
 public sealed class ExpressiveMongoIgnoreConvention : ConventionBase, IClassMapConvention
 {
-    /// <summary>
-    /// The name under which this convention's pack is registered in the global
-    /// <see cref="ConventionRegistry"/>. Exposed so callers can inspect or unregister it.
-    /// </summary>
     public const string ConventionPackName = "ExpressiveSharp.MongoDB";
 
-    // The resolver's caches are static, so a single shared instance is sufficient. Used
-    // to detect properties synthesized via [ExpressiveProperty] / [ExpressiveFor] — these
+    // Detects properties synthesized via [ExpressiveProperty] / [ExpressiveFor] — these
     // carry no CLR marker attribute, so we identify them through the generated registry.
     private static readonly IExpressiveResolver _resolver = new ExpressiveResolver();
 
     public ExpressiveMongoIgnoreConvention() : base("ExpressiveSharpIgnore") { }
 
-    /// <summary>
-    /// Runs during class-map construction. Inspects the class's CLR properties directly
-    /// (instead of <see cref="BsonClassMap.DeclaredMemberMaps"/>, which may not be populated
-    /// yet at this stage) and unmaps any that carry <see cref="ExpressiveAttribute"/> or
-    /// <see cref="ExpressiveForAttribute"/>, or that are registered as synthesized by
-    /// <c>[ExpressiveProperty]</c> in the runtime expression registry.
-    /// </summary>
     public void Apply(BsonClassMap classMap)
     {
         ArgumentNullException.ThrowIfNull(classMap);
 
+        // Inspect CLR properties directly instead of BsonClassMap.DeclaredMemberMaps,
+        // which may not be populated yet at this stage.
         foreach (var property in classMap.ClassType.GetProperties(
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
         {
-            // Only unmap properties declared on this exact type; inherited ones are handled
-            // by the base class's own class-map convention pass.
+            // Inherited members are handled by the base class's own class-map convention pass.
             if (property.DeclaringType != classMap.ClassType)
             {
                 continue;
@@ -74,8 +51,6 @@ public sealed class ExpressiveMongoIgnoreConvention : ConventionBase, IClassMapC
         }
     }
 
-    // ── Registration ────────────────────────────────────────────────────────
-
     private static int _registered;
 
     /// <summary>
@@ -83,31 +58,21 @@ public sealed class ExpressiveMongoIgnoreConvention : ConventionBase, IClassMapC
     /// <see cref="ConventionRegistry"/>. Subsequent calls are no-ops.
     /// </summary>
     /// <remarks>
-    /// <para>
     /// <b>Ordering matters.</b> MongoDB builds and caches a <see cref="BsonClassMap"/> for a
     /// document type on the first call to <c>IMongoDatabase.GetCollection&lt;T&gt;()</c>. A
-    /// convention registered <i>after</i> that call does not apply to the cached map; the
-    /// <c>[Expressive]</c> properties will still be serialized to BSON.
-    /// </para>
-    /// <para>
-    /// Call this method once at application startup, before any <c>GetCollection&lt;T&gt;</c>
-    /// call for a type that has <c>[Expressive]</c> properties. Alternatively, wrap the
-    /// collection in <see cref="ExpressiveMongoCollection{TDocument}"/> or call
-    /// <c>collection.AsExpressive()</c> before any other collection handle is obtained; both
-    /// of those paths call this method.
-    /// </para>
-    /// <para>
-    /// The filter predicate returns <c>true</c> for every type — the convention's
-    /// <see cref="Apply(BsonClassMap)"/> is a no-op for classes without <c>[Expressive]</c>
-    /// properties, so applying it globally is harmless and avoids subtle ordering issues
-    /// where a type-level predicate is evaluated before attribute metadata is visible.
-    /// </para>
+    /// convention registered <i>after</i> that call does not apply to the cached map.
+    /// Wrap the collection in <see cref="ExpressiveMongoCollection{TDocument}"/> or call
+    /// <c>collection.AsExpressive()</c> before any other collection handle is obtained — both
+    /// paths call this method.
     /// </remarks>
     public static void EnsureRegistered()
     {
         if (Interlocked.Exchange(ref _registered, 1) == 1) return;
 
         var pack = new ConventionPack { new ExpressiveMongoIgnoreConvention() };
+        // Filter returns true for every type — Apply is a no-op for classes without
+        // [Expressive] properties, and a type-level filter risks evaluating before
+        // attribute metadata is visible.
         ConventionRegistry.Register(ConventionPackName, pack, _ => true);
     }
 }

--- a/src/ExpressiveSharp.MongoDB/Infrastructure/ExpressiveMongoQueryProvider.cs
+++ b/src/ExpressiveSharp.MongoDB/Infrastructure/ExpressiveMongoQueryProvider.cs
@@ -7,16 +7,11 @@ using MongoDB.Driver.Linq;
 namespace ExpressiveSharp.MongoDB.Infrastructure;
 
 /// <summary>
-/// Decorates MongoDB's <see cref="IMongoQueryProvider"/> to automatically expand
+/// Decorates MongoDB's <see cref="IMongoQueryProvider"/> to expand
 /// <see cref="ExpressiveAttribute"/> member references before query execution.
+/// CreateQuery returns an <see cref="ExpressiveMongoQueryable{T}"/> wrapper so that
+/// chained operations continue to use this provider.
 /// </summary>
-/// <remarks>
-/// <see cref="CreateQuery{TElement}"/> returns an <see cref="ExpressiveMongoQueryable{T}"/>
-/// wrapper so that chained operations continue to use this provider.
-/// <see cref="Execute{TResult}"/> and <see cref="ExecuteAsync{TResult}"/> call
-/// <see cref="ExpressionExtensions.ExpandExpressives(Expression, ExpressiveOptions)"/>
-/// on the expression before delegating to the inner provider.
-/// </remarks>
 internal sealed class ExpressiveMongoQueryProvider : IMongoQueryProvider
 {
     private readonly IMongoQueryProvider _inner;
@@ -33,7 +28,6 @@ internal sealed class ExpressiveMongoQueryProvider : IMongoQueryProvider
     public IQueryable CreateQuery(Expression expression)
     {
         var inner = _inner.CreateQuery(expression);
-        // Wrap in our queryable to maintain provider chain
         var elementType = inner.ElementType;
         var wrapperType = typeof(ExpressiveMongoQueryable<>).MakeGenericType(elementType);
         return (IQueryable)Activator.CreateInstance(wrapperType, inner, this)!;

--- a/src/ExpressiveSharp.MongoDB/Infrastructure/ExpressiveMongoQueryable.cs
+++ b/src/ExpressiveSharp.MongoDB/Infrastructure/ExpressiveMongoQueryable.cs
@@ -4,16 +4,11 @@ using MongoDB.Driver;
 
 namespace ExpressiveSharp.MongoDB.Infrastructure;
 
-/// <summary>
-/// Internal wrapper that adapts an <see cref="IQueryable{T}"/> backed by MongoDB's LINQ provider
-/// to <see cref="IExpressiveMongoQueryable{T}"/>, enabling delegate-based LINQ overloads
-/// with modern C# syntax via source generator interception.
-/// </summary>
 /// <remarks>
-/// Also implements <see cref="IOrderedQueryable{T}"/> so that <c>ThenBy</c>/<c>ThenByDescending</c>
-/// interceptors can cast the wrapper without a runtime exception, and
-/// <see cref="IAsyncCursorSource{TDocument}"/> so that <c>MongoQueryable.ToListAsync</c> /
-/// <c>ToCursorAsync</c> (which cast the source directly, not the provider) accept the wrapper.
+/// Implements <see cref="IOrderedQueryable{T}"/> so <c>ThenBy</c>/<c>ThenByDescending</c>
+/// interceptors can cast the wrapper, and <see cref="IAsyncCursorSource{TDocument}"/> so
+/// <c>MongoQueryable.ToListAsync</c> / <c>ToCursorAsync</c> (which cast the source directly,
+/// not the provider) accept the wrapper.
 /// </remarks>
 internal sealed class ExpressiveMongoQueryable<T> : IExpressiveMongoQueryable<T>, IOrderedQueryable<T>, IAsyncCursorSource<T>
 {
@@ -36,8 +31,7 @@ internal sealed class ExpressiveMongoQueryable<T> : IExpressiveMongoQueryable<T>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>
-    /// Returns the MongoDB aggregation pipeline (MQL) for this query without
-    /// executing it. Delegates to the native MongoDB queryable's ToString().
+    /// Returns the MongoDB aggregation pipeline (MQL) for this query without executing it.
     /// </summary>
     public override string ToString()
         => ExpandedInnerQueryable().ToString() ?? base.ToString()!;
@@ -48,8 +42,8 @@ internal sealed class ExpressiveMongoQueryable<T> : IExpressiveMongoQueryable<T>
     public Task<IAsyncCursor<T>> ToCursorAsync(CancellationToken cancellationToken = default)
         => ((IAsyncCursorSource<T>)ExpandedInnerQueryable()).ToCursorAsync(cancellationToken);
 
-    // Expand [Expressive] members in the expression tree and rebuild a fresh inner queryable
-    // bound to MongoDB's native provider, which implements IAsyncCursorSource<T>.
+    // Expand [Expressive] members and rebuild a fresh inner queryable bound to MongoDB's
+    // native provider, which implements IAsyncCursorSource<T>.
     private IQueryable<T> ExpandedInnerQueryable()
         => _source.Provider.CreateQuery<T>(_provider.Expand(_source.Expression));
 }

--- a/src/ExpressiveSharp.MongoDB/MongoExpressiveOptions.cs
+++ b/src/ExpressiveSharp.MongoDB/MongoExpressiveOptions.cs
@@ -4,15 +4,11 @@ using ExpressiveSharp.Transformers;
 namespace ExpressiveSharp.MongoDB;
 
 /// <summary>
-/// Factory for creating an <see cref="ExpressiveOptions"/> pre-configured with
-/// transformers suitable for MongoDB's LINQ provider.
+/// Factory for an <see cref="ExpressiveOptions"/> pre-configured with transformers
+/// suitable for MongoDB's LINQ provider.
 /// </summary>
 public static class MongoExpressiveOptions
 {
-    /// <summary>
-    /// Creates an <see cref="ExpressiveOptions"/> with the default transformer pipeline
-    /// for MongoDB queries. Matches the transformers used by the EF Core integration.
-    /// </summary>
     public static ExpressiveOptions CreateDefault()
     {
         var options = new ExpressiveOptions();

--- a/src/ExpressiveSharp/ExpressionPolyfill.cs
+++ b/src/ExpressiveSharp/ExpressionPolyfill.cs
@@ -6,22 +6,16 @@ namespace ExpressiveSharp;
 public static class ExpressionPolyfill
 {
     /// <summary>
-    /// Converts a lambda that uses modern C# syntax (e.g., <c>?.</c>) into a valid
+    /// Converts a lambda using modern C# syntax (e.g., <c>?.</c>) into an
     /// <see cref="Expression{TDelegate}"/>. The call is intercepted at compile time by
     /// the ExpressiveSharp source generator — it never executes at runtime.
     /// </summary>
     /// <example>
     /// <code>
-    /// // Type argument is inferred from the explicitly-typed lambda parameter:
     /// var expr = ExpressionPolyfill.Create((Order o) => o.Tag?.Length);
-    ///
-    /// // Explicit type argument also works:
     /// var expr = ExpressionPolyfill.Create&lt;Func&lt;Order, int?&gt;&gt;(o => o.Tag?.Length);
     /// </code>
     /// </example>
-    /// <typeparam name="TDelegate">The delegate type of the lambda (usually inferred).</typeparam>
-    /// <param name="lambda">The lambda expression to polyfill.</param>
-    /// <returns>An expression tree equivalent of <paramref name="lambda"/>.</returns>
     public static Expression<TDelegate> Create<TDelegate>(
         TDelegate lambda) where TDelegate : Delegate
         => throw new UnreachableException(
@@ -29,15 +23,9 @@ public static class ExpressionPolyfill
             "Ensure the generator package is installed and the InterceptorsNamespaces MSBuild property is configured.");
 
     /// <summary>
-    /// Converts a lambda that uses modern C# syntax (e.g., <c>?.</c>) into a valid
-    /// <see cref="Expression{TDelegate}"/>, then applies the specified transformers.
-    /// The expression tree is built at compile time by the source generator; the
-    /// transformers are applied at runtime before the result is returned.
+    /// Like <see cref="Create{TDelegate}(TDelegate)"/>, but applies the given transformers
+    /// to the generated expression tree at runtime before returning it.
     /// </summary>
-    /// <typeparam name="TDelegate">The delegate type of the lambda (usually inferred).</typeparam>
-    /// <param name="lambda">The lambda expression to polyfill.</param>
-    /// <param name="transformers">Transformers to apply to the expression tree at runtime.</param>
-    /// <returns>A transformed expression tree equivalent of <paramref name="lambda"/>.</returns>
     public static Expression<TDelegate> Create<TDelegate>(
         TDelegate lambda,
         params IExpressionTreeTransformer[] transformers) where TDelegate : Delegate

--- a/src/ExpressiveSharp/ExpressionRewriteOptions.cs
+++ b/src/ExpressiveSharp/ExpressionRewriteOptions.cs
@@ -1,17 +1,11 @@
 namespace ExpressiveSharp
 {
     /// <summary>
-    /// Options for controlling how inline lambdas in <c>IExpressiveQueryable&lt;T&gt;</c> chains are processed.
+    /// Transformers applied at runtime to the expression trees generated for inline lambdas
+    /// in an <c>IExpressiveQueryable&lt;T&gt;</c> chain.
     /// </summary>
-    /// <remarks>
-    /// Transformers listed here are applied at runtime to the expression trees
-    /// generated for inline lambdas in the query chain.
-    /// </remarks>
     public sealed class ExpressionRewriteOptions
     {
-        /// <summary>
-        /// Transformers to apply to the expression trees in this query chain.
-        /// </summary>
         public IExpressionTreeTransformer[]? Transformers { get; init; }
     }
 }

--- a/src/ExpressiveSharp/ExpressiveQueryableWrapper.cs
+++ b/src/ExpressiveSharp/ExpressiveQueryableWrapper.cs
@@ -7,13 +7,9 @@ using System.Linq.Expressions;
 namespace ExpressiveSharp
 {
     /// <summary>
-    /// Internal wrapper that adapts an <see cref="IQueryable{T}"/> to <see cref="IExpressiveQueryable{T}"/>.
-    /// Created by <see cref="ExpressiveQueryableExtensions.AsExpressive{T}"/> and by source-generated interceptors.
-    /// </summary>
-    /// <summary>
-    /// Also implements <see cref="IOrderedQueryable{T}"/> (which adds no members over <see cref="IQueryable{T}"/>)
-    /// so that the source-generated <c>ThenBy</c>/<c>ThenByDescending</c> interceptors can cast the wrapper
-    /// to <see cref="IOrderedQueryable{T}"/> without a runtime exception.
+    /// Adapts an <see cref="IQueryable{T}"/> to <see cref="IExpressiveQueryable{T}"/>.
+    /// Also implements <see cref="IOrderedQueryable{T}"/> so that source-generated
+    /// <c>ThenBy</c>/<c>ThenByDescending</c> interceptors can cast without throwing.
     /// </summary>
     internal sealed class ExpressiveQueryableWrapper<T> : IExpressiveQueryable<T>, IOrderedQueryable<T>, IAsyncEnumerable<T>
     {

--- a/src/ExpressiveSharp/Extensions/ExpressionExtensions.cs
+++ b/src/ExpressiveSharp/Extensions/ExpressionExtensions.cs
@@ -6,17 +6,14 @@ namespace ExpressiveSharp;
 public static class ExpressionExtensions
 {
     /// <summary>
-    /// Replaces all calls to properties and methods that are marked with the <c>Expressive</c>
-    /// attribute with their respective expression trees, then applies any globally registered
-    /// default transformers (see <see cref="ExpressiveOptions.Default"/>).
+    /// Replaces calls to <c>[Expressive]</c> members with their generated expression trees,
+    /// then applies the transformers registered on <see cref="ExpressiveOptions.Default"/>.
     /// </summary>
     public static Expression ExpandExpressives(this Expression expression)
         => expression.ExpandExpressives(ExpressiveOptions.Default);
 
     /// <summary>
-    /// Replaces all calls to properties and methods that are marked with the <c>Expressive</c>
-    /// attribute with their respective expression trees, then applies transformers from the
-    /// specified <see cref="ExpressiveOptions"/> instance.
+    /// Like <see cref="ExpandExpressives(Expression)"/> but uses transformers from the given options.
     /// </summary>
     public static Expression ExpandExpressives(this Expression expression, ExpressiveOptions options)
     {
@@ -30,9 +27,7 @@ public static class ExpressionExtensions
     }
 
     /// <summary>
-    /// Replaces all calls to properties and methods that are marked with the <c>Expressive</c>
-    /// attribute with their respective expression trees, then applies the specified transformers
-    /// (instead of the global defaults).
+    /// Like <see cref="ExpandExpressives(Expression)"/> but uses the explicitly supplied transformers.
     /// </summary>
     public static Expression ExpandExpressives(
         this Expression expression,

--- a/src/ExpressiveSharp/Extensions/ExpressiveQueryableExtensions.cs
+++ b/src/ExpressiveSharp/Extensions/ExpressiveQueryableExtensions.cs
@@ -2,26 +2,20 @@ using System.Linq;
 
 namespace ExpressiveSharp
 {
-    /// <summary>
-    /// Entry-point extension methods for the <see cref="IExpressiveQueryable{T}"/> query chain.
-    /// </summary>
     public static class ExpressiveQueryableExtensions
     {
         /// <summary>
-        /// Wraps an <see cref="IQueryable{T}"/> in an <see cref="IExpressiveQueryable{T}"/> to enable
-        /// delegate-based LINQ overloads that support modern C# syntax (null-conditional operators, etc.)
-        /// via compile-time source generator interception.
+        /// Wraps an <see cref="IQueryable{T}"/> in an <see cref="IExpressiveQueryable{T}"/> so that
+        /// delegate-based LINQ overloads supporting modern C# syntax become available.
         /// </summary>
-        /// <param name="source">The queryable source to wrap.</param>
         /// <param name="options">
-        /// Options controlling how inline lambda bodies are rewritten to expression trees.
-        /// This value is read by the source generator at compile time; it is ignored at runtime.
+        /// Read by the source generator at compile time; ignored at runtime.
         /// </param>
         public static IExpressiveQueryable<T> AsExpressive<T>(
             this IQueryable<T> source,
             ExpressionRewriteOptions? options = null)
             // If the source is already an IExpressiveQueryable<T> (e.g. a provider-specific
-            // wrapper like ExpressiveMongoQueryable<T>), return it unchanged so that any
+            // wrapper like ExpressiveMongoQueryable<T>), return it unchanged so any
             // additional interfaces it implements (IAsyncCursorSource<T>, IAsyncEnumerable<T>,
             // etc.) remain observable through the returned reference.
             => source as IExpressiveQueryable<T>

--- a/src/ExpressiveSharp/Extensions/ExpressiveQueryableLinqExtensions.cs
+++ b/src/ExpressiveSharp/Extensions/ExpressiveQueryableLinqExtensions.cs
@@ -8,17 +8,12 @@ namespace ExpressiveSharp
 {
     /// <summary>
     /// Delegate-based LINQ overloads on <see cref="IExpressiveQueryable{T}"/> that shadow the
-    /// <see cref="Queryable"/> extension methods. These stubs are intercepted at compile time by
-    /// the ExpressiveSharp source generator, which rewrites the inline lambda body
-    /// into an expression tree and routes the call to the corresponding <see cref="IQueryable{T}"/>
-    /// operator. Do not call these methods directly.
+    /// <see cref="Queryable"/> methods. The source generator rewrites the inline lambda body to an
+    /// expression tree and routes the call to the corresponding <see cref="IQueryable{T}"/> operator.
+    /// These are picked over the <see cref="Queryable"/> overloads because
+    /// <see cref="IExpressiveQueryable{T}"/> is more specific than <see cref="IQueryable{T}"/>.
+    /// Do not call directly.
     /// </summary>
-    /// <remarks>
-    /// These methods are hidden from IntelliSense. The C# compiler resolves them in preference to the
-    /// <see cref="Queryable"/> equivalents because <see cref="IExpressiveQueryable{T}"/> is a more specific
-    /// type than <see cref="IQueryable{T}"/>, which causes the delegate-accepting overload to win,
-    /// allowing modern C# syntax (null-conditional operators, pattern matching, etc.) to compile.
-    /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class ExpressiveQueryableLinqExtensions
     {
@@ -87,8 +82,6 @@ namespace ExpressiveSharp
             Func<T, TKey> keySelector)
             => throw new UnreachableException(InterceptedMessage);
 
-        // ── Partitioning ─────────────────────────────────────────────────────
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IExpressiveQueryable<T> TakeWhile<T>(
             this IExpressiveQueryable<T> source,
@@ -101,8 +94,6 @@ namespace ExpressiveSharp
             Func<T, bool> predicate)
             => throw new UnreachableException(InterceptedMessage);
 
-        // ── Set operations with key selector ─────────────────────────────────
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IExpressiveQueryable<T> DistinctBy<T, TKey>(
             this IExpressiveQueryable<T> source,
@@ -110,16 +101,12 @@ namespace ExpressiveSharp
             => throw new UnreachableException(InterceptedMessage);
 
 #if NET9_0_OR_GREATER
-        // ── .NET 9+ methods ──────────────────────────────────────────────────
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IExpressiveQueryable<KeyValuePair<TKey, int>> CountBy<T, TKey>(
             this IExpressiveQueryable<T> source,
             Func<T, TKey> keySelector)
             => throw new UnreachableException(InterceptedMessage);
 #endif
-
-        // ── Predicate methods (scalar-returning) ─────────────────────────────
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool Any<T>(
@@ -144,8 +131,6 @@ namespace ExpressiveSharp
             this IExpressiveQueryable<T> source,
             Func<T, bool> predicate)
             => throw new UnreachableException(InterceptedMessage);
-
-        // ── Element methods (scalar-returning) ───────────────────────────────
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static T First<T>(
@@ -182,8 +167,6 @@ namespace ExpressiveSharp
             this IExpressiveQueryable<T> source,
             Func<T, bool> predicate)
             => throw new UnreachableException(InterceptedMessage);
-
-        // ── Aggregation: Sum ─────────────────────────────────────────────────
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static int Sum<T>(
@@ -245,8 +228,6 @@ namespace ExpressiveSharp
             Func<T, decimal?> selector)
             => throw new UnreachableException(InterceptedMessage);
 
-        // ── Aggregation: Average ─────────────────────────────────────────────
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static double Average<T>(
             this IExpressiveQueryable<T> source,
@@ -306,8 +287,6 @@ namespace ExpressiveSharp
             this IExpressiveQueryable<T> source,
             Func<T, decimal?> selector)
             => throw new UnreachableException(InterceptedMessage);
-
-        // ── Aggregation: Min / Max ───────────────────────────────────────────
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static TResult Min<T, TResult>(
@@ -399,8 +378,6 @@ namespace ExpressiveSharp
             => Queryable.Index(source).AsExpressive();
 #endif
 
-        // ── Non-lambda-first intercepted methods ─────────────────────────────
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IExpressiveQueryable<TResult> Zip<T, TSecond, TResult>(
             this IExpressiveQueryable<T> source,
@@ -434,8 +411,6 @@ namespace ExpressiveSharp
             IEnumerable<TKey> second,
             Func<T, TKey> keySelector)
             => throw new UnreachableException(InterceptedMessage);
-
-        // ── Multi-lambda methods ─────────────────────────────────────────────
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IExpressiveQueryable<IGrouping<TKey, TElement>> GroupBy<T, TKey, TElement>(
@@ -514,8 +489,6 @@ namespace ExpressiveSharp
             Func<TAccumulate, T, TAccumulate> func)
             => throw new UnreachableException(InterceptedMessage);
 #endif
-
-        // ── IEqualityComparer / IComparer overloads (intercepted) ────────────
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IExpressiveQueryable<T> OrderBy<T, TKey>(

--- a/src/ExpressiveSharp/Extensions/TypeExtensions.cs
+++ b/src/ExpressiveSharp/Extensions/TypeExtensions.cs
@@ -6,7 +6,7 @@ internal static class TypeExtensions
 {
     public static Type[] GetNestedTypePath(this Type type)
     {
-        // First pass: count the nesting depth so we can size the array exactly.
+        // First pass: measure depth so we can allocate the array exactly.
         var depth = 0;
         var current = type;
         while (true)
@@ -20,7 +20,7 @@ internal static class TypeExtensions
             current = current.DeclaringType;
         }
 
-        // Second pass: fill the array outermost-first by walking back from the leaf.
+        // Second pass: fill outermost-first by walking back from the leaf.
         var path = new Type[depth];
         current = type;
         for (var i = depth - 1; i >= 0; i--)
@@ -34,7 +34,7 @@ internal static class TypeExtensions
 
     private static bool CanHaveOverridingMethod(this Type derivedType, MethodInfo methodInfo)
     {
-        // We only need to search for virtual instance methods who are not declared on the derivedType
+        // Only virtual instance methods not already declared on derivedType can be overridden.
         if (derivedType == methodInfo.DeclaringType || methodInfo.IsStatic || !methodInfo.IsVirtual)
         {
             return false;
@@ -68,7 +68,7 @@ internal static class TypeExtensions
                 => derivedMethodInfo.IsOverridingMethodOf(baseDefinition));
         }
 
-        return overridingMethod ?? methodInfo; // If no derived methods were found, return the original methodInfo
+        return overridingMethod ?? methodInfo;
     }
 
     private static PropertyInfo GetOverridingProperty(this Type derivedType, PropertyInfo propertyInfo)
@@ -91,13 +91,12 @@ internal static class TypeExtensions
                 => (isGetAccessor ? p.GetMethod : p.SetMethod)?.IsOverridingMethodOf(baseDefinition) == true);
         }
 
-        return overridingProperty ?? propertyInfo; // If no derived methods were found, return the original methodInfo
+        return overridingProperty ?? propertyInfo;
     }
 
     private static MethodInfo GetImplementingMethod(this Type derivedType, MethodInfo methodInfo)
     {
         var interfaceType = methodInfo.DeclaringType;
-        // We only need to search for interface methods
         if (interfaceType?.IsInterface != true || derivedType.IsInterface || methodInfo.IsStatic || !methodInfo.IsVirtual)
         {
             return methodInfo;

--- a/src/ExpressiveSharp/IExpressiveQueryable.cs
+++ b/src/ExpressiveSharp/IExpressiveQueryable.cs
@@ -3,16 +3,11 @@ using System.Linq;
 namespace ExpressiveSharp
 {
     /// <summary>
-    /// Represents a queryable sequence with expression-rewrite support. Extends <see cref="IQueryable{T}"/> so that all
-    /// standard EF Core and LINQ queryable extensions remain available, while also exposing
-    /// delegate-based overloads of common LINQ operators (Where, Select, OrderBy, etc.) that allow
-    /// modern C# syntax — such as null-conditional operators — to be used in inline lambdas.
+    /// Queryable sequence with expression-rewrite support. Extends <see cref="IQueryable{T}"/>
+    /// so existing LINQ/EF Core extensions remain available, and exposes delegate-based
+    /// overloads of common operators that the source generator rewrites into expression trees,
+    /// allowing modern C# syntax (null-conditional, pattern matching, etc.) in inline lambdas.
     /// </summary>
-    /// <remarks>
-    /// The delegate-based overloads are intercepted at compile time by the
-    /// ExpressiveSharp source generator, which rewrites the lambda body into an
-    /// expression tree using the same rewrite rules as <see cref="ExpressiveAttribute"/>.
-    /// </remarks>
     public interface IExpressiveQueryable<T> : IQueryable<T>
     {
     }

--- a/src/ExpressiveSharp/Services/ExpressionClassNameGenerator.cs
+++ b/src/ExpressiveSharp/Services/ExpressionClassNameGenerator.cs
@@ -35,8 +35,7 @@ namespace ExpressiveSharp.Services
         }
 
         /// <summary>
-        /// Generates the class-level name (without member or parameter suffixes) for the
-        /// consolidated partial class that holds all expression methods for a given type.
+        /// Class-level name (no member/parameter suffix) for the consolidated partial class.
         /// </summary>
         public static string GenerateClassName(string? namespaceName, IEnumerable<string>? nestedInClassNames)
         {
@@ -45,8 +44,7 @@ namespace ExpressiveSharp.Services
         }
 
         /// <summary>
-        /// Generates the fully-qualified class name (with <see cref="Namespace"/> prefix)
-        /// for the consolidated partial class.
+        /// Same as <see cref="GenerateClassName"/> but prefixed with <see cref="Namespace"/>.
         /// </summary>
         public static string GenerateClassFullName(string? namespaceName, IEnumerable<string>? nestedInClassNames)
         {
@@ -56,9 +54,7 @@ namespace ExpressiveSharp.Services
         }
 
         /// <summary>
-        /// Generates the method suffix that encodes a member name and its parameter types.
-        /// The result is used as a method name prefix (e.g. "Add_P0_int") within the
-        /// consolidated partial class.
+        /// Method-name suffix encoding a member and its parameter types (e.g. "Add_P0_int").
         /// </summary>
         public static string GenerateMethodSuffix(string memberName, IEnumerable<string>? parameterTypeNames)
         {
@@ -142,7 +138,6 @@ namespace ExpressiveSharp.Services
 
         static string GenerateNameImpl(StringBuilder stringBuilder, string? namespaceName, IEnumerable<string>? nestedInClassNames, string memberName, IEnumerable<string>? parameterTypeNames)
         {
-            // Append namespace, replacing '.' separators with '_' in a single pass (no intermediate string).
             if (namespaceName is not null)
             {
                 foreach (var c in namespaceName)
@@ -179,7 +174,7 @@ namespace ExpressiveSharp.Services
 
             }
 
-            // Append member name; only allocate a replacement string for the rare explicit-interface case.
+            // Explicit interface members contain '.', which is invalid in identifiers.
             if (memberName.IndexOf('.') >= 0)
             {
                 stringBuilder.Append(memberName.Replace(".", "__"));
@@ -189,7 +184,7 @@ namespace ExpressiveSharp.Services
                 stringBuilder.Append(memberName);
             }
 
-            // Add parameter types to make method overloads unique
+            // Encode parameter types so overloaded methods produce distinct names.
             if (parameterTypeNames is not null)
             {
                 var parameterIndex = 0;
@@ -198,15 +193,12 @@ namespace ExpressiveSharp.Services
                     stringBuilder.Append("_P");
                     stringBuilder.Append(parameterIndex);
                     stringBuilder.Append('_');
-                    // Single-pass sanitization: replace invalid identifier characters with '_',
-                    // stripping the "global::" prefix on the fly — avoids 9 intermediate string allocations.
                     AppendSanitizedTypeName(stringBuilder, parameterTypeName);
                     parameterIndex++;
                 }
             }
 
-            // Add generic arity at the very end (after parameter types)
-            // This matches how the CLR names generic types
+            // Generic arity goes at the very end to match CLR generic naming.
             if (arity > 0)
             {
                 stringBuilder.Append('`');
@@ -217,9 +209,8 @@ namespace ExpressiveSharp.Services
         }
 
         /// <summary>
-        /// Appends <paramref name="typeName"/> to <paramref name="sb"/>, stripping the
-        /// <c>global::</c> prefix and replacing every character that is invalid in a C# identifier
-        /// with <c>'_'</c> — all in a single pass with no intermediate string allocations.
+        /// Strips the <c>global::</c> prefix and replaces every character invalid in a C#
+        /// identifier with <c>'_'</c>.
         /// </summary>
         private static void AppendSanitizedTypeName(StringBuilder sb, string typeName)
         {

--- a/src/ExpressiveSharp/Services/ExpressiveHotReloadHandler.cs
+++ b/src/ExpressiveSharp/Services/ExpressiveHotReloadHandler.cs
@@ -18,11 +18,8 @@ internal static class ExpressiveHotReloadHandler
 
     public static void UpdateApplication(Type[]? updatedTypes) => ClearCache(updatedTypes);
 
-    /// <summary>
-    /// When the runtime tells us which types changed, use their assemblies directly.
-    /// Fall back to a full scan only when <paramref name="updatedTypes"/> is null or empty,
-    /// which the runtime may do for large/unknown change sets.
-    /// </summary>
+    // Falls back to scanning every loaded assembly when updatedTypes is null/empty,
+    // which the runtime does for large or unknown change sets.
     private static IEnumerable<Assembly> SelectAffectedAssemblies(Type[]? updatedTypes)
     {
         if (updatedTypes is { Length: > 0 })
@@ -38,11 +35,8 @@ internal static class ExpressiveHotReloadHandler
         return AppDomain.CurrentDomain.GetAssemblies();
     }
 
-    /// <summary>
-    /// Invokes <c>ResetMap()</c> on each assembly's generated <c>ExpressionRegistry</c> class
-    /// (when present) so the next <c>TryGet</c> rebuilds <c>LambdaExpression</c> instances
-    /// from the hot-reloaded factory IL.
-    /// </summary>
+    // Invokes ResetMap() on each assembly's generated ExpressionRegistry so the next
+    // TryGet rebuilds LambdaExpression instances from the hot-reloaded factory IL.
     private static void ResetGeneratedRegistries(IEnumerable<Assembly> assemblies)
     {
         foreach (var assembly in assemblies)

--- a/src/ExpressiveSharp/Services/ExpressiveOptions.cs
+++ b/src/ExpressiveSharp/Services/ExpressiveOptions.cs
@@ -1,16 +1,11 @@
 namespace ExpressiveSharp.Services;
 
 /// <summary>
-/// Configuration for expression tree transformers applied by
-/// <see cref="Extensions.ExpressionExtensions.ExpandExpressives(System.Linq.Expressions.Expression)"/>.
-/// Use <see cref="Default"/> for the global instance, or create new instances for isolated scenarios.
+/// Set of transformers applied by <c>ExpandExpressives()</c>. Use <see cref="Default"/>
+/// for the global instance, or new instances for isolated scenarios.
 /// </summary>
 public class ExpressiveOptions
 {
-    /// <summary>
-    /// The global default instance used by the parameterless
-    /// <see cref="Extensions.ExpressionExtensions.ExpandExpressives(System.Linq.Expressions.Expression)"/> overload.
-    /// </summary>
     public static ExpressiveOptions Default { get; } = new();
 
     private readonly List<IExpressionTreeTransformer> _transformers = [];
@@ -20,10 +15,6 @@ public class ExpressiveOptions
     private readonly object _lock = new();
 #endif
 
-    /// <summary>
-    /// Registers additional transformers that will be applied to
-    /// <c>ExpandExpressives()</c> calls using this instance.
-    /// </summary>
     public void AddTransformers(params IExpressionTreeTransformer[] transformers)
     {
         lock (_lock)
@@ -32,9 +23,6 @@ public class ExpressiveOptions
         }
     }
 
-    /// <summary>
-    /// Clears all registered transformers on this instance.
-    /// </summary>
     public void ClearTransformers()
     {
         lock (_lock)
@@ -43,9 +31,6 @@ public class ExpressiveOptions
         }
     }
 
-    /// <summary>
-    /// Returns a snapshot of the currently registered transformers.
-    /// </summary>
     public IReadOnlyList<IExpressionTreeTransformer> GetTransformers()
     {
         lock (_lock)

--- a/src/ExpressiveSharp/Services/ExpressiveReplacer.cs
+++ b/src/ExpressiveSharp/Services/ExpressiveReplacer.cs
@@ -7,10 +7,9 @@ using ExpressiveSharp.Extensions;
 namespace ExpressiveSharp.Services;
 
 /// <summary>
-/// Expression visitor that replaces calls to members marked with <see cref="ExpressiveAttribute"/>
-/// with their generated expression tree equivalents. This is the generic base class; EF Core-specific
-/// subclasses can override <see cref="VisitMethodCallCore"/> and <see cref="VisitExtension"/> to add
-/// query provider awareness.
+/// Replaces calls to <see cref="ExpressiveAttribute"/>-marked members with their generated
+/// expression trees. EF Core-specific subclasses override <see cref="VisitMethodCallCore"/>
+/// and <see cref="VisitExtension"/> to add query-provider awareness.
 /// </summary>
 public class ExpressiveReplacer : ExpressionVisitor
 {
@@ -70,7 +69,6 @@ public class ExpressiveReplacer : ExpressionVisitor
             node = node.Update(node.Object, updatedArgs);
         }
 
-        // Allow subclasses to hook into method call processing (e.g., tracking detection).
         VisitMethodCallCore(node);
 
         var methodInfo = node.Object?.Type.GetConcreteMethod(node.Method) ?? node.Method;

--- a/src/ExpressiveSharp/Services/ExpressiveResolver.cs
+++ b/src/ExpressiveSharp/Services/ExpressiveResolver.cs
@@ -11,19 +11,15 @@ namespace ExpressiveSharp.Services
 {
     public sealed class ExpressiveResolver : IExpressiveResolver
     {
-        // We never store null in the dictionary; assemblies without a registry use a sentinel delegate.
+        // Sentinel delegate for assemblies without a registry; ConcurrentDictionary forbids null values.
         private readonly static Func<MemberInfo, LambdaExpression> _nullRegistry = static _ => null!;
         private readonly static ConcurrentDictionary<Assembly, Func<MemberInfo, LambdaExpression>> _assemblyRegistries = new();
 
-        /// <summary>
-        /// Caches the fully-resolved <see cref="LambdaExpression"/> per <see cref="MemberInfo"/> so that
-        /// EF Core never repeats reflection work for the same member across queries.
-        /// </summary>
         private readonly static ConcurrentDictionary<MemberInfo, LambdaExpression> _expressionCache = new();
 
         /// <summary>
-        /// Clears all process-level caches built up by the resolver. Intended for test harnesses
-        /// and the docs prerenderer, where many short-lived snippet assemblies are loaded in sequence.
+        /// Clears all process-level caches. For test harnesses and the docs prerenderer, where many
+        /// short-lived snippet assemblies are loaded in sequence.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         internal static void ResetAllCaches()
@@ -36,10 +32,9 @@ namespace ExpressiveSharp.Services
         }
 
         /// <summary>
-        /// Invalidates cached expression trees so the next lookup rebuilds from the (possibly
-        /// hot-reloaded) generated factory method. Called from <see cref="ExpressiveHotReloadHandler"/>.
-        /// Preserves <c>_assemblyScanFilter</c> and <c>_typeNameCache</c> — neither goes stale on
-        /// non-rude edits, and wiping the filter would silently disable a user-configured restriction.
+        /// Invalidates cached expression trees on hot-reload. Preserves <c>_assemblyScanFilter</c>
+        /// (wiping it would silently disable a user-configured restriction) and <c>_typeNameCache</c>
+        /// (does not go stale on non-rude edits).
         /// </summary>
         internal static void ClearCachesForMetadataUpdate()
         {
@@ -66,17 +61,8 @@ namespace ExpressiveSharp.Services
             Volatile.Write(ref _lastScannedAssemblyCount, 0);
         }
 
-        /// <summary>
-        /// Caches <see cref="Type"/> → C#-formatted name strings, since the same parameter types
-        /// appear repeatedly across different expressive members.
-        /// </summary>
         private readonly static ConditionalWeakTable<Type, string> _typeNameCache = new();
 
-        /// <summary>
-        /// O(1) hash-table lookup replacing the original 16 sequential <c>if</c> checks.
-        /// Rearranging the entries has no effect on lookup cost (hash-based), but the most common
-        /// EF Core types (<c>int</c>, <c>string</c>, <c>bool</c>) are listed first for readability.
-        /// </summary>
         private readonly static Dictionary<Type, string> _csharpKeywords = new(16)
         {
             [typeof(int)]     = "int",
@@ -97,9 +83,8 @@ namespace ExpressiveSharp.Services
         };
 
         /// <summary>
-        /// Looks up the generated <c>ExpressionRegistry</c> class in an assembly (once, then caches it).
-        /// Returns a delegate that calls <c>TryGet(MemberInfo)</c> on the registry, or null if the registry
-        /// is not present in that assembly (e.g. if the source generator was not run against it).
+        /// Returns a delegate calling <c>TryGet(MemberInfo)</c> on the assembly's generated
+        /// <c>ExpressionRegistry</c>, or null if the source generator did not run for this assembly.
         /// </summary>
         private static Func<MemberInfo, LambdaExpression>? GetAssemblyRegistry(Assembly assembly)
         {
@@ -109,15 +94,11 @@ namespace ExpressiveSharp.Services
                 var tryGetMethod = registryType?.GetMethod("TryGet", BindingFlags.Static | BindingFlags.Public);
 
                 if (tryGetMethod is null)
-                {
-                    // Use sentinel to indicate "no registry for this assembly"
                     return _nullRegistry;
-                }
 
                 return (Func<MemberInfo, LambdaExpression>)Delegate.CreateDelegate(typeof(Func<MemberInfo, LambdaExpression>), tryGetMethod);
             });
 
-            // Translate sentinel back to null for callers, preserving existing behavior.
             return ReferenceEquals(registry, _nullRegistry) ? null : registry;
         }
 
@@ -129,8 +110,7 @@ namespace ExpressiveSharp.Services
         /// <inheritdoc/>
         public LambdaExpression? FindExternalExpression(MemberInfo memberInfo)
         {
-            // Ensure all loaded assemblies with registries have been discovered.
-            // This handles the edge case where only [ExpressiveFor] is used (no [Expressive] members)
+            // Handles the case where only [ExpressiveFor] is used (no [Expressive] members)
             // and no assembly registry has been lazily loaded yet.
             EnsureAllRegistriesLoaded();
 
@@ -173,8 +153,8 @@ namespace ExpressiveSharp.Services
         private static readonly object _scanLock = new();
 
         /// <summary>
-        /// Scans loaded assemblies for expression registries. Rescans when new assemblies
-        /// have been loaded since the previous scan (matters for runtime-compiled assemblies).
+        /// Rescans when new assemblies have been loaded since the previous scan
+        /// (matters for runtime-compiled assemblies).
         /// </summary>
         private static void EnsureAllRegistriesLoaded()
         {
@@ -203,9 +183,8 @@ namespace ExpressiveSharp.Services
         }
 
         /// <summary>
-        /// Ensures the registry for the given assembly is loaded into <see cref="_assemblyRegistries"/>.
-        /// Call this for assemblies that may contain [ExpressiveFor] stubs but no [Expressive] members
-        /// (which would otherwise trigger lazy loading).
+        /// Call this for assemblies that may contain [ExpressiveFor] stubs but no [Expressive]
+        /// members (which would otherwise trigger lazy loading).
         /// </summary>
         public static void EnsureRegistryLoaded(Assembly assembly)
         {
@@ -240,44 +219,23 @@ namespace ExpressiveSharp.Services
         {
             var declaringType = expressiveMemberInfo.DeclaringType ?? throw new InvalidOperationException("Expected a valid type here");
 
-            // Fast path: check the per-assembly static registry (generated by source generator).
-            // The first call per assembly does a reflection lookup to find the registry class and
-            // caches it as a delegate; subsequent calls use the cached delegate for an O(1) dictionary lookup.
+            // Fast path: per-assembly generated static registry.
             var registry = GetAssemblyRegistry(declaringType.Assembly);
             var registeredExpr = registry?.Invoke(expressiveMemberInfo);
 
-            return registeredExpr ??
-                   // Slow path: reflection fallback for open-generic class members and generic methods
-                   // that are not yet in the registry.
-                   FindGeneratedExpressionViaReflection(expressiveMemberInfo);
+            // Slow path: reflection fallback for open-generic class members and generic methods not yet in the registry.
+            return registeredExpr ?? FindGeneratedExpressionViaReflection(expressiveMemberInfo);
         }
 
-        /// <summary>
-        /// Sentinel stored in <see cref="_reflectionCache"/> to represent
-        /// "no generated type found for this member", distinguishing it from a not-yet-populated entry.
-        /// <see cref="ConcurrentDictionary{TKey,TValue}"/> does not allow null values, so a sentinel is required.
-        /// </summary>
+        // Sentinel for "no generated type found" — ConcurrentDictionary forbids null values.
         private readonly static LambdaExpression _reflectionNullSentinel =
             Expression.Lambda(Expression.Empty());
 
-        /// <summary>
-        /// Caches the fully-resolved <see cref="LambdaExpression"/> per <see cref="MemberInfo"/>
-        /// for the reflection-based slow path.
-        /// On the first call per member the reflection work (<c>Assembly.GetType</c>, <c>GetMethod</c>,
-        /// <c>MakeGenericType</c>, <c>MakeGenericMethod</c>) is performed once and the resulting
-        /// expression tree is stored here; subsequent calls return the cached reference directly,
-        /// eliminating expression-tree re-construction on every access.
-        /// This is especially important for constructors whose object-initializer trees are
-        /// significantly more expensive to build than simple method-body trees.
-        /// </summary>
         private readonly static ConcurrentDictionary<MemberInfo, LambdaExpression> _reflectionCache = new();
 
         /// <summary>
-        /// Resolves the <see cref="LambdaExpression"/> for an <c>[Expressive]</c> member using the
-        /// reflection-based slow path only, bypassing the static registry.
-        /// The result is cached after the first call, so subsequent calls return the cached expression
-        /// without any reflection or expression-tree construction overhead.
-        /// Useful for members not yet in the registry (e.g. open-generic types).
+        /// Reflection-based slow path, bypassing the static registry. Useful for members not yet
+        /// in the registry (e.g. open-generic types). Result is cached.
         /// </summary>
         public static LambdaExpression? FindGeneratedExpressionViaReflection(MemberInfo expressiveMemberInfo)
         {
@@ -287,16 +245,8 @@ namespace ExpressiveSharp.Services
         }
 
         /// <summary>
-        /// Performs the one-time reflection work for a member: locates the generated expression
-        /// accessor (inline or external-class path), invokes it, and returns the resulting
-        /// <see cref="LambdaExpression"/>. Returns <c>null</c> if no generated type is found.
-        /// <para>
-        /// Using <c>MethodInfo.Invoke</c> rather than a compiled delegate is appropriate here because
-        /// the result is cached in <see cref="_reflectionCache"/> — the invocation cost is paid only
-        /// on cache misses, and subsequent EF Core queries reuse the cached expression. Under
-        /// contention the value factory may be invoked more than once, but only a single expression
-        /// instance is ultimately stored per member.
-        /// </para>
+        /// One-time reflection work. <c>MethodInfo.Invoke</c> is fine here because the result is
+        /// cached — invocation cost is paid only on cache misses.
         /// </summary>
         private static LambdaExpression? BuildReflectionExpression(MemberInfo expressiveMemberInfo)
         {
@@ -305,20 +255,18 @@ namespace ExpressiveSharp.Services
 
             var originalDeclaringType = declaringType;
 
-            // For generic types, use the generic type definition to match the generated name.
+            // Use the generic type definition to match the generated name.
             if (declaringType.IsGenericType && !declaringType.IsGenericTypeDefinition)
             {
                 declaringType = declaringType.GetGenericTypeDefinition();
             }
 
-            // Build parameter type name array with a plain for-loop — avoids IEnumerator + delegate allocations.
             string[]? parameterTypeNames = null;
             var memberLookupName = expressiveMemberInfo.Name;
 
             if (expressiveMemberInfo is MethodInfo method)
             {
-                // For generic methods, use the generic definition so type parameters (TEntity, etc.)
-                // are used instead of the concrete closed-generic arguments.
+                // Use the generic definition so type parameters (TEntity, etc.) are used instead of closed-generic arguments.
                 var methodToInspect = method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
                 var parameters = methodToInspect.GetParameters();
 
@@ -333,7 +281,7 @@ namespace ExpressiveSharp.Services
             }
             else if (expressiveMemberInfo is ConstructorInfo ctor)
             {
-                // Constructors are stored under the synthetic name "_ctor".
+                // Constructors are registered under the synthetic name "_ctor".
                 memberLookupName = "_ctor";
                 var parameters = ctor.GetParameters();
 
@@ -347,7 +295,6 @@ namespace ExpressiveSharp.Services
                 }
             }
 
-            // Build the generated class name (without member) and method suffix separately.
             var nestedTypeNames = NestedTypePathToNames(declaringType.GetNestedTypePath());
             var generatedContainingTypeName = ExpressionClassNameGenerator.GenerateClassFullName(
                 declaringType.Namespace,
@@ -386,7 +333,6 @@ namespace ExpressiveSharp.Services
             if (expression is null)
                 return null;
 
-            // Apply declared transformers from the generated class (if any)
             var transformerMethodName = methodSuffix + "_Transformers";
             var transformersMethod = expressionFactoryType.GetMethod(transformerMethodName, BindingFlags.Static | BindingFlags.NonPublic);
             if (transformersMethod?.Invoke(null, null) is IExpressionTreeTransformer[] transformers)
@@ -402,11 +348,6 @@ namespace ExpressiveSharp.Services
             return expression;
         }
 
-        /// <summary>
-        /// Projects an array of <see cref="Type"/> objects — in practice always the
-        /// <c>Type[]</c> returned by <see cref="ExpressiveSharp.Extensions.TypeExtensions.GetNestedTypePath"/> — to a <c>string[]</c>
-        /// of simple type names without allocating a LINQ enumerator or intermediate delegate.
-        /// </summary>
         private static string[] NestedTypePathToNames(Type[] types)
         {
             var names = new string[types.Length];
@@ -418,36 +359,27 @@ namespace ExpressiveSharp.Services
             return names;
         }
 
-        /// <summary>
-        /// Returns the C#-formatted full name of <paramref name="type"/>.
-        /// Results are memoised in <see cref="_typeNameCache"/>; the same <see cref="Type"/> object
-        /// is encountered repeatedly across expressive members (e.g. <c>int</c>, <c>string</c>).
-        /// </summary>
         private static string GetFullTypeName(Type type)
             => _typeNameCache.GetValue(type, static t => ComputeFullTypeName(t));
 
         private static string ComputeFullTypeName(Type type)
         {
-            // Handle generic type parameters (e.g., T, TEntity)
             if (type.IsGenericParameter)
             {
                 return type.Name;
             }
 
-            // Handle nullable value types (e.g., int? -> int?)
             var underlyingType = Nullable.GetUnderlyingType(type);
             if (underlyingType != null)
             {
                 return $"{GetFullTypeName(underlyingType)}?";
             }
 
-            // Handle array types
             if (type.IsArray)
             {
                 var elementType = type.GetElementType();
                 if (elementType == null)
                 {
-                    // Fallback for edge cases where GetElementType() might return null
                     return type.Name;
                 }
 
@@ -465,21 +397,20 @@ namespace ExpressiveSharp.Services
                 }
             }
 
-            // Map primitive types to their C# keyword equivalents to match Roslyn's output
+            // Map primitives to C# keywords to match Roslyn's output.
             var typeKeyword = GetCSharpKeyword(type);
             if (typeKeyword != null)
             {
                 return typeKeyword;
             }
 
-            // For generic types, construct the full name matching Roslyn's format
             if (type.IsGenericType)
             {
                 var genericTypeDef = type.GetGenericTypeDefinition();
                 var genericArgs = type.GetGenericArguments();
                 var baseName = genericTypeDef.FullName ?? genericTypeDef.Name;
 
-                // Remove the `n suffix (e.g., `1, `2)
+                // Strip the `n arity suffix.
                 var backtickIndex = baseName.IndexOf('`');
                 if (backtickIndex > 0)
                 {
@@ -492,20 +423,13 @@ namespace ExpressiveSharp.Services
 
             if (type.FullName != null)
             {
-                // Replace + with . for nested types to match Roslyn's format
+                // + → . for nested types to match Roslyn's format.
                 return type.FullName.Replace('+', '.');
             }
 
             return type.Name;
         }
 
-        /// <summary>
-        /// O(1) dictionary lookup — replaces the original 16 sequential <c>if</c> checks.
-        /// Note: reordering the entries in <see cref="_csharpKeywords"/> has <em>no effect</em> on
-        /// performance because <see cref="Dictionary{TKey,TValue}"/> uses hashing, not linear scan.
-        /// (Reordering only mattered with the old <c>if</c>-chain, where placing <c>int</c> / <c>string</c>
-        /// / <c>bool</c> first would have reduced average comparisons from ~8 to ~1.)
-        /// </summary>
         private static string? GetCSharpKeyword(Type type) => _csharpKeywords.GetValueOrDefault(type);
     }
 }

--- a/src/ExpressiveSharp/Transformers/ConvertLoopsToLinq.cs
+++ b/src/ExpressiveSharp/Transformers/ConvertLoopsToLinq.cs
@@ -30,10 +30,9 @@ public sealed class ConvertLoopsToLinq : ExpressionVisitor, IExpressionTreeTrans
 
     protected override Expression VisitBlock(BlockExpression node)
     {
-        // First, recursively visit sub-expressions
         var visited = (BlockExpression)base.VisitBlock(node);
 
-        // Look for the foreach accumulator pattern:
+        // Foreach accumulator pattern:
         // Block([accumulator], [Assign(accumulator, init), innerBlock, accumulator])
         if (TryMatchForEachAccumulator(visited, out var result))
             return result;
@@ -89,7 +88,6 @@ public sealed class ConvertLoopsToLinq : ExpressionVisitor, IExpressionTreeTrans
             || innerBlock.Variables.Count != 2)
             return false;
 
-        // Find the enumerator and iteration variable
         // Inner block: [Assign(enumerator, Call(collection, GetEnumerator)), Loop(...)]
         if (innerBlock.Expressions.Count < 2)
             return false;
@@ -110,7 +108,6 @@ public sealed class ConvertLoopsToLinq : ExpressionVisitor, IExpressionTreeTrans
         if (collection is null)
             return false;
 
-        // Find the Loop expression
         if (innerBlock.Expressions[1] is not LoopExpression loop)
             return false;
 
@@ -122,11 +119,10 @@ public sealed class ConvertLoopsToLinq : ExpressionVisitor, IExpressionTreeTrans
 
         var loopBody = ifThenElse.IfTrue;
 
-        // The loop body block: Block(Assign(iterVar, Property(enum, Current)), <userBody>)
+        // Loop body block: Block(Assign(iterVar, Property(enum, Current)), <userBody>)
         if (loopBody is not BlockExpression bodyBlock || bodyBlock.Expressions.Count < 2)
             return false;
 
-        // First expression in body: Assign(iterVar, Property(enumerator, Current))
         if (bodyBlock.Expressions[0] is not BinaryExpression { NodeType: ExpressionType.Assign } currentAssign)
             return false;
 
@@ -134,15 +130,12 @@ public sealed class ConvertLoopsToLinq : ExpressionVisitor, IExpressionTreeTrans
         if (iterVar is null)
             return false;
 
-        // The user's loop body is the second expression (or remaining expressions in the block)
         var userBody = bodyBlock.Expressions.Count == 2
             ? bodyBlock.Expressions[1]
             : Expression.Block(bodyBlock.Expressions.Skip(1));
 
-        // Determine the element type from the iteration variable
         var elementType = iterVar.Type;
 
-        // Now match the user body against known patterns
         if (TryMatchCountPattern(userBody, accumulator, initValue, collection, iterVar, elementType, out result))
             return true;
 
@@ -525,8 +518,6 @@ public sealed class ConvertLoopsToLinq : ExpressionVisitor, IExpressionTreeTrans
 
         return true;
     }
-
-    // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static bool IsConstant(Expression expr, object? value)
     {

--- a/src/ExpressiveSharp/Transformers/FlattenBlockExpressions.cs
+++ b/src/ExpressiveSharp/Transformers/FlattenBlockExpressions.cs
@@ -3,27 +3,10 @@ using System.Linq.Expressions;
 namespace ExpressiveSharp.Transformers;
 
 /// <summary>
-/// Inlines block-local variables at their use sites and removes <see cref="BlockExpression"/>
-/// nodes, producing a single expression that typical LINQ providers (EF Core, etc.) can translate.
+/// Inlines single-assignment block-local variables and replaces the
+/// <see cref="BlockExpression"/> with its final result, producing a tree most LINQ providers
+/// (EF Core, etc.) can translate. Variables assigned multiple times are left untouched.
 /// </summary>
-/// <remarks>
-/// <para>
-/// Handles block expressions of the form:
-/// <code>
-/// Block([var1, var2], [
-///   Assign(var1, expr1),
-///   Assign(var2, expr2),      // may reference var1
-///   resultExpression           // may reference var1, var2
-/// ])
-/// </code>
-/// Each variable is replaced with its assigned expression at every use site, and
-/// the block is replaced with the final (result) expression.
-/// </para>
-/// <para>
-/// Limitations: variables that are assigned multiple times are not inlined — the
-/// block is left as-is in those cases.
-/// </para>
-/// </remarks>
 public sealed class FlattenBlockExpressions : ExpressionVisitor, IExpressionTreeTransformer
 {
     public Expression Transform(Expression expression)
@@ -31,19 +14,16 @@ public sealed class FlattenBlockExpressions : ExpressionVisitor, IExpressionTree
 
     protected override Expression VisitBlock(BlockExpression node)
     {
-        // First, recursively flatten any nested blocks in sub-expressions
         var visited = (BlockExpression)base.VisitBlock(node);
 
         if (visited.Variables.Count == 0)
         {
-            // No variables — just return the last expression (the result)
             return visited.Expressions.Count == 1
                 ? visited.Expressions[0]
                 : visited;
         }
 
-        // Build a map: variable → assigned expression.
-        // Only inline variables that have exactly one assignment.
+        // Only inline variables that have exactly one assignment; otherwise bail out.
         var assignments = new Dictionary<ParameterExpression, Expression>();
 
         foreach (var expr in visited.Expressions)
@@ -53,22 +33,17 @@ public sealed class FlattenBlockExpressions : ExpressionVisitor, IExpressionTree
                 && visited.Variables.Contains(variable))
             {
                 if (assignments.ContainsKey(variable))
-                {
-                    // Multiple assignments to the same variable — bail out entirely
                     return visited;
-                }
 
                 assignments[variable] = assign.Right;
             }
         }
 
-        // All block variables must have exactly one assignment for safe inlining
         if (assignments.Count != visited.Variables.Count)
             return visited;
 
-        // Resolve transitive dependencies in declaration order.
-        // E.g., var a = x * 2; var b = a + 1;
-        // → resolve a first, then when resolving b, substitute a's value in b's assignment.
+        // Resolve transitive references in declaration order so later variables see
+        // the already-inlined values of earlier ones (var a = x * 2; var b = a + 1).
         var resolved = new Dictionary<ParameterExpression, Expression>();
         foreach (var variable in visited.Variables)
         {
@@ -79,16 +54,10 @@ public sealed class FlattenBlockExpressions : ExpressionVisitor, IExpressionTree
             resolved[variable] = inlined;
         }
 
-        // The result is the last expression in the block
         var result = visited.Expressions[^1];
-
-        // Replace all variable references in the result expression
         return new VariableInliner(resolved).Visit(result);
     }
 
-    /// <summary>
-    /// Replaces <see cref="ParameterExpression"/> references with their inlined values.
-    /// </summary>
     private sealed class VariableInliner(IReadOnlyDictionary<ParameterExpression, Expression> replacements)
         : ExpressionVisitor
     {

--- a/src/ExpressiveSharp/Transformers/FlattenConcatArrayCalls.cs
+++ b/src/ExpressiveSharp/Transformers/FlattenConcatArrayCalls.cs
@@ -4,20 +4,10 @@ using System.Reflection;
 namespace ExpressiveSharp.Transformers;
 
 /// <summary>
-/// Rewrites <c>string.Concat(new string[] { a, b, c, ... })</c> into a chain of
-/// <c>string.Concat</c> calls using the 2-, 3-, or 4-arg overloads.
+/// Rewrites <c>string.Concat(new string[] { a, b, c, ... })</c> into a chain of 2/3/4-arg
+/// <c>string.Concat</c> calls so providers like EF Core (which can't translate <c>NewArrayInit</c>
+/// with non-constant elements) can emit SQL concatenation.
 /// </summary>
-/// <remarks>
-/// <para>
-/// EF Core and other LINQ providers cannot translate <c>NewArrayInit</c> with non-constant
-/// elements to SQL. This transformer flattens the array form into individual <c>Concat</c>
-/// calls that providers can translate to SQL string concatenation.
-/// </para>
-/// <para>
-/// For example, <c>string.Concat(new string[] { a, b, c, d, e })</c> becomes
-/// <c>string.Concat(string.Concat(a, b, c, d), e)</c>.
-/// </para>
-/// </remarks>
 public sealed class FlattenConcatArrayCalls : ExpressionVisitor, IExpressionTreeTransformer
 {
     private static readonly MethodInfo Concat2 = typeof(string).GetMethod(
@@ -36,7 +26,6 @@ public sealed class FlattenConcatArrayCalls : ExpressionVisitor, IExpressionTree
     {
         var visited = (MethodCallExpression)base.VisitMethodCall(node);
 
-        // Match: string.Concat(string[]) where the argument is NewArrayInit
         if (visited.Method.DeclaringType == typeof(string)
             && visited.Method.Name == nameof(string.Concat)
             && visited.Arguments.Count == 1
@@ -57,16 +46,11 @@ public sealed class FlattenConcatArrayCalls : ExpressionVisitor, IExpressionTree
         return visited;
     }
 
-    /// <summary>
-    /// Reduces a list of parts into chained Concat calls, consuming up to 4 parts
-    /// at a time starting from the left.
-    /// </summary>
     private static Expression ReduceParts(IList<Expression> parts)
     {
         var i = 0;
         Expression current;
 
-        // First chunk: consume up to 4
         var firstChunkSize = Math.Min(4, parts.Count);
         current = firstChunkSize switch
         {
@@ -76,8 +60,7 @@ public sealed class FlattenConcatArrayCalls : ExpressionVisitor, IExpressionTree
         };
         i = firstChunkSize;
 
-        // Remaining parts: fold with Concat2, consuming up to 3 new parts per step
-        // (current + up to 3 new = 4 args max via Concat4)
+        // Each step consumes up to 3 new parts (current + 3 = 4 args max via Concat4).
         while (i < parts.Count)
         {
             var remaining = parts.Count - i;

--- a/src/ExpressiveSharp/Transformers/FlattenTupleComparisons.cs
+++ b/src/ExpressiveSharp/Transformers/FlattenTupleComparisons.cs
@@ -4,23 +4,11 @@ using System.Reflection;
 namespace ExpressiveSharp.Transformers;
 
 /// <summary>
-/// Replaces field access on inline <c>ValueTuple</c> construction with the corresponding
-/// constructor argument, enabling LINQ providers (EF Core, etc.) to translate tuple comparisons.
+/// Replaces field access on an inline <c>ValueTuple</c> construction with the corresponding
+/// constructor argument, e.g. <c>new (a, b).Item1</c> -> <c>a</c>. This lets providers translate
+/// <c>(Price, Quantity) == (50.0, 5)</c> as <c>Price == 50.0 AND Quantity == 5</c> instead of
+/// failing on the unsupported <c>ValueTuple</c> construction.
 /// </summary>
-/// <remarks>
-/// <para>
-/// Rewrites patterns like:
-/// <code>
-/// Expression.Field(Expression.New(ValueTuple&lt;T1,T2&gt; ctor, a, b), "Item1")
-/// </code>
-/// Into:
-/// <code>
-/// a
-/// </code>
-/// This allows <c>(Price, Quantity) == (50.0, 5)</c> to be translated as
-/// <c>Price == 50.0 AND Quantity == 5</c> instead of requiring <c>ValueTuple</c> construction.
-/// </para>
-/// </remarks>
 public sealed class FlattenTupleComparisons : ExpressionVisitor, IExpressionTreeTransformer
 {
     public Expression Transform(Expression expression)
@@ -28,7 +16,6 @@ public sealed class FlattenTupleComparisons : ExpressionVisitor, IExpressionTree
 
     protected override Expression VisitMember(MemberExpression node)
     {
-        // First, visit the inner expression so nested patterns are handled
         var visited = (MemberExpression)base.VisitMember(node);
 
         if (visited.Expression is NewExpression newExpr

--- a/src/ExpressiveSharp/Transformers/RemoveNullConditionalPatterns.cs
+++ b/src/ExpressiveSharp/Transformers/RemoveNullConditionalPatterns.cs
@@ -3,14 +3,9 @@ using System.Linq.Expressions;
 namespace ExpressiveSharp.Transformers;
 
 /// <summary>
-/// Removes null-conditional patterns from expression trees.
-/// Matches the pattern: <c>(x != null) ? x.Member : default(T)</c>
-/// and simplifies to: <c>x.Member</c>.
+/// Simplifies <c>(x != null) ? x.Member : default(T)</c> to <c>x.Member</c> — useful for
+/// providers like EF Core where the database engine already null-propagates.
 /// </summary>
-/// <remarks>
-/// This is useful for LINQ providers like EF Core where null propagation
-/// is handled by the database engine and the null-check ternary is unnecessary.
-/// </remarks>
 public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressionTreeTransformer
 {
     public Expression Transform(Expression expression)
@@ -18,27 +13,19 @@ public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressi
 
     protected override Expression VisitConditional(ConditionalExpression node)
     {
-        // Pattern: (x != null) ? whenTrue : default(T)
-        // where whenTrue is a pure member access chain on x.
-        //
-        // We deliberately refuse to strip when whenTrue contains a method call
-        // (e.g. `x?.ToUpper()`). Unlike pure member access, method-call null
-        // propagation is not guaranteed across LINQ providers — MongoDB's
-        // $toUpper on a null/missing field returns "" instead of null, so
-        // stripping the null check silently changes semantics. Property access
-        // chains (`Customer?.Address?.Country`) are safe because both SQL and
-        // MongoDB's aggregation framework propagate missing/null through them.
+        // We refuse to strip when whenTrue contains a method call (e.g. x?.ToUpper()).
+        // Method-call null propagation is not guaranteed across providers — MongoDB's
+        // $toUpper on null/missing returns "" instead of null, so dropping the null
+        // check silently changes semantics. Pure property access chains
+        // (Customer?.Address?.Country) are safe in both SQL and MongoDB aggregation.
         if (node.Test is BinaryExpression { NodeType: ExpressionType.NotEqual } notEqual
             && IsNullConstant(notEqual.Right)
             && IsDefaultOrNull(node.IfFalse))
         {
             var receiver = notEqual.Left;
 
-            // Check if the whenTrue branch is a pure member access on the same receiver.
             if (AccessesReceiver(node.IfTrue, receiver) && !ContainsMethodCall(node.IfTrue))
             {
-                // Strip the null check — return the whenTrue branch with
-                // any nested null-conditional patterns also removed.
                 // If types differ (e.g., int? vs int from Convert), unwrap the Convert.
                 var result = Visit(node.IfTrue);
                 if (result is UnaryExpression { NodeType: ExpressionType.Convert } convert
@@ -53,10 +40,8 @@ public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressi
         return base.VisitConditional(node);
     }
 
-    /// <summary>
-    /// Returns true if <paramref name="expr"/> contains a method call anywhere in its
-    /// receiver/member chain (including nested null-conditional patterns).
-    /// </summary>
+    // True if there's a method call anywhere in the receiver/member chain,
+    // including inside nested null-conditional patterns.
     private static bool ContainsMethodCall(Expression expr)
     {
         var current = expr;
@@ -74,8 +59,7 @@ public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressi
                     current = member.Expression;
                     break;
                 case ConditionalExpression conditional:
-                    // Nested ?. — inspect the true branch (the other branches are
-                    // null/default which contain no method calls by construction).
+                    // Other branches are null/default by construction.
                     return ContainsMethodCall(conditional.IfTrue);
                 default:
                     return false;
@@ -93,10 +77,7 @@ public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressi
         => expr is DefaultExpression
         || (expr is ConstantExpression { Value: null });
 
-    /// <summary>
-    /// Returns true if <paramref name="expr"/> directly or transitively accesses
-    /// <paramref name="receiver"/> (e.g., receiver.Prop, receiver.Prop.SubProp).
-    /// </summary>
+    // True if expr directly or transitively accesses receiver (e.g. receiver.Prop.SubProp).
     private static bool AccessesReceiver(Expression expr, Expression receiver)
     {
         var current = expr;
@@ -116,7 +97,6 @@ public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressi
             }
         }
 
-        // Walk up the member access chain
         while (current is MemberExpression member)
         {
             if (member.Expression is not null && ExpressionsEqual(member.Expression, receiver))
@@ -124,11 +104,9 @@ public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressi
             current = member.Expression;
         }
 
-        // Direct reference
         if (current is not null && ExpressionsEqual(current, receiver))
             return true;
 
-        // Method call on receiver (e.g., receiver.Method())
         if (expr is MethodCallExpression methodCall)
         {
             if (methodCall.Object is not null && ExpressionsEqual(methodCall.Object, receiver))

--- a/src/ExpressiveSharp/Transformers/ReplaceThrowWithDefault.cs
+++ b/src/ExpressiveSharp/Transformers/ReplaceThrowWithDefault.cs
@@ -3,14 +3,10 @@ using System.Linq.Expressions;
 namespace ExpressiveSharp.Transformers;
 
 /// <summary>
-/// Replaces <see cref="ExpressionType.Throw"/> nodes with <see cref="Expression.Default(Type)"/>.
+/// Replaces <see cref="ExpressionType.Throw"/> nodes with <see cref="Expression.Default(Type)"/>
+/// so providers like EF Core (which can't translate <c>Throw</c> to SQL) still see a node of
+/// the same type, preserving surrounding <c>Coalesce</c>/<c>Condition</c> structure.
 /// </summary>
-/// <remarks>
-/// This is useful for LINQ providers like EF Core that cannot translate
-/// <c>Expression.Throw</c> to SQL. The throw node is replaced with a
-/// type-compatible default, preserving the surrounding tree structure
-/// (e.g., <c>Coalesce</c>, <c>Condition</c>) and its type contracts.
-/// </remarks>
 public sealed class ReplaceThrowWithDefault : ExpressionVisitor, IExpressionTreeTransformer
 {
     public Expression Transform(Expression expression)

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/AsyncQueryableTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/AsyncQueryableTestBase.cs
@@ -4,18 +4,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Integration tests for <see cref="IExpressiveQueryable{T}"/> async terminal
-/// methods, multi-lambda operators, chain continuity, and null-conditional
-/// syntax in delegate lambdas. These exercise the polyfill interceptor path
-/// that rewrites delegate-based LINQ calls into expression trees.
-/// </summary>
 public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
 {
     [TestInitialize]
     public Task SeedStoreData() => Context.SeedStoreAsync();
-
-    // ── Async terminal methods with predicates ─────────────────────────
 
     [TestMethod]
     public async Task AnyAsync_WithPredicate_Executes()
@@ -73,8 +65,6 @@ public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
         Assert.IsNull(result);
     }
 
-    // ── Async aggregation with selectors ───────────────────────────────
-
     [TestMethod]
     public async Task SumAsync_WithSelector_Executes()
     {
@@ -103,8 +93,6 @@ public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
         // (120 + 75 + 10 + 50) / 4 = 63.75
         Assert.AreEqual(63.75, result, 0.001);
     }
-
-    // ── Chain continuity + async execution ─────────────────────────────
 
     [TestMethod]
     public async Task AsNoTracking_Where_ToListAsync_ExecutesCorrectly()
@@ -139,8 +127,6 @@ public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
         Assert.AreEqual(120, result.Price);
     }
 
-    // ── Multi-lambda methods ───────────────────────────────────────────
-
     [TestMethod]
     public async Task GroupBy_WithElementSelector_Executes()
     {
@@ -168,8 +154,6 @@ public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
         CollectionAssert.Contains(results, "Bob");
     }
 
-    // ── Passthrough chain-continuity ───────────────────────────────────
-
     [TestMethod]
     public async Task Take_Skip_Where_ToListAsync_ExecutesCorrectly()
     {
@@ -181,8 +165,6 @@ public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
 
         Assert.AreEqual(2, results.Count);
     }
-
-    // ── Null-conditional in async context ──────────────────────────────
 
     [TestMethod]
     public async Task NullConditional_InWhere_ToListAsync_ExecutesCorrectly()
@@ -204,12 +186,6 @@ public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
         Assert.IsNotNull(result);
         Assert.AreEqual(2, result!.Id);
     }
-
-    // ── SelectMany / GroupJoin / DistinctBy / TakeWhile / Contains ──────
-    //
-    // These were previously uncovered — the polyfill interceptor rewrites
-    // each delegate-based call into an expression tree before EF Core sees
-    // it. If any of these break per-provider we want to know.
 
     [TestMethod]
     public async Task SelectMany_WithCollection_Executes()

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/CapturedVariableTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/CapturedVariableTestBase.cs
@@ -4,10 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Verifies that the polyfill interceptor correctly handles captured (outer-scope)
-/// variables when lambdas are rewritten from delegates to expression trees.
-/// </summary>
 public abstract class CapturedVariableTestBase : EFCoreRelationalTestBase
 {
     [TestInitialize]
@@ -199,10 +195,7 @@ public abstract class CapturedVariableTestBase : EFCoreRelationalTestBase
         Assert.AreEqual(2, results[1]);
     }
 
-    /// <summary>
-    /// Helper that captures <c>this._minPrice</c> (an instance field) in a lambda.
-    /// Must be internal (not private) because the generated interceptor references the type.
-    /// </summary>
+    // Must be internal (not private): the generated interceptor references the type.
     internal class InstanceFieldCaptureHelper
     {
         private readonly IntegrationTestDbContext _context;

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/CommonScenarioTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/CommonScenarioTestBase.cs
@@ -5,18 +5,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Scenario tests exercising individual ExpressiveSharp features (arithmetic,
-/// switch expressions, pattern matching, null-conditional chains, loops,
-/// tuples, constructor projections, etc.) against a real EF Core provider.
-/// Runs against any provider (relational or Cosmos).
-/// </summary>
+// Runs against any provider (relational or Cosmos).
 public abstract class CommonScenarioTestBase : EFCoreTestBase
 {
     [TestInitialize]
     public virtual Task SeedStoreData() => Context.SeedStoreAsync();
-
-    // ── Arithmetic ──────────────────────────────────────────────────────────
 
     [TestMethod]
     public async Task Select_Total_ReturnsCorrectValues()
@@ -75,8 +68,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         CollectionAssert.AreEqual(new[] { 2, 4, 1, 3 }, results);
     }
 
-    // ── Block Body ──────────────────────────────────────────────────────────
-
     [TestMethod]
     public async Task Select_GetCategory_ReturnsCorrectValues()
     {
@@ -102,8 +93,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
             new[] { "Regular", "Bulk", "Regular", "Regular" },
             results);
     }
-
-    // ── Checked Arithmetic ──────────────────────────────────────────────────
 
     [TestMethod]
     public async Task Select_CheckedTotal_ReturnsCorrectValues()
@@ -132,8 +121,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         CollectionAssert.AreEqual(new[] { 1, 2, 4 }, ids);
     }
 
-    // ── Collection Expression ───────────────────────────────────────────────
-
     [TestMethod]
     public virtual async Task Select_PriceBreakpoints_ReturnsArrayLiteral()
     {
@@ -148,8 +135,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
             CollectionAssert.AreEqual(new[] { 10, 50, 100 }, breakpoints);
         }
     }
-
-    // ── Constructor Projection ──────────────────────────────────────────────
 
     [TestMethod]
     public async Task Select_OrderDto_ProjectsCorrectly()
@@ -169,8 +154,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         Assert.AreEqual("N/A", order3.Description);
         Assert.AreEqual(30.0, order3.Total);
     }
-
-    // ── Enum Expansion ──────────────────────────────────────────────────────
 
     [TestMethod]
     public async Task Select_StatusDescription_ReturnsCorrectValues()
@@ -201,8 +184,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         Assert.AreEqual(1, dict["Order approved"]);
         Assert.AreEqual(1, dict["Order rejected"]);
     }
-
-    // ── ExpressiveFor Mapping ───────────────────────────────────────────────
 
     [TestMethod]
     public async Task Select_ClampedPrice_ReturnsCorrectValues()
@@ -245,14 +226,9 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
             Assert.IsTrue(results.Any(r => Math.Abs(r - exp) < 0.001), $"Expected {exp} in results");
     }
 
-    // ── ExpressiveFor on instance method ────────────────────────────────────
-
     [TestMethod]
     public async Task Select_InstanceMethod_ViaExpressiveFor_ReturnsCorrectValues()
     {
-        // DisplayFormatter.Wrap is an instance method mapped via
-        // [ExpressiveFor]. The formatter is captured from outer scope
-        // (like a DI-injected service would be).
         var formatter = new DisplayFormatter("<", ">");
 
         Expression<Func<Order, string>> expr = o => formatter.Wrap(o.Tag ?? "none");
@@ -271,10 +247,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
     [TestMethod]
     public async Task Select_InstanceProperty_ViaExpressiveFor_ReturnsConstant()
     {
-        // DisplayFormatter.Label is an instance property mapped via
-        // [ExpressiveFor]. The property value is captured from outer scope
-        // (Prefix/Suffix are captured) — the expanded expression becomes a
-        // constant string interpolation evaluated per-row.
         var formatter = new DisplayFormatter("A", "B");
 
         Expression<Func<Order, string>> expr = o => formatter.Label + ":" + o.Id;
@@ -289,8 +261,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
             new[] { "[A/B]:1", "[A/B]:2", "[A/B]:3", "[A/B]:4" },
             results);
     }
-
-    // ── Loop Tests ──────────────────────────────────────────────────────────
 
     [TestMethod]
     public virtual async Task Select_ItemCount_ReturnsCorrectCounts()
@@ -346,8 +316,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
 
         CollectionAssert.AreEquivalent(new[] { 150.0, 500.0, 0.0, 0.0 }, results);
     }
-
-    // ── Null Conditional ────────────────────────────────────────────────────
 
     [TestMethod]
     public virtual async Task Select_CustomerName_ReturnsCorrectNullableValues()
@@ -406,10 +374,8 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
     [TestMethod]
     public virtual async Task OrderBy_TagLength_NullsAppearFirst()
     {
-        // NULL sort order is provider-specific: SQLite/SQL Server/MySQL
-        // put NULLs first on ASC, PostgreSQL puts them last. This test
-        // asserts the SQL Server / SQLite / MySQL convention; Postgres
-        // overrides with its own expectation.
+        // NULL sort order is provider-specific: SQLite/SQL Server/MySQL put NULLs first
+        // on ASC; Postgres overrides this test with its own expectation.
         Expression<Func<Order, int?>> tagLenExpr = o => o.TagLength;
         var expanded = (Expression<Func<Order, int?>>)tagLenExpr.ExpandExpressives();
 
@@ -420,8 +386,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         Assert.AreEqual(4, results.Count);
         Assert.AreEqual(3, results[0]); // Order 3 has null Tag → sorts first
     }
-
-    // ── Nullable Chain ──────────────────────────────────────────────────────
 
     [TestMethod]
     public virtual async Task Select_CustomerCountry_TwoLevelChain()
@@ -460,8 +424,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
 
         CollectionAssert.AreEquivalent(new[] { "New York", "London", null }, results);
     }
-
-    // ── Pattern Matching ────────────────────────────────────────────────────
 
     [TestMethod]
     public async Task Where_IsPattern_NullCheck()
@@ -515,8 +477,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
             results);
     }
 
-    // ── Polyfill Pathway ────────────────────────────────────────────────────
-
     [TestMethod]
     public async Task Polyfill_SimpleCondition_FiltersCorrectly()
     {
@@ -557,8 +517,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
 
         CollectionAssert.AreEquivalent(new[] { "RUSH", "STD", "N/A", "SPECIAL" }, results);
     }
-
-    // ── String Operations ───────────────────────────────────────────────────
 
     [TestMethod]
     public async Task Select_Summary_ReturnsCorrectValues()
@@ -648,8 +606,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         Assert.AreEqual(1, results[0].Id);
     }
 
-    // ── Switch Expression ───────────────────────────────────────────────────
-
     [TestMethod]
     public async Task Select_GetGrade_ReturnsCorrectValues()
     {
@@ -708,8 +664,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         Assert.AreEqual(1, dict["Budget"]);
     }
 
-    // ── Tuple Binary ────────────────────────────────────────────────────────
-
     [TestMethod]
     public async Task Select_IsPriceQuantityMatch_ReturnsCorrectValues()
     {
@@ -743,8 +697,6 @@ public abstract class CommonScenarioTestBase : EFCoreTestBase
         Assert.AreEqual(1, results.Count);
         Assert.AreEqual(4, results[0].Id);
     }
-
-    // ── Tuple Projection ────────────────────────────────────────────────────
 
     [TestMethod]
     public async Task Select_InlineTuple_ProjectsCorrectly()

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/CosmosIntegrationTestDbContext.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/CosmosIntegrationTestDbContext.cs
@@ -4,11 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Cosmos DB version of the integration test context.
-/// Models Customer and Address as owned types embedded within Order documents,
-/// since Cosmos DB does not support cross-document JOINs or foreign keys.
-/// </summary>
+// Customer/Address are owned types embedded within Order documents; Cosmos
+// does not support cross-document JOINs or foreign keys.
 public class CosmosIntegrationTestDbContext : DbContext
 {
     public DbSet<Order> Orders => Set<Order>();

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/EFCoreRelationalTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/EFCoreRelationalTestBase.cs
@@ -2,29 +2,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Base class for EF Core integration tests that require a relational SQL
-/// provider (SQLite, SQL Server, PostgreSQL, MySQL, Oracle, ...) and a
-/// strongly-typed context. Feature test bases using relational-only
-/// constructs — window functions (<c>ROW_NUMBER</c>, <c>RANK</c>, ...),
-/// bulk <c>ExecuteUpdate</c>, typed DbSet access — derive from this class
-/// rather than <see cref="EFCoreTestBase"/> so that Cosmos concrete classes
-/// can ignore them.
-///
-/// Generic over <typeparamref name="TContext"/> so test suites with their
-/// own specialized DbContext (e.g. query-filter tests) can reuse the same
-/// lifecycle infrastructure.
-/// </summary>
+// Relational-provider base for tests that use SQL-only constructs (window functions,
+// ExecuteUpdate, typed DbSet access). Cosmos concrete classes ignore these.
 public abstract class EFCoreRelationalTestBase<TContext> : EFCoreTestBase
     where TContext : DbContext
 {
     protected new TContext Context => (TContext)base.Context;
 }
 
-/// <summary>
-/// Convenience alias for the common case: a relational test using
-/// <see cref="IntegrationTestDbContext"/>.
-/// </summary>
 public abstract class EFCoreRelationalTestBase : EFCoreRelationalTestBase<IntegrationTestDbContext>
 {
 }

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/EFCoreTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/EFCoreTestBase.cs
@@ -3,30 +3,16 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Base class for all EF Core integration tests. Provides context lifecycle
-/// (create, ensure-created, cleanup, drop-database) for <b>any</b> EF Core
-/// provider, including non-relational ones like Cosmos DB. The
-/// <see cref="Context"/> property is exposed as a base <see cref="DbContext"/>
-/// so tests that need to work on Cosmos must use <c>Context.Set&lt;T&gt;()</c>
-/// rather than strongly-typed DbSet properties.
-///
-/// Tests that require relational-only features (window functions, bulk
-/// <c>ExecuteUpdate</c>, typed access to <see cref="IntegrationTestDbContext"/>
-/// DbSets) should derive from <see cref="EFCoreRelationalTestBase"/> instead.
-/// </summary>
+// Provider-agnostic context lifecycle. Context is exposed as base DbContext so
+// Cosmos-compatible tests must use Context.Set<T>() instead of typed DbSets.
 public abstract class EFCoreTestBase
 {
     protected DbContext Context { get; private set; } = null!;
 
     private IAsyncDisposable? _handle;
 
-    /// <summary>
-    /// Implemented by each per-provider concrete class. Returns an async-disposable
-    /// handle whose <c>Context</c> is the live DbContext. Disposing the handle
-    /// drops the per-test database (or closes the SQLite connection) and disposes
-    /// the context.
-    /// </summary>
+    // Returns an async-disposable handle whose Context is the live DbContext.
+    // Disposing drops the per-test database (or closes the SQLite connection).
     protected abstract IAsyncDisposable CreateContextHandle(out DbContext context);
 
     [TestInitialize]

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/ExecuteUpdateTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/ExecuteUpdateTestBase.cs
@@ -5,14 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Integration tests for <c>ExecuteUpdate</c> via <c>IExpressiveQueryable</c>.
-/// Proves that modern C# syntax (switch expressions, null-coalescing) inside
-/// <c>SetProperty</c> value lambdas translates to real SQL — a capability
-/// impossible with normal C# expression trees.
-///
-/// EF Core 10 changed the bulk-update API, so this base is conditional.
-/// </summary>
+// Conditional on pre-EF Core 10 because EF Core 10 changed the bulk-update API.
 public abstract class ExecuteUpdateTestBase : EFCoreRelationalTestBase
 {
     [TestInitialize]

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/ExpressiveExpansionTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/ExpressiveExpansionTestBase.cs
@@ -4,16 +4,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Regression tests verifying that [Expressive] members are correctly expanded
-/// through the ExpressiveQueryCompiler pipeline in real EF Core queries.
-/// </summary>
 public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
 {
     [TestInitialize]
     public Task SeedStoreData() => Context.SeedStoreAsync();
-
-    // ── Nested [Expressive] calls ───────────────────────────────────────────
 
     [TestMethod]
     public async Task NestedExpressive_TotalUsedInGetGrade_ExpandsRecursively()
@@ -44,8 +38,6 @@ public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
         Assert.AreEqual("Budget", results[2].Grade);
         Assert.AreEqual(30.0, results[2].Total);
     }
-
-    // ── [Expressive] in Where ───────────────────────────────────────────────
 
     [TestMethod]
     public async Task ExpressiveInWhere_FilterByTotal()
@@ -79,8 +71,6 @@ public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
 
         CollectionAssert.AreEquivalent(new[] { 2 }, results);
     }
-
-    // ── Null-conditional [Expressive] ───────────────────────────────────────
 
     [TestMethod]
     public async Task NullConditionalExpressive_CustomerName_InFilter()
@@ -118,8 +108,6 @@ public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
         Assert.IsNull(results[3].CustomerCountry);
     }
 
-    // ── [Expressive] extension method (enum expansion) ──────────────────────
-
     [TestMethod]
     public async Task ExpressiveExtensionMethod_StatusDescription()
     {
@@ -143,8 +131,6 @@ public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
 
         CollectionAssert.AreEquivalent(new[] { 2, 4 }, results);
     }
-
-    // ── Captured variable + [Expressive] combined ───────────────────────────
 
     [TestMethod]
     public async Task CapturedVariable_WithExpressive_InSameQuery()
@@ -174,8 +160,6 @@ public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
         Assert.AreEqual(240.0, results.Single());
     }
 
-    // ── [Expressive] string interpolation ───────────────────────────────────
-
     [TestMethod]
     public async Task ExpressiveStringInterpolation_Summary()
     {
@@ -187,8 +171,6 @@ public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
         Assert.IsTrue(results.Any(s => s.Contains("RUSH")));
         Assert.IsTrue(results.Any(s => s.Contains("N/A")));
     }
-
-    // ── [Expressive] constructor projection ─────────────────────────────────
 
     [TestMethod]
     public async Task ExpressiveConstructor_OrderDto_ProjectsCorrectly()
@@ -203,8 +185,6 @@ public abstract class ExpressiveExpansionTestBase : EFCoreRelationalTestBase
         Assert.AreEqual(240.0, results[0].Total);
         Assert.AreEqual("N/A", results[2].Description);
     }
-
-    // ── Multiple [Expressive] in single projection ──────────────────────────
 
     [TestMethod]
     public async Task MultipleExpressives_InSingleSelect()

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/IncludeTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/IncludeTestBase.cs
@@ -4,12 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Integration tests for Include/ThenInclude chain continuity via
-/// <see cref="IIncludableExpressiveQueryable{TEntity, TProperty}"/>. Verifies
-/// that navigation loading works end-to-end after <c>Include</c> on a
-/// expressive queryable.
-/// </summary>
 public abstract class IncludeTestBase : EFCoreRelationalTestBase
 {
     [TestInitialize]
@@ -72,8 +66,7 @@ public abstract class IncludeTestBase : EFCoreRelationalTestBase
     [TestMethod]
     public async Task IgnoreQueryFilters_Executes()
     {
-        // No query filters on IntegrationTestDbContext, but calling IgnoreQueryFilters
-        // should still return a valid executable chain.
+        // IntegrationTestDbContext has no filters, but IgnoreQueryFilters must still chain.
         var results = await Context.Orders
             .IgnoreQueryFilters()
             .ToListAsync();

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/QueryFilterTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/QueryFilterTestBase.cs
@@ -4,14 +4,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Integration tests for the <see cref="ExpressiveExpandQueryFiltersConvention"/>.
-/// Uses a dedicated <see cref="QueryFilterTestDbContext"/> with two global
-/// query filters — one expression-bodied (<c>o.Total &gt; 0</c>) and one
-/// block-bodied (<c>c.HasValidEmail()</c>) — to verify that both the
-/// standard convention and the <c>FlattenBlockExpressions</c> transformer
-/// run during filter expansion at model finalization.
-/// </summary>
+// Verifies ExpressiveExpandQueryFiltersConvention plus the FlattenBlockExpressions
+// transformer using two global filters: expression-bodied (Total > 0) and
+// block-bodied (Customer.HasValidEmail()).
 public abstract class QueryFilterTestBase : EFCoreRelationalTestBase<QueryFilterTestDbContext>
 {
     [TestInitialize]
@@ -34,8 +29,6 @@ public abstract class QueryFilterTestBase : EFCoreRelationalTestBase<QueryFilter
             new Order { Id = 4, Price = 0, Quantity = 0, CustomerId = 2 });   // Total = 0 ✗
         await Context.SaveChangesAsync();
     }
-
-    // ── Expression-bodied [Expressive] filter (Order.Total > 0) ────────
 
     [TestMethod]
     public async Task ExpressionBodyFilter_FiltersOutZeroTotals()
@@ -65,14 +58,11 @@ public abstract class QueryFilterTestBase : EFCoreRelationalTestBase<QueryFilter
         Assert.AreEqual(3, count);
     }
 
-    // ── Block-body [Expressive] filter (Customer.HasValidEmail()) ──────
-
     [TestMethod]
     public async Task BlockBodyFilter_FiltersOutNullEmails()
     {
-        // HasValidEmail() has an if/else that the FlattenBlockExpressions
-        // transformer must inline during filter expansion. Customers 1 and 2
-        // have emails, customer 3 has null.
+        // HasValidEmail() has an if/else that FlattenBlockExpressions must inline
+        // during filter expansion.
         var ids = await Context.Customers
             .OrderBy(c => c.Id)
             .Select(c => c.Id)

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/StoreQueryTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/StoreQueryTestBase.cs
@@ -5,12 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Store-domain queries that combine multiple ExpressiveSharp features in a
-/// single query (null-conditional + arithmetic, switch + arithmetic, enum +
-/// block body, compound sort, group-by). These are regression checks that
-/// feature interactions work end-to-end against any EF Core provider.
-/// </summary>
 public abstract class StoreQueryTestBase : EFCoreTestBase
 {
     [TestInitialize]
@@ -19,7 +13,6 @@ public abstract class StoreQueryTestBase : EFCoreTestBase
     [TestMethod]
     public async Task FilterByCustomerName_ProjectTotal()
     {
-        // Combines null-conditional (CustomerName) + arithmetic (Total)
         Expression<Func<Order, string?>> nameExpr = o => o.CustomerName;
         var expandedName = (Expression<Func<Order, string?>>)nameExpr.ExpandExpressives();
 
@@ -134,20 +127,11 @@ public abstract class StoreQueryTestBase : EFCoreTestBase
         Assert.AreEqual(1, dict[OrderStatus.Rejected]);
     }
 
-    // ── Cross-feature interactions ─────────────────────────────────────
-    //
-    // These tests combine multiple ExpressiveSharp features in a single
-    // query to catch seams where individual features work alone but break
-    // in combination.
-
     [TestMethod]
     public async Task NullConditional_WithExpressiveFor_ComposedInProjection()
     {
-        // Combines:
-        //   * PricingUtils.Clamp   — [ExpressiveFor] on a static method
-        //   * o.Customer?.Name     — null-conditional chain ([Expressive]
-        //                            member CustomerName)
-        // The expected result: for each order, return "clamped-price:customer-or-NONE".
+        // Combines [ExpressiveFor] on PricingUtils.Clamp with [Expressive]
+        // null-conditional CustomerName.
         Expression<Func<Order, string>> expr = o =>
             PricingUtils.Clamp(o.Price, 20.0, 100.0).ToString() + ":" + (o.CustomerName ?? "NONE");
 
@@ -172,10 +156,8 @@ public abstract class StoreQueryTestBase : EFCoreTestBase
     [TestMethod]
     public async Task CapturedVariable_PlusExpressive_Total_FiltersCorrectly()
     {
-        // Combines:
-        //   * Captured variable `minTotal` (polyfill interceptor path)
-        //   * o.Total            — [Expressive] member (query compiler path)
-        // Both rewrite mechanisms must cooperate in a single query.
+        // Both rewrite mechanisms (interceptor + query compiler) must cooperate
+        // in a single query.
         var minTotal = 200.0;
         Expression<Func<Order, bool>> baseExpr = o => o.Total > minTotal;
         var expanded = (Expression<Func<Order, bool>>)baseExpr.ExpandExpressives();
@@ -193,10 +175,8 @@ public abstract class StoreQueryTestBase : EFCoreTestBase
     [TestMethod]
     public async Task ExpressiveFor_Inside_ExpressiveMember_ComposesCorrectly()
     {
-        // Interaction: the [ExpressiveFor] mapping for PricingUtils.Clamp is
-        // itself used inside a projection alongside an [Expressive] member.
-        // This verifies the resolver handles ExpressiveFor targets and
-        // [Expressive] members in the same expression tree.
+        // Verifies the resolver handles [ExpressiveFor] targets and [Expressive]
+        // members in the same expression tree.
         Expression<Func<Order, double>> expr = o =>
             PricingUtils.Clamp(o.Total, 0.0, 200.0);
 

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/StoreSeedExtensions.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/StoreSeedExtensions.cs
@@ -4,16 +4,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Shared seed logic for tests that exercise the Store scenario graph
-/// (Address → Customer → Order → LineItem). Every EF Core feature test base
-/// that needs the canonical Store dataset calls <see cref="SeedStoreAsync"/>
-/// rather than duplicating the four-entity insert ceremony.
-///
-/// Entities are re-materialized (not the originals from <see cref="SeedData"/>)
-/// to avoid tracker conflicts when the same seed runs against multiple
-/// contexts in the same test session.
-/// </summary>
+// Entities are re-materialized (not the originals from SeedData) to avoid
+// tracker conflicts when the same seed runs against multiple contexts in the
+// same test session.
 internal static class StoreSeedExtensions
 {
     public static async Task SeedStoreAsync(this DbContext context)

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/TestContextFactories.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/TestContextFactories.cs
@@ -12,18 +12,10 @@ using MySqlConnector;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Per-provider context factories used by test bases that need direct
-/// <see cref="DbContext"/> access (tests that bypass <c>IIntegrationTestRunner</c>).
-///
-/// Each factory creates a fresh, uniquely-named database inside the shared
-/// container (or an in-memory SQLite connection) and returns a disposable
-/// handle that the caller disposes in test cleanup.
-/// </summary>
+// Each factory creates a uniquely-named database inside the shared container
+// (or an in-memory SQLite connection) and returns a handle disposed in cleanup.
 internal static class TestContextFactories
 {
-    // ── SQLite ──────────────────────────────────────────────────────────
-
     public static SqliteContextHandle<IntegrationTestDbContext> CreateSqlite()
         => CreateSqlite<IntegrationTestDbContext>(opt => new IntegrationTestDbContext(opt));
 
@@ -54,8 +46,6 @@ internal static class TestContextFactories
             await connection.DisposeAsync();
         }
     }
-
-    // ── SQL Server ──────────────────────────────────────────────────────
 
 #if TEST_SQLSERVER
     public static SqlServerContextHandle<IntegrationTestDbContext> CreateSqlServer()
@@ -93,8 +83,6 @@ internal static class TestContextFactories
         }
     }
 #endif
-
-    // ── PostgreSQL ──────────────────────────────────────────────────────
 
 #if TEST_POSTGRES
     public static PostgresContextHandle<IntegrationTestDbContext> CreatePostgres()
@@ -150,8 +138,6 @@ internal static class TestContextFactories
     }
 #endif
 
-    // ── MySQL (Pomelo) ──────────────────────────────────────────────────
-
 #if TEST_POMELO_MYSQL && !NET10_0_OR_GREATER
     public static PomeloMySqlContextHandle<IntegrationTestDbContext> CreatePomeloMySql()
         => CreatePomeloMySql<IntegrationTestDbContext>(opt => new IntegrationTestDbContext(opt));
@@ -197,8 +183,6 @@ internal static class TestContextFactories
         }
     }
 #endif
-
-    // ── Cosmos DB ───────────────────────────────────────────────────────
 
 #if TEST_COSMOS
     public static CosmosContextHandle CreateCosmos()

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/TransformerBehaviorTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/TransformerBehaviorTestBase.cs
@@ -5,25 +5,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Per-transformer behavior tests. Each test exercises exactly one
-/// transformer from <c>ExpressiveSharp.Transformers</c> (or from a plugin)
-/// in isolation, with a canonical minimal example whose test name makes
-/// the transformer obvious in failure output.
-///
-/// These overlap with scenario tests in coverage but serve a different
-/// purpose: if a transformer regresses, the failures here point directly
-/// at the transformer by name, rather than the user having to trace through
-/// a generic scenario test failure.
-///
-/// Transformers under test:
-/// <list type="bullet">
-///   <item><c>ConvertLoopsToLinq</c> — <c>foreach</c> → LINQ method</item>
-///   <item><c>FlattenBlockExpressions</c> — inline block-local variables</item>
-///   <item><c>FlattenTupleComparisons</c> — <c>(a, b) == (c, d)</c> → flat AND</item>
-///   <item><c>RemoveNullConditionalPatterns</c> — strip <c>?.</c> null checks</item>
-/// </list>
-/// </summary>
+// Each test isolates exactly one transformer so failures point directly at the
+// transformer by name. Covers ConvertLoopsToLinq, FlattenBlockExpressions,
+// FlattenTupleComparisons, RemoveNullConditionalPatterns.
 public abstract class TransformerBehaviorTestBase : EFCoreRelationalTestBase
 {
     [TestInitialize]

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/UseExpressivesConventionTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/UseExpressivesConventionTestBase.cs
@@ -4,16 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Tests the <c>UseExpressives()</c> convention plugins:
-/// <list type="bullet">
-///   <item>Marking <c>[Expressive]</c> properties as unmapped</item>
-///   <item>Expanding <c>[Expressive]</c> calls inside global query filters</item>
-/// </list>
-/// The convention checks are model-level and don't need a database, but the
-/// query-filter test requires real execution to verify the filter actually
-/// shapes results correctly.
-/// </summary>
 public abstract class UseExpressivesConventionTestBase : EFCoreRelationalTestBase
 {
     [TestMethod]

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/WindowFunctionTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/WindowFunctionTestBase.cs
@@ -5,12 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Integration tests for window functions (ROW_NUMBER, RANK, DENSE_RANK, NTILE,
-/// indexed Select). These exercise the
-/// <see cref="RelationalExpressivePlugin"/> translators and the indexed-Select
-/// rewriter end-to-end against a real database.
-/// </summary>
 public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
 {
     [TestInitialize]
@@ -210,13 +204,9 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
         Assert.AreEqual(4, results[9].Quartile);
     }
 
-    // ── Interaction: window function over an [Expressive] projection ───
-    //
-    // RowNumber over o.Total (which is [Expressive] => Price * Quantity).
-    // The ExpressiveQueryCompiler must expand Total inside the OrderBy
-    // argument of the window spec BEFORE the window translator translates
-    // it to SQL.
-
+    // RowNumber over o.Total (which is [Expressive] => Price * Quantity). The
+    // ExpressiveQueryCompiler must expand Total inside the OrderBy argument of
+    // the window spec before the window translator runs.
     [TestMethod]
     public async Task RowNumber_OverExpressiveTotal_UsesExpandedExpression()
     {
@@ -256,17 +246,9 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
             Assert.IsTrue(results[i].Total >= results[i - 1].Total);
     }
 
-    // ── Aggregate window function tests ─────────────────────────────────
-    //
-    // Aggregate functions (SUM, AVG, COUNT, MIN, MAX) with OVER produce
-    // results that depend on the frame clause — unlike ranking functions.
-    // A running total (SUM with ROWS UNBOUNDED PRECEDING TO CURRENT ROW)
-    // gives a different value per row than a full-partition SUM.
-    //
-    // Seed data (ordered by Price ASC):
-    //   Price:  10, 15, 20, 20, 25, 30, 35, 40, 45, 50
-    //   Running total: 10, 25, 45, 65, 90, 120, 155, 195, 240, 290
-
+    // Aggregate window functions (SUM, AVG, COUNT, MIN, MAX) depend on the frame clause.
+    // Seed prices (ASC): 10, 15, 20, 20, 25, 30, 35, 40, 45, 50
+    // Running total:     10, 25, 45, 65, 90, 120, 155, 195, 240, 290
     [TestMethod]
     public async Task Sum_WithRowsFrame_ProducesRunningTotal()
     {
@@ -470,13 +452,7 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
         Assert.AreEqual(50.0, results[^1].RunningMax);
     }
 
-    // ── Navigation function tests (LAG / LEAD) ──────────────────────────
-    //
-    // LAG/LEAD access a row at a fixed offset from the current row.
-    // They do NOT support frame clauses (SQL standard forbids it).
-    //
-    // Ordered by Price ASC: 10, 15, 20, 20, 25, 30, 35, 40, 45, 50
-
+    // LAG/LEAD do NOT support frame clauses (SQL standard forbids it).
     [TestMethod]
     public async Task Lag_Default_ReturnsPreviousRowPrice()
     {
@@ -619,8 +595,6 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
         Assert.AreEqual(c2[0].Price, c2[1].PrevInGroup);
     }
 
-    // ── FIRST_VALUE / LAST_VALUE ─────────────────────────────────────────
-
     [TestMethod]
     public async Task FirstValue_ReturnsFirstPriceInPartition()
     {
@@ -693,8 +667,6 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
         Assert.IsTrue(c2.All(r => Math.Abs(r.FirstInGroup - 10.0) < 1e-9));
     }
 
-    // ── PERCENT_RANK ─────────────────────────────────────────────────────
-
     [TestMethod]
     public async Task PercentRank_ReturnsBetweenZeroAndOne()
     {
@@ -721,8 +693,6 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
         Assert.IsTrue(results.All(r => r.Pct >= 0.0 && r.Pct <= 1.0));
     }
 
-    // ── CUME_DIST ────────────────────────────────────────────────────────
-
     [TestMethod]
     public async Task CumeDist_ReturnsBetweenZeroAndOne()
     {
@@ -747,8 +717,6 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
         // Unlike PERCENT_RANK, first row's CUME_DIST > 0.0
         Assert.IsTrue(results[0].Cume > 0.0);
     }
-
-    // ── NTH_VALUE ────────────────────────────────────────────────────────
 
     [TestMethod]
     public async Task NthValue_ReturnsValueAtPosition()
@@ -780,8 +748,6 @@ public abstract class WindowFunctionTestBase : EFCoreRelationalTestBase
             Assert.Inconclusive("NTH_VALUE is not supported by this database provider.");
         }
     }
-
-    // ── Coverage gap tests ───────────────────────────────────────────────
 
     [TestMethod]
     public async Task Count_Expression_CountsNonNullOnly()

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/IntegrationTestDbContext.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/IntegrationTestDbContext.cs
@@ -10,15 +10,7 @@ public class IntegrationTestDbContext : DbContext
     public DbSet<Customer> Customers => Set<Customer>();
     public DbSet<Product> Products => Set<Product>();
 
-    /// <summary>
-    /// Delegate-based DbSet for tests that exercise the polyfill interceptor
-    /// (e.g. <c>?.</c>, indexed Select with WindowFunction.RowNumber).
-    /// </summary>
     public ExpressiveDbSet<Order> ExpressiveOrders => Set<Order>().AsExpressiveDbSet();
-
-    /// <summary>
-    /// Delegate-based DbSet for ExecuteUpdate tests with modern C# syntax.
-    /// </summary>
     public ExpressiveDbSet<Product> ExpressiveProducts => Set<Product>().AsExpressiveDbSet();
 
     public IntegrationTestDbContext(DbContextOptions<IntegrationTestDbContext> options) : base(options)

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Models/Product.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Models/Product.cs
@@ -1,10 +1,7 @@
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Models;
 
-/// <summary>
-/// Entity used for ExecuteUpdate integration tests. Distinct from the shared
-/// Order/Customer graph because bulk update tests need their own data set that
-/// can be mutated freely per test without affecting other scenarios.
-/// </summary>
+// Used for ExecuteUpdate tests; isolated from the shared Order/Customer graph
+// so bulk-update tests can mutate freely.
 public class Product
 {
     public int Id { get; set; }

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/QueryFilterTestDbContext.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/QueryFilterTestDbContext.cs
@@ -3,18 +3,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests;
 
-/// <summary>
-/// Standalone DbContext used by query filter expansion tests. Has two global
-/// query filters that reference <c>[Expressive]</c> members of different
-/// shapes:
-/// <list type="bullet">
-///   <item><c>Order</c>: expression-bodied <c>o.Total &gt; 0</c> — the
-///     <see cref="ExpressiveExpandQueryFiltersConvention"/> must expand it.</item>
-///   <item><c>Customer</c>: block-bodied <c>c.HasValidEmail()</c> — exercises
-///     the <c>FlattenBlockExpressions</c> transformer <b>inside</b> the filter
-///     expansion path.</item>
-/// </list>
-/// </summary>
+// Two global query filters reference [Expressive] members of different shapes:
+// Order has expression-bodied (Total > 0); Customer has block-bodied
+// (HasValidEmail()) which exercises FlattenBlockExpressions inside filter expansion.
 public class QueryFilterTestDbContext : DbContext
 {
     public DbSet<Order> Orders => Set<Order>();
@@ -30,9 +21,6 @@ public class QueryFilterTestDbContext : DbContext
         {
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Id).ValueGeneratedNever();
-            // Block-body [Expressive] in a query filter — the
-            // FlattenBlockExpressions transformer must run during filter
-            // expansion to inline the if/else.
             entity.HasQueryFilter(c => c.HasValidEmail());
         });
 
@@ -43,7 +31,6 @@ public class QueryFilterTestDbContext : DbContext
             entity.HasOne(e => e.Customer)
                 .WithMany()
                 .HasForeignKey(e => e.CustomerId);
-            // Expression-bodied [Expressive] (Total => Price * Quantity).
             entity.HasQueryFilter(o => o.Total > 0);
         });
     }

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Cosmos/CommonScenarioTests.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Cosmos/CommonScenarioTests.cs
@@ -7,13 +7,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Tests.Cosmos;
 
-/// <summary>
-/// Cosmos DB runs a subset of <see cref="CommonScenarioTestBase"/>: tests that
-/// use <c>GROUP BY</c> on computed expressions, cross-entity queries, or array
-/// literal projections are not supported by Cosmos and are overridden as
-/// <see cref="Assert.Inconclusive"/>. Seeding is also customized because
-/// Customer and Address are owned types embedded in the Order document.
-/// </summary>
+// Cosmos runs a subset of CommonScenarioTestBase; unsupported tests below are
+// overridden as Inconclusive. Seeding is also customized because Customer and
+// Address are owned types embedded in the Order document.
 [TestClass]
 public class CommonScenarioTests : CommonScenarioTestBase
 {

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Sqlite/ExpressiveDbSetDiscoveryTests.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Sqlite/ExpressiveDbSetDiscoveryTests.cs
@@ -4,12 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Tests.Sqlite;
 
-/// <summary>
-/// Verifies the <see cref="ExpressiveDbSetDiscoveryConvention"/> and
-/// <see cref="ExpressiveDbSetTableNameConvention"/> against real schema
-/// creation and query execution. These are convention-plugin tests that
-/// don't depend on provider-specific SQL, so they run on SQLite only.
-/// </summary>
+// Convention-plugin tests; provider-agnostic so SQLite-only.
 [TestClass]
 public class ExpressiveDbSetDiscoveryTests
 {
@@ -76,7 +71,7 @@ public class ExpressiveDbSetDiscoveryTests
     [TestMethod]
     public void ExpressiveOnlyContext_UseExpressivesBeforeProvider_EntityStillDiscovered()
     {
-        // Verify the deferred decoration path: UseExpressives() called before UseSqlite()
+        // Deferred decoration path: UseExpressives() called before UseSqlite().
         using var ctx = new ExpressiveOnlyContext(CreateOptionsReversed<ExpressiveOnlyContext>());
         ctx.Database.EnsureCreated();
 
@@ -94,8 +89,6 @@ public class ExpressiveDbSetDiscoveryTests
         Assert.AreEqual("Items", tableName,
             "When both DbSet and ExpressiveDbSet exist, the DbSet table name should be used");
     }
-
-    // ── Test-local models ───────────────────────────────────────────────
 
     public class DiscoveryItem
     {

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Sqlite/ExpressivePropertiesNotMappedConventionTests.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Sqlite/ExpressivePropertiesNotMappedConventionTests.cs
@@ -5,11 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Tests.Sqlite;
 
-/// <summary>
-/// Verifies the <see cref="ExpressivePropertiesNotMappedConvention"/> ignores properties that
-/// would otherwise be mapped to columns when they have no backing database value —
-/// either via <c>[Expressive]</c> directly, or as the target of an <c>[ExpressiveFor]</c> stub.
-/// </summary>
 [TestClass]
 public class ExpressivePropertiesNotMappedConventionTests
 {
@@ -106,24 +101,21 @@ public class ExpressivePropertiesNotMappedConventionTests
         Assert.AreEqual(14, results[1].DoubledValue);
     }
 
-    // ── Test-local models ────────────────────────────────────────────────
-
     public class NotMappedItem
     {
         public int Id { get; set; }
         public int Value { get; set; }
 
-        /// <summary>Computed by [Expressive] — existing convention path.</summary>
         [Expressive]
         public int DoubledValue => Value * 2;
 
-        /// <summary>Targeted by a co-located property stub (new single-arg form).</summary>
+        // Targeted by a co-located property stub (single-arg [ExpressiveFor] form).
         public string DescribedValue { get; set; } = "";
 
         [ExpressiveFor(nameof(DescribedValue))]
         public string DescribedValueExpression => "value=" + Value;
 
-        /// <summary>Targeted by a stub declared in an external static class.</summary>
+        // Targeted by a stub declared in an external static class.
         public string ExternalDescribedValue { get; set; } = "";
     }
 

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Sqlite/SynthesizedExpressiveSqlTests.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/Sqlite/SynthesizedExpressiveSqlTests.cs
@@ -5,16 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Tests.Sqlite;
 
-/// <summary>
-/// EF Core SQLite tests for <c>[ExpressiveProperty]</c>. Uses a self-contained
-/// DbContext with a synthesized entity so the test doesn't depend on shared scenario models.
-/// Verifies:
-/// <list type="bullet">
-///   <item>The synthesized property is auto-Ignored in the EF model (no column is generated).</item>
-///   <item>Queries referencing the property emit SQL with the inlined formula.</item>
-///   <item>Projection into <c>new T { Member = ... }</c> materializes via the <c>init</c> accessor.</item>
-/// </list>
-/// </summary>
 [TestClass]
 public class SynthesizedExpressiveSqlTests
 {
@@ -93,7 +83,6 @@ public class SynthesizedExpressiveSqlTests
     }
 }
 
-/// <summary>Self-contained entity for synthesized-property EF Core tests.</summary>
 public partial class SynthesizedPerson
 {
     public int Id { get; set; }
@@ -104,7 +93,6 @@ public partial class SynthesizedPerson
     private string FullNameExpression => LastName + ", " + FirstName;
 }
 
-/// <summary>Self-contained DbContext for synthesized-property EF Core tests.</summary>
 public class SynthesizedDbContext(DbContextOptions<SynthesizedDbContext> options) : DbContext(options)
 {
     public DbSet<SynthesizedPerson> People => Set<SynthesizedPerson>();

--- a/tests/ExpressiveSharp.Generator.Tests/CodeFixers/AddExpressiveCodeFixProviderTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/CodeFixers/AddExpressiveCodeFixProviderTests.cs
@@ -39,7 +39,6 @@ public sealed class AddExpressiveCodeFixProviderTests : GeneratorTestBase
         TestContext.WriteLine(fixedSource);
         TestContext.WriteLine("END OUTPUT");
 
-        // The code fix should add [Expressive] to the Helper method declaration
         var lines = fixedSource.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
         var helperLine = System.Array.FindIndex(lines, l => l.Contains("public static int Helper"));
         Assert.IsTrue(helperLine > 0, "Should find Helper method in output");
@@ -130,15 +129,12 @@ public sealed class AddExpressiveCodeFixProviderTests : GeneratorTestBase
             "Expected exactly one 'using ExpressiveSharp;' directive");
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
     private async Task<string> ApplyCodeFixAsync(
         string declSource,
         string? callerSource = null,
         string declFileName = "TestFile.cs",
         string callerFileName = "Caller.cs")
     {
-        // 1. Build workspace with documents
         var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
         var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
 
@@ -155,7 +151,6 @@ public sealed class AddExpressiveCodeFixProviderTests : GeneratorTestBase
 
         var project = workspace.AddProject(projectInfo);
 
-        // Add global usings
         var globalUsingsDoc = workspace.AddDocument(project.Id, "GlobalUsings.cs",
             SourceText.From("""
                 global using System;
@@ -165,18 +160,15 @@ public sealed class AddExpressiveCodeFixProviderTests : GeneratorTestBase
                 """));
         project = globalUsingsDoc.Project;
 
-        // Add declaration source
         var declDoc = workspace.AddDocument(project.Id, declFileName, SourceText.From(declSource));
         project = declDoc.Project;
 
-        // Add caller source if provided (for cross-file tests)
         if (callerSource is not null)
         {
             var callerDoc = workspace.AddDocument(project.Id, callerFileName, SourceText.From(callerSource));
             project = callerDoc.Project;
         }
 
-        // 2. Get compilation and run analyzer
         var compilation = await project.GetCompilationAsync()
             ?? throw new System.Exception("Failed to get compilation");
 
@@ -190,14 +182,12 @@ public sealed class AddExpressiveCodeFixProviderTests : GeneratorTestBase
         Assert.IsTrue(diagnostic.AdditionalLocations.Count > 0,
             "Expected additional location (declaration) on EXP0013");
 
-        // 3. Find the document containing the diagnostic usage
         var usageTree = diagnostic.Location.SourceTree;
         Assert.IsNotNull(usageTree, "Diagnostic should have a source tree");
 
         var usageDoc = project.Solution.GetDocument(usageTree);
         Assert.IsNotNull(usageDoc, "Should find workspace document for diagnostic location");
 
-        // 4. Apply the code fix
         var codeFix = new AddExpressiveCodeFixProvider();
         var actions = new System.Collections.Generic.List<CodeAction>();
         var context = new CodeFixContext(
@@ -213,7 +203,6 @@ public sealed class AddExpressiveCodeFixProviderTests : GeneratorTestBase
         var applyOperation = operations.OfType<ApplyChangesOperation>().First();
         var fixedSolution = applyOperation.ChangedSolution;
 
-        // 5. Get the fixed declaration document
         var declTree = diagnostic.AdditionalLocations[0].SourceTree;
         Assert.IsNotNull(declTree, "Declaration should have a source tree");
 

--- a/tests/ExpressiveSharp.Generator.Tests/CodeFixers/MigrationAnalyzerTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/CodeFixers/MigrationAnalyzerTests.cs
@@ -178,8 +178,6 @@ public sealed class MigrationAnalyzerTests : GeneratorTestBase
             "Expected namespace to be replaced with ExpressiveSharp");
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
     private async Task<ImmutableArray<Diagnostic>> GetMigrationDiagnosticsAsync(
         string source, string? customStub = null)
     {
@@ -221,17 +219,14 @@ public sealed class MigrationAnalyzerTests : GeneratorTestBase
 
         var project = workspace.AddProject(projectInfo);
 
-        // Add the Projectables stubs
         var stubDoc = workspace.AddDocument(project.Id, "Stubs.cs",
             SourceText.From(ProjectablesStub));
         project = stubDoc.Project;
 
-        // Add the source under test
         var testDoc = workspace.AddDocument(project.Id, "TestFile.cs",
             SourceText.From(source));
         project = testDoc.Project;
 
-        // Run analyzer
         var compilation = await project.GetCompilationAsync()
             ?? throw new System.Exception("Failed to get compilation");
 
@@ -243,13 +238,11 @@ public sealed class MigrationAnalyzerTests : GeneratorTestBase
         var diagnostic = diagnostics.FirstOrDefault(d => d.Id == expectedDiagnosticId);
         Assert.IsNotNull(diagnostic, $"Expected {expectedDiagnosticId} diagnostic");
 
-        // Find the document containing the diagnostic
         var diagnosticTree = diagnostic.Location.SourceTree;
         Assert.IsNotNull(diagnosticTree);
         var diagnosticDoc = project.Solution.GetDocument(diagnosticTree);
         Assert.IsNotNull(diagnosticDoc);
 
-        // Apply the code fix
         var codeFix = new MigrationCodeFixProvider();
         var actions = new System.Collections.Generic.List<CodeAction>();
         var context = new CodeFixContext(

--- a/tests/ExpressiveSharp.Generator.Tests/CodeFixers/MissingExpressiveImportAnalyzerTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/CodeFixers/MissingExpressiveImportAnalyzerTests.cs
@@ -162,8 +162,6 @@ public sealed class MissingExpressiveImportAnalyzerTests : GeneratorTestBase
             "Should not report any diagnostic for plain IQueryable");
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
     private async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
     {
         using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();

--- a/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/DiagnosticTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/DiagnosticTests.cs
@@ -8,8 +8,6 @@ namespace ExpressiveSharp.Generator.Tests.ExpressiveGenerator;
 [TestClass]
 public class DiagnosticTests : GeneratorTestBase
 {
-    // ── EXP0001: RequiresBodyDefinition ─────────────────────────────────────
-
     [TestMethod]
     public void AutoProperty_NoBody_ReportsEXP0001()
     {
@@ -46,8 +44,6 @@ public class DiagnosticTests : GeneratorTestBase
             "Expected EXP0001 for abstract method without body");
     }
 
-    // ── EXP0003: NoSourceAvailableForDelegatedConstructor ───────────────────
-
     [TestMethod]
     public void DelegatedConstructor_BaseInBCL_ReportsEXP0003()
     {
@@ -72,8 +68,6 @@ public class DiagnosticTests : GeneratorTestBase
         Assert.IsTrue(result.Diagnostics.Any(d => d.Id == "EXP0003"),
             "Expected EXP0003 for delegated constructor with no source available");
     }
-
-    // ── EXP0007: UnsupportedInitializer ─────────────────────────────────────
 
     [TestMethod]
     public void NestedObjectInitializer_ReportsEXP0007()
@@ -102,8 +96,6 @@ public class DiagnosticTests : GeneratorTestBase
             "Expected EXP0007 for nested member initializer");
     }
 
-    // ── EXP0018: IgnoredOperation ─────────────────────────────────────────
-
     [TestMethod]
     public void StringInterpolation_AlignmentSpecifier_ReportsEXP0018()
     {
@@ -126,8 +118,6 @@ public class DiagnosticTests : GeneratorTestBase
             "Generator should still produce output (interpolation without alignment)");
     }
 
-    // ── EXP0009: UnsupportedOperator ────────────────────────────────────────
-
     [TestMethod]
     public void UnsignedRightShift_ReportsEXP0009()
     {
@@ -147,8 +137,6 @@ public class DiagnosticTests : GeneratorTestBase
         Assert.IsTrue(result.Diagnostics.Any(d => d.Id == "EXP0009"),
             "Expected EXP0009 for unsigned right shift operator (>>>)");
     }
-
-    // ── EXP0011: UnresolvablePatternMember ──────────────────────────────────
 
     [TestMethod]
     public void PositionalPattern_NoMatchingProperty_ReportsEXP0011()
@@ -173,8 +161,6 @@ public class DiagnosticTests : GeneratorTestBase
         Assert.IsTrue(result.Diagnostics.Any(d => d.Id == "EXP0011"),
             "Expected EXP0011 for positional pattern with unresolvable member names");
     }
-
-    // ── EXP0012: FactoryMethodShouldBeConstructor ───────────────────────────
 
     [TestMethod]
     public void FactoryMethod_ReturningNewContainingType_ReportsEXP0012()
@@ -202,8 +188,6 @@ public class DiagnosticTests : GeneratorTestBase
         Assert.IsTrue(result.GeneratedTrees.Length > 0,
             "Generator should still produce output alongside Info diagnostic");
     }
-
-    // ── EXP0014: ExpressiveForTargetTypeNotFound ────────────────────────────
 
     [TestMethod]
     public void ExpressiveFor_NonExistentTargetType_ReportsEXP0014()

--- a/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/ExpressiveForTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/ExpressiveForTests.cs
@@ -165,14 +165,11 @@ public class ExpressiveForTests : GeneratorTestBase
         Assert.AreEqual(0, result.Diagnostics.Length);
         Assert.AreEqual(2, result.GeneratedTrees.Length);
 
-        // Verify the registry contains both entries
         Assert.IsNotNull(result.RegistryTree, "Registry should be generated");
         var registryText = result.RegistryTree!.GetText().ToString();
         Assert.IsTrue(registryText.Contains("Math"), "Registry should contain Math.Abs entry");
         Assert.IsTrue(registryText.Contains("MyType"), "Registry should contain MyType.Doubled entry");
     }
-
-    // ── Diagnostic Tests ────────────────────────────────────────────────────
 
     [TestMethod]
     public void MemberNotFound_EXP0015()
@@ -365,7 +362,6 @@ public class ExpressiveForTests : GeneratorTestBase
             """);
         var result = RunExpressiveGenerator(compilation);
 
-        // Should have EXP0019 diagnostic
         var exp0019 = result.Diagnostics.Where(d => d.Id == "EXP0019").ToArray();
         Assert.AreEqual(1, exp0019.Length);
     }
@@ -391,13 +387,10 @@ public class ExpressiveForTests : GeneratorTestBase
             """);
         var result = RunExpressiveGenerator(compilation);
 
-        // EXP0020 reported on each duplicate stub
         var exp0020 = result.Diagnostics.Where(d => d.Id == "EXP0020").ToArray();
         Assert.AreEqual(2, exp0020.Length);
     }
 
-    // ── Signature-matrix coverage ──────────────────────────────────────────
-    //
     // Each test below exercises one specific branch of
     // ExpressiveForSignatureMatcher (method/property, stub kind, static/instance).
     // Happy-path acceptance is covered by the snapshot tests above; this block

--- a/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/ExpressivePropertyTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/ExpressivePropertyTests.cs
@@ -13,8 +13,6 @@ namespace ExpressiveSharp.Generator.Tests.ExpressiveGenerator;
 [TestClass]
 public class ExpressivePropertyTests : GeneratorTestBase
 {
-    // ── Happy-path snapshots ────────────────────────────────────────────────
-
     [TestMethod]
     public Task ReferenceTypeTarget_EmitsCoalesceForm()
     {
@@ -36,7 +34,6 @@ public class ExpressivePropertyTests : GeneratorTestBase
         var result = RunExpressiveGenerator(compilation);
 
         Assert.AreEqual(0, result.Diagnostics.Length);
-        // Two generated files: expression factory + synthesized partial.
         Assert.AreEqual(2, result.GeneratedTrees.Length);
 
         return Verifier.Verify(string.Join("\n\n// ===\n\n",
@@ -244,8 +241,6 @@ public class ExpressivePropertyTests : GeneratorTestBase
         return Verifier.Verify(string.Join("\n\n// ===\n\n",
             result.GeneratedTrees.Select(t => t.ToString())));
     }
-
-    // ── Diagnostic tests ────────────────────────────────────────────────────
 
     [TestMethod]
     public void TargetAlreadyExists_ReportsEXP0031()

--- a/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/GlobalOptionsTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/GlobalOptionsTests.cs
@@ -7,8 +7,6 @@ namespace ExpressiveSharp.Generator.Tests.ExpressiveGenerator;
 [TestClass]
 public class GlobalOptionsTests : GeneratorTestBase
 {
-    // ── Block body (always on — no opt-in needed) ───────────────────────────
-
     [TestMethod]
     public void BlockBody_AlwaysAllowed_NoDiagnostics()
     {
@@ -30,8 +28,6 @@ public class GlobalOptionsTests : GeneratorTestBase
         Assert.AreEqual(0, result.Diagnostics.Length);
         Assert.AreEqual(1, result.GeneratedTrees.Length);
     }
-
-    // ── EnumMethodExpansion (enabled by default, disable via Disable flag) ──
 
     [TestMethod]
     public void EnumMethodExpansion_EnabledByDefault_ExpandsWithoutAttributeFlag()
@@ -85,8 +81,6 @@ public class GlobalOptionsTests : GeneratorTestBase
         Assert.IsFalse(generated.Contains("MyEnum.A =="));
     }
 
-    // ── NullConditionalMode ─────────────────────────────────────────────────
-
     [TestMethod]
     public void GlobalNullConditionalMode_Rewrite_AllowsNullConditionals()
     {
@@ -135,8 +129,6 @@ public class GlobalOptionsTests : GeneratorTestBase
         Assert.AreEqual(0, result.Diagnostics.Length);
         Assert.AreEqual(1, result.GeneratedTrees.Length);
     }
-
-    // ── Hard-coded defaults ─────────────────────────────────────────────────
 
     [TestMethod]
     public void NoGlobalOptions_HardCodedDefaultsApply_BlockBodyWorks()

--- a/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/MissingExpressiveDiagnosticTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/ExpressiveGenerator/MissingExpressiveDiagnosticTests.cs
@@ -15,8 +15,6 @@ namespace ExpressiveSharp.Generator.Tests.ExpressiveGenerator;
 [TestClass]
 public class MissingExpressiveDiagnosticTests : GeneratorTestBase
 {
-    // ── Positive: EXP0013 fires ─────────────────────────────────────────────
-
     [TestMethod]
     public async Task MethodCall_ToSourceMethodWithExpressionBody_WarnsEXP0013()
     {
@@ -159,8 +157,6 @@ public class MissingExpressiveDiagnosticTests : GeneratorTestBase
             "EXP0013 should include the declaration as an additional location");
     }
 
-    // ── Negative: no EXP0013 ────────────────────────────────────────────────
-
     [TestMethod]
     public async Task MethodCall_ToMethodWithExpressive_NoWarning()
     {
@@ -269,8 +265,6 @@ public class MissingExpressiveDiagnosticTests : GeneratorTestBase
         Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0013"),
             "Should not warn for enum extension method — generator expands these via TryEmitEnumMethodExpansion");
     }
-
-    // ── Prong 2: IExpressiveQueryable LINQ lambdas ────────────────────────
 
     [TestMethod]
     public async Task ExpressiveQueryable_Select_WithNonExpressiveExtensionMethod_WarnsEXP0013()
@@ -389,8 +383,6 @@ public class MissingExpressiveDiagnosticTests : GeneratorTestBase
             "Expected EXP0013 for non-[Expressive] method group in IExpressiveQueryable Select");
     }
 
-    // ── Prong 2 Negative: no EXP0013 in LINQ lambdas ───────────────────────
-
     [TestMethod]
     public async Task ExpressiveQueryable_WithExpressiveMethod_NoWarning()
     {
@@ -506,8 +498,6 @@ public class MissingExpressiveDiagnosticTests : GeneratorTestBase
             "Should not warn for enum extension method in IExpressiveQueryable LINQ lambda");
     }
 
-    // ── Sibling-mapping suppression ─────────────────────────────────────────
-    //
     // When a stub on the same type registers an expression for a member via
     // [ExpressiveProperty("X")] or [ExpressiveFor(nameof(X))], the referenced member
     // is effectively expressive — EXP0013 must not fire on it.
@@ -558,8 +548,6 @@ public class MissingExpressiveDiagnosticTests : GeneratorTestBase
         Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0013"),
             "Should not warn for a reference to an [ExpressiveFor]-mapped same-type target");
     }
-
-    // ── Helper ──────────────────────────────────────────────────────────────
 
     private async Task<ImmutableArray<Diagnostic>> RunAnalyzerAsync(string source)
     {

--- a/tests/ExpressiveSharp.Generator.Tests/Infrastructure/GeneratorTestBase.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/Infrastructure/GeneratorTestBase.cs
@@ -28,23 +28,18 @@ public abstract partial class GeneratorTestBase
 
         public ImmutableArray<Diagnostic> Diagnostics => _inner.Diagnostics;
 
-        /// <summary>Generated trees excluding <c>ExpressionRegistry.g.cs</c> and <c>*.Attributes.g.cs</c>.</summary>
         public ImmutableArray<SyntaxTree> GeneratedTrees =>
             _inner.GeneratedTrees
                 .Where(t => !t.FilePath.EndsWith("ExpressionRegistry.g.cs", StringComparison.Ordinal)
                     && !t.FilePath.EndsWith(".Attributes.g.cs", StringComparison.Ordinal))
                 .ToImmutableArray();
 
-        /// <summary>All generated trees including <c>ExpressionRegistry.g.cs</c>.</summary>
         public ImmutableArray<SyntaxTree> AllGeneratedTrees => _inner.GeneratedTrees;
 
-        /// <summary>The registry tree, or <c>null</c> if none was generated.</summary>
         public SyntaxTree? RegistryTree =>
             _inner.GeneratedTrees
                 .FirstOrDefault(t => t.FilePath.EndsWith("ExpressionRegistry.g.cs", StringComparison.Ordinal));
     }
-
-    // ── Reference helpers ────────────────────────────────────────────────────
 
     protected IReadOnlyList<MetadataReference> GetDefaultReferences()
     {
@@ -77,8 +72,6 @@ public abstract partial class GeneratorTestBase
             .WithLanguageVersion(languageVersion)
             .WithFeatures([interceptorFeature]);
     }
-
-    // ── Compilation factory ──────────────────────────────────────────────────
 
     private const string GlobalUsings = """
         global using System;
@@ -120,8 +113,6 @@ public abstract partial class GeneratorTestBase
         LogSourceDiagnostics(compilation);
         return compilation;
     }
-
-    // ── Generator runners ────────────────────────────────────────────────────
 
     protected TestGeneratorRunResult RunExpressiveGenerator(
         Compilation compilation,
@@ -172,8 +163,6 @@ public abstract partial class GeneratorTestBase
         return result;
     }
 
-    // ── Logging helpers ──────────────────────────────────────────────────────
-
     private void LogSourceDiagnostics(Compilation compilation)
     {
         var diagnostics = compilation.GetDiagnostics();
@@ -183,8 +172,6 @@ public abstract partial class GeneratorTestBase
         TestContext.WriteLine("Source compilation diagnostics:");
         foreach (var d in diagnostics)
             TestContext.WriteLine("  > " + d);
-
-        // Note: source errors are expected in negative test cases; individual tests assert as needed.
     }
 
     private void LogGeneratorResult(TestGeneratorRunResult result, Compilation outputCompilation)
@@ -241,8 +228,6 @@ public abstract partial class GeneratorTestBase
                 TestContext.WriteLine("  > " + e);
         }
     }
-
-    // ── MSBuild global property injection ────────────────────────────────────
 
     private sealed class DictionaryAnalyzerConfigOptions : AnalyzerConfigOptions
     {

--- a/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/PolyfillInterceptorGenerator/ScalarMethodTests.cs
@@ -7,8 +7,6 @@ namespace ExpressiveSharp.Generator.Tests.PolyfillInterceptorGenerator;
 [TestClass]
 public class ScalarMethodTests : GeneratorTestBase
 {
-    // ── Predicate methods (bool-returning) ───────────────────────────────
-
     [TestMethod]
     public Task Any_GeneratesScalarInterceptor()
     {
@@ -61,8 +59,6 @@ public class ScalarMethodTests : GeneratorTestBase
         return Verifier.Verify(result.GeneratedTrees[0].GetText().ToString());
     }
 
-    // ── Counting methods ─────────────────────────────────────────────────
-
     [TestMethod]
     public Task Count_GeneratesScalarInterceptor()
     {
@@ -114,8 +110,6 @@ public class ScalarMethodTests : GeneratorTestBase
 
         return Verifier.Verify(result.GeneratedTrees[0].GetText().ToString());
     }
-
-    // ── Element methods ──────────────────────────────────────────────────
 
     [TestMethod]
     public Task First_GeneratesScalarInterceptor()
@@ -273,8 +267,6 @@ public class ScalarMethodTests : GeneratorTestBase
         return Verifier.Verify(result.GeneratedTrees[0].GetText().ToString());
     }
 
-    // ── Min / Max ────────────────────────────────────────────────────────
-
     [TestMethod]
     public Task Min_GenericSelector_GeneratesScalarInterceptor()
     {
@@ -378,8 +370,6 @@ public class ScalarMethodTests : GeneratorTestBase
 
         return Verifier.Verify(result.GeneratedTrees[0].GetText().ToString());
     }
-
-    // ── Sum ──────────────────────────────────────────────────────────────
 
     [TestMethod]
     public Task Sum_IntSelector_GeneratesScalarInterceptor()
@@ -640,8 +630,6 @@ public class ScalarMethodTests : GeneratorTestBase
 
         return Verifier.Verify(result.GeneratedTrees[0].GetText().ToString());
     }
-
-    // ── Average ──────────────────────────────────────────────────────────
 
     [TestMethod]
     public Task Average_IntSelector_GeneratesScalarInterceptor()

--- a/tests/ExpressiveSharp.IntegrationTests/Infrastructure/ExpressionCompileRunner.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Infrastructure/ExpressionCompileRunner.cs
@@ -3,15 +3,6 @@ using ExpressiveSharp.IntegrationTests.Scenarios.Store.Models;
 
 namespace ExpressiveSharp.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// In-memory helper used by the ExpressionCompile test classes. Compiles
-/// expression trees to delegates and runs them against seeded
-/// <see cref="List{T}"/> collections — no database involved.
-///
-/// Validates that expanded expression trees are behaviorally correct at
-/// runtime (verification level 3 in docs/advanced/testing-strategy.md) without
-/// relying on any ORM-specific translation.
-/// </summary>
 internal sealed class ExpressionCompileRunner
 {
     private List<Order> _orders = new();

--- a/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/DisplayFormatter.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/DisplayFormatter.cs
@@ -2,18 +2,8 @@ using ExpressiveSharp.Mapping;
 
 namespace ExpressiveSharp.IntegrationTests.Scenarios.Store.Models;
 
-/// <summary>
-/// Represents an external (e.g. third-party) class with <b>instance</b>
-/// methods and properties. Demonstrates two <c>[ExpressiveFor]</c> styles in one model:
-/// <list type="bullet">
-///   <item>The <c>Wrap</c> mapping uses the ergonomic co-located form — an <b>instance stub</b>
-///         with the <b>single-argument</b> attribute, where the stub's <c>this</c> is the receiver.</item>
-///   <item>The <c>Label</c> mapping uses the original external form — a static stub in
-///         <see cref="DisplayFormatterMappings"/> with the explicit receiver parameter.</item>
-/// </list>
-/// Integration tests assert both paths produce identical runtime behavior, so regressions
-/// in either the new or the legacy form are caught end-to-end.
-/// </summary>
+// Exercises both [ExpressiveFor] styles: Wrap uses co-located instance-stub form;
+// Label uses static stub with explicit receiver in DisplayFormatterMappings.
 public class DisplayFormatter
 {
     public string Prefix { get; }
@@ -25,10 +15,8 @@ public class DisplayFormatter
         Suffix = suffix;
     }
 
-    /// <summary>Wraps a string with the configured prefix/suffix — instance method.</summary>
     public string Wrap(string value) => Prefix + value + Suffix;
 
-    /// <summary>Label that combines the prefix/suffix — instance property.</summary>
     public string Label => "[" + Prefix + "/" + Suffix + "]";
 
     // Single-arg + instance-stub form: the target is Wrap on this type, and the stub's `this`
@@ -38,10 +26,6 @@ public class DisplayFormatter
     string WrapExpr(string value) => Prefix + value + Suffix;
 }
 
-/// <summary>
-/// <c>[ExpressiveFor]</c> mapping for <see cref="DisplayFormatter.Label"/> using the original
-/// external-class form (static stub with explicit receiver parameter).
-/// </summary>
 static class DisplayFormatterMappings
 {
     [ExpressiveFor(typeof(DisplayFormatter), nameof(DisplayFormatter.Label))]

--- a/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/Order.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/Order.cs
@@ -15,11 +15,9 @@ public class Order
     [Expressive]
     public double Total => Price * Quantity;
 
-    // Multi-level null-conditional chain: Order → Customer → Address → Country
     [Expressive]
     public string? CustomerCountry => Customer?.Address?.Country;
 
-    // Tuple projection
     [Expressive]
     public (int Id, string Grade, double Total) GetOrderSummaryTuple()
         => (Id, GetGrade(), Total);
@@ -80,19 +78,17 @@ public class Order
     [Expressive]
     public string Summary => $"Order #{Id}: {Tag ?? "N/A"}";
 
-    // String concatenation via + operator (tests Expression.Call(string.Concat) emission)
     [Expressive]
     public string SummaryConcat => "Order #" + Id + ": " + (Tag ?? "N/A");
 
-    // Format specifier: works in-memory but not translatable to SQL
+    // Format specifier: works in-memory but not translatable to SQL.
     [Expressive]
     public string FormattedPrice => $"{Price:F2}";
 
-    // 5+ interpolation parts: tests string.Concat(string[]) overload
+    // 5+ interpolation parts: exercises string.Concat(string[]) overload.
     [Expressive]
     public string DetailedSummary => $"Order #{Id}: {Tag ?? "N/A"} (${Price})";
 
-    // Loop-based computed members (foreach → Expression.Loop)
     [Expressive(AllowBlockBody = true)]
     public int ItemCount()
     {
@@ -136,23 +132,18 @@ public class Order
         return total;
     }
 
-    // Collection expression: array literal
     [Expressive]
     public int[] PriceBreakpoints => [10, 50, 100];
 
-    // Tuple equality
     [Expressive]
     public bool IsPriceQuantityMatch => (Price, Quantity) == (50.0, 5);
 
-    // Tuple inequality
     [Expressive]
     public bool IsPriceQuantityDifferent => (Price, Quantity) != (50.0, 5);
 
-    // Checked arithmetic
     [Expressive]
     public double CheckedTotal => checked(Price * Quantity);
 
-    // Throw expression in null-coalescing
     [Expressive]
     public string SafeTag => Tag ?? throw new InvalidOperationException("Tag is required");
 }

--- a/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/PriceInfo.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/PriceInfo.cs
@@ -1,9 +1,5 @@
 namespace ExpressiveSharp.IntegrationTests.Scenarios.Store.Models;
 
-/// <summary>
-/// Record used by the C# language feature tests to exercise <c>with</c>
-/// expressions in lambdas that get compiled to expression trees.
-/// </summary>
 public record PriceInfo(double BasePrice, double Multiplier)
 {
     public double Final => BasePrice * Multiplier;

--- a/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/PricingUtils.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Scenarios/Store/Models/PricingUtils.cs
@@ -2,28 +2,17 @@ using ExpressiveSharp.Mapping;
 
 namespace ExpressiveSharp.IntegrationTests.Scenarios.Store.Models;
 
-/// <summary>
-/// A utility class representing an external/third-party library whose methods
-/// cannot normally be used in EF Core LINQ queries because EF Core has no
-/// built-in SQL translation for them.
-///
-/// With [ExpressiveFor], we provide expression-tree equivalents that EF Core CAN translate.
-/// </summary>
+// External/third-party utility class with no built-in EF Core SQL translation;
+// [ExpressiveFor] mappings below supply translatable expression bodies.
 public static class PricingUtils
 {
-    /// <summary>Clamps a value between min and max.</summary>
     public static double Clamp(double value, double min, double max)
         => Math.Max(min, Math.Min(max, value));
 
-    /// <summary>Applies a percentage discount to a price.</summary>
     public static double ApplyDiscount(double price, double discountPercent)
         => price * (1 - discountPercent / 100.0);
 }
 
-/// <summary>
-/// Provides expression-tree bodies for <see cref="PricingUtils"/> methods,
-/// enabling them to be used in EF Core queries via <c>ExpandExpressives()</c>.
-/// </summary>
 static class PricingUtilsMappings
 {
     [ExpressiveFor(typeof(PricingUtils), nameof(PricingUtils.Clamp))]

--- a/tests/ExpressiveSharp.IntegrationTests/Tests/AnonymousTypeInterceptorTests.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Tests/AnonymousTypeInterceptorTests.cs
@@ -2,11 +2,7 @@ using ExpressiveSharp.IntegrationTests.Scenarios.Store.Models;
 
 namespace ExpressiveSharp.IntegrationTests.Tests;
 
-/// <summary>
-/// Integration tests for anonymous type scenarios that verify the generated
-/// interceptors compile and produce correct results at runtime.
-/// Covers fixes for GitHub issues #8 (Join anonymous result) and #9 (anonymous element type).
-/// </summary>
+// Regression coverage for GitHub issues #8 (Join anonymous result) and #9 (anonymous element type).
 [TestClass]
 public class AnonymousTypeInterceptorTests
 {
@@ -17,10 +13,7 @@ public class AnonymousTypeInterceptorTests
         new Order { Id = 3, Tag = null, Price = 10, Quantity = 3 },
     };
 
-    /// <summary>
-    /// Issue #9: Where after Select into anonymous type should produce
-    /// a working interceptor with generic TElem parameter.
-    /// </summary>
+    // Issue #9: Where after Select into anonymous type — interceptor with generic TElem parameter.
     [TestMethod]
     public void Select_AnonymousType_ThenWhere_CompilesAndRuns()
     {
@@ -35,9 +28,6 @@ public class AnonymousTypeInterceptorTests
         Assert.IsTrue(results.Any(r => r.Id == 2)); // 75*20 = 1500 > 100
     }
 
-    /// <summary>
-    /// Issue #9: OrderByDescending after Select into anonymous type.
-    /// </summary>
     [TestMethod]
     public void Select_AnonymousType_ThenOrderByDescending_CompilesAndRuns()
     {
@@ -53,9 +43,6 @@ public class AnonymousTypeInterceptorTests
         Assert.AreEqual(3, results[2].Id); // 30
     }
 
-    /// <summary>
-    /// Issue #9: Select from anonymous element type to a concrete type.
-    /// </summary>
     [TestMethod]
     public void Select_AnonymousType_ThenSelectConcrete_CompilesAndRuns()
     {
@@ -68,10 +55,7 @@ public class AnonymousTypeInterceptorTests
         CollectionAssert.AreEquivalent(new[] { 1, 2, 3 }, results);
     }
 
-    /// <summary>
-    /// Issue #8: Join with anonymous result selector should produce
-    /// a working interceptor with generic type parameters.
-    /// </summary>
+    // Issue #8: Join with anonymous result selector — interceptor with generic type parameters.
     [TestMethod]
     public void Join_AnonymousResultSelector_CompilesAndRuns()
     {
@@ -94,10 +78,8 @@ public class AnonymousTypeInterceptorTests
         Assert.IsTrue(results.Any(r => r.OrderTag == "STD" && r.ProductName == "Gadget"));
     }
 
-    /// <summary>
-    /// Issue #9: DistinctBy after Select into anonymous type, exercising
-    /// EmitGenericSingleLambda with anonymous element type.
-    /// </summary>
+    // Issue #9: DistinctBy after Select into anonymous type — exercises EmitGenericSingleLambda
+    // with anonymous element type.
     [TestMethod]
     public void Select_AnonymousType_ThenDistinctBy_CompilesAndRuns()
     {

--- a/tests/ExpressiveSharp.IntegrationTests/Tests/CommonScenarioTests.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Tests/CommonScenarioTests.cs
@@ -6,16 +6,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.IntegrationTests.Tests;
 
-/// <summary>
-/// Scenario tests that compile expanded expression trees to delegates and run
-/// them against seeded in-memory collections. Validates every feature
-/// (arithmetic, switch expressions, pattern matching, null-conditional chains,
-/// loops, tuples, constructor projections, etc.) at runtime without touching
-/// any ORM.
-///
-/// The parallel EF Core integration tests live in
-/// <c>ExpressiveSharp.EntityFrameworkCore.IntegrationTests</c>.
-/// </summary>
 [TestClass]
 public class CommonScenarioTests
 {
@@ -26,8 +16,6 @@ public class CommonScenarioTests
     {
         _runner.Seed(SeedData.Addresses, SeedData.Customers, SeedData.Orders, SeedData.LineItems);
     }
-
-    // ── Arithmetic ──────────────────────────────────────────────────────────
 
     [TestMethod]
     public void Select_Total_ReturnsCorrectValues()
@@ -85,8 +73,6 @@ public class CommonScenarioTests
         CollectionAssert.AreEqual(new[] { 2, 4, 1, 3 }, results);
     }
 
-    // ── Block Body ──────────────────────────────────────────────────────────
-
     [TestMethod]
     public void Select_GetCategory_ReturnsCorrectValues()
     {
@@ -112,8 +98,6 @@ public class CommonScenarioTests
             new[] { "Regular", "Bulk", "Regular", "Regular" },
             results);
     }
-
-    // ── Checked Arithmetic ──────────────────────────────────────────────────
 
     [TestMethod]
     public void Select_CheckedTotal_ReturnsCorrectValues()
@@ -142,8 +126,6 @@ public class CommonScenarioTests
         CollectionAssert.AreEqual(new[] { 1, 2, 4 }, ids);
     }
 
-    // ── Collection Expression ───────────────────────────────────────────────
-
     [TestMethod]
     public void Select_PriceBreakpoints_ReturnsArrayLiteral()
     {
@@ -158,8 +140,6 @@ public class CommonScenarioTests
             CollectionAssert.AreEqual(new[] { 10, 50, 100 }, breakpoints);
         }
     }
-
-    // ── Constructor Projection ──────────────────────────────────────────────
 
     [TestMethod]
     public void Select_OrderDto_ProjectsCorrectly()
@@ -219,8 +199,6 @@ public class CommonScenarioTests
         Assert.AreEqual(1500.0, results.Single(r => r.Id == 2).Total);
     }
 
-    // ── Enum Expansion ──────────────────────────────────────────────────────
-
     [TestMethod]
     public void Select_StatusDescription_ReturnsCorrectValues()
     {
@@ -247,8 +225,6 @@ public class CommonScenarioTests
         Assert.AreEqual(1, dict["Order approved"]);
         Assert.AreEqual(1, dict["Order rejected"]);
     }
-
-    // ── ExpressiveFor Mapping ───────────────────────────────────────────────
 
     [TestMethod]
     public void Select_ClampedPrice_ReturnsCorrectValues()
@@ -291,8 +267,6 @@ public class CommonScenarioTests
             Assert.IsTrue(results.Any(r => Math.Abs(r - exp) < 0.001), $"Expected {exp} in results");
     }
 
-    // ── ExpressiveFor on instance method ────────────────────────────────────
-
     [TestMethod]
     public void Select_InstanceMethod_ViaExpressiveFor_ReturnsCorrectValues()
     {
@@ -322,8 +296,6 @@ public class CommonScenarioTests
             new[] { "[A/B]:1", "[A/B]:2", "[A/B]:3", "[A/B]:4" },
             results);
     }
-
-    // ── Loop Tests ──────────────────────────────────────────────────────────
 
     [TestMethod]
     public void Select_ItemCount_ReturnsCorrectCounts()
@@ -379,8 +351,6 @@ public class CommonScenarioTests
 
         CollectionAssert.AreEquivalent(new[] { 150.0, 500.0, 0.0, 0.0 }, results);
     }
-
-    // ── Null Conditional ────────────────────────────────────────────────────
 
     [TestMethod]
     public void Select_CustomerName_ReturnsCorrectNullableValues()
@@ -449,8 +419,6 @@ public class CommonScenarioTests
         Assert.AreEqual(3, results[0]); // Order 3 has null Tag
     }
 
-    // ── Nullable Chain ──────────────────────────────────────────────────────
-
     [TestMethod]
     public void Select_CustomerCountry_TwoLevelChain()
     {
@@ -487,8 +455,6 @@ public class CommonScenarioTests
 
         CollectionAssert.AreEquivalent(new[] { "New York", "London", null }, results);
     }
-
-    // ── Pattern Matching ────────────────────────────────────────────────────
 
     [TestMethod]
     public void Where_IsPattern_NullCheck()
@@ -542,8 +508,6 @@ public class CommonScenarioTests
             results);
     }
 
-    // ── Polyfill Pathway ────────────────────────────────────────────────────
-
     [TestMethod]
     public void Polyfill_SimpleCondition_FiltersCorrectly()
     {
@@ -585,8 +549,6 @@ public class CommonScenarioTests
         CollectionAssert.AreEquivalent(new[] { "RUSH", "STD", "N/A", "SPECIAL" }, results);
     }
 
-    // ── String Operations ───────────────────────────────────────────────────
-
     [TestMethod]
     public void Select_Summary_ReturnsCorrectValues()
     {
@@ -624,8 +586,6 @@ public class CommonScenarioTests
             },
             results);
     }
-
-    // ── Switch Expression ───────────────────────────────────────────────────
 
     [TestMethod]
     public void Select_GetGrade_ReturnsCorrectValues()
@@ -681,8 +641,6 @@ public class CommonScenarioTests
         Assert.AreEqual(1, dict["Budget"]);
     }
 
-    // ── Tuple Binary ────────────────────────────────────────────────────────
-
     [TestMethod]
     public void Select_IsPriceQuantityMatch_ReturnsCorrectValues()
     {
@@ -716,8 +674,6 @@ public class CommonScenarioTests
         Assert.AreEqual(1, results.Count);
         Assert.AreEqual(4, results[0].Id);
     }
-
-    // ── Tuple Projection ────────────────────────────────────────────────────
 
     [TestMethod]
     public void Select_InlineTuple_ProjectsCorrectly()
@@ -755,13 +711,8 @@ public class CommonScenarioTests
         Assert.IsTrue(results.Contains((3, "none")));
     }
 
-    // ── C# Language Feature Coverage ────────────────────────────────────
-    //
-    // These features are documented as supported by the generator but have
-    // no integration coverage elsewhere. Tests live in the ExpressionCompile
-    // path because most of them (with expressions, dictionary initializers)
-    // don't SQL-translate.
-
+    // C# language features below live in the ExpressionCompile path because
+    // most (with expressions, dictionary initializers) don't SQL-translate.
     [TestMethod]
     public void WithExpression_OnRecord_ReturnsModifiedInstance()
     {

--- a/tests/ExpressiveSharp.IntegrationTests/Tests/MultiLambdaInterceptorTests.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Tests/MultiLambdaInterceptorTests.cs
@@ -26,17 +26,13 @@ public class MultiLambdaInterceptorTests
         },
     };
 
-    /// <summary>
-    /// SelectMany with result selector uses two lambdas that share the parameter name 'o'.
-    /// This tests that the generator emits unique variable names for each lambda body.
-    /// </summary>
+    // Both lambdas reuse parameter name 'o' — verifies generator emits unique
+    // local variable names per lambda body.
     [TestMethod]
     public void SelectMany_WithResultSelector_SharedParamName_CompilesAndRuns()
     {
         var source = _orders.AsQueryable();
 
-        // Both lambdas use 'o' — this triggers the duplicate variable name bug
-        // if the generator doesn't prefix local variables per lambda.
         var results = source.AsExpressive()
             .SelectMany(o => o.Items, (o, item) => o.Tag + ": " + item.ProductName)
             .ToList();
@@ -47,11 +43,8 @@ public class MultiLambdaInterceptorTests
         CollectionAssert.Contains(results, "B: Doohickey");
     }
 
-    /// <summary>
-    /// Join with three lambdas where outer and inner key selectors share parameter patterns.
-    /// Tests unique variable naming across all three lambda bodies.
-    /// Uses non-nullable int keys (Id) to avoid nullable type mismatch issues.
-    /// </summary>
+    // Three lambdas with overlapping param patterns — exercises unique variable naming
+    // across lambda bodies. Uses non-nullable int keys to avoid type mismatch.
     [TestMethod]
     public void Join_ThreeLambdas_CompilesAndRuns()
     {
@@ -74,10 +67,8 @@ public class MultiLambdaInterceptorTests
         CollectionAssert.Contains(results, "B: Gadget");
     }
 
-    /// <summary>
-    /// Join where the outer key is nullable (int?) but the inner key is non-nullable (int).
-    /// The emitter must insert an implicit conversion so the expression tree compiles.
-    /// </summary>
+    // Nullable outer key (int?) vs non-nullable inner key (int) — emitter must
+    // insert an implicit conversion so the expression tree compiles.
     [TestMethod]
     public void Join_NullableOuterKey_NonNullableInnerKey_CompilesAndRuns()
     {

--- a/tests/ExpressiveSharp.IntegrationTests/Tests/StoreQueryTests.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Tests/StoreQueryTests.cs
@@ -6,10 +6,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExpressiveSharp.IntegrationTests.Tests;
 
-/// <summary>
-/// Store-domain queries that combine multiple ExpressiveSharp features in a
-/// single query, compiled to delegates and run in-memory.
-/// </summary>
 [TestClass]
 public class StoreQueryTests
 {

--- a/tests/ExpressiveSharp.IntegrationTests/Tests/SynthesizedExpressiveTests.cs
+++ b/tests/ExpressiveSharp.IntegrationTests/Tests/SynthesizedExpressiveTests.cs
@@ -13,8 +13,6 @@ namespace ExpressiveSharp.IntegrationTests.Tests;
 [TestClass]
 public class SynthesizedExpressiveTests
 {
-    // ── In-memory runtime behavior ──────────────────────────────────────────
-
     [TestMethod]
     public void InMemoryConstruction_ReadsComputeFromFormula()
     {
@@ -73,8 +71,6 @@ public class SynthesizedExpressiveTests
 
         Assert.AreEqual("(unnamed) <no-email>", entity.DisplayLabel);
     }
-
-    // ── Expression-tree expansion ──────────────────────────────────────────
 
     [TestMethod]
     public void ExpandExpressives_Select_RewritesSynthesizedToFormula()

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Infrastructure/MongoTestBase.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Infrastructure/MongoTestBase.cs
@@ -6,10 +6,6 @@ using MongoDB.Driver;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Infrastructure;
 
-/// <summary>
-/// Base class for all MongoDB integration tests. Creates a unique database per test,
-/// seeds embedded Order documents, and drops the database on cleanup.
-/// </summary>
 public abstract class MongoTestBase
 {
     protected IMongoDatabase Database { get; private set; } = null!;
@@ -41,10 +37,7 @@ public abstract class MongoTestBase
             await _client.DropDatabaseAsync(_dbName);
     }
 
-    /// <summary>
-    /// Seeds the database with embedded Order documents.
-    /// Customer and Address are embedded within each Order (document model).
-    /// </summary>
+    // Customer and Address are embedded within each Order (document model).
     protected virtual async Task SeedDataAsync()
     {
         var addressLookup = SeedData.Addresses.ToDictionary(a => a.Id);

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/AsyncMethodTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/AsyncMethodTests.cs
@@ -6,10 +6,6 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies MongoDB-specific async methods work through delegate-based stubs
-/// with <c>[PolyfillTarget(typeof(MongoQueryable))]</c>.
-/// </summary>
 [TestClass]
 public class AsyncMethodTests : MongoTestBase
 {

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/EmbeddedDocumentTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/EmbeddedDocumentTests.cs
@@ -7,17 +7,12 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies expressive features work with MongoDB's embedded document model.
-/// </summary>
 [TestClass]
 public class EmbeddedDocumentTests : MongoTestBase
 {
     [TestMethod]
     public async Task ExpressiveMember_OnEmbeddedDocument_Expands()
     {
-        // CustomerName is [Expressive] => Customer?.Name
-        // Customer is an embedded document in MongoDB
         Expression<Func<Order, string?>> expr = o => o.CustomerName;
         var expanded = (Expression<Func<Order, string?>>)expr.ExpandExpressives();
 
@@ -36,8 +31,6 @@ public class EmbeddedDocumentTests : MongoTestBase
     [TestMethod]
     public async Task NullConditional_ThroughEmbeddedDocument_Works()
     {
-        // CustomerCountry is [Expressive] => Customer?.Address?.Country
-        // Two levels of embedded document navigation
         Expression<Func<Order, string?>> expr = o => o.CustomerCountry;
         var expanded = (Expression<Func<Order, string?>>)expr.ExpandExpressives();
 

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/ExpressiveMongoCollectionTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/ExpressiveMongoCollectionTests.cs
@@ -6,10 +6,6 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies the <see cref="ExpressiveMongoCollection{TDocument}"/> high-level wrapper
-/// correctly provides queryable access and delegates CRUD operations.
-/// </summary>
 [TestClass]
 public class ExpressiveMongoCollectionTests : MongoTestBase
 {
@@ -26,17 +22,14 @@ public class ExpressiveMongoCollectionTests : MongoTestBase
     {
         var wrapper = new ExpressiveMongoCollection<Order>(Orders);
 
-        // Insert via inner
         var newOrder = new Order { Id = 100, Tag = "TEST", Price = 99.0, Quantity = 1, Status = OrderStatus.Approved };
         await wrapper.Inner.InsertOneAsync(newOrder);
 
-        // Query via wrapper
         var results = await MongoQueryable.ToListAsync(
             wrapper.AsQueryable().Where(o => o.Id == 100));
         Assert.AreEqual(1, results.Count);
         Assert.AreEqual("TEST", results[0].Tag);
 
-        // Delete via inner
         await wrapper.Inner.DeleteOneAsync(Builders<Order>.Filter.Eq(o => o.Id, 100));
         var count = await MongoQueryable.CountAsync(
             wrapper.AsQueryable().Where(o => o.Id == 100));
@@ -48,7 +41,6 @@ public class ExpressiveMongoCollectionTests : MongoTestBase
     {
         var wrapper = new ExpressiveMongoCollection<Order>(Orders);
 
-        // End-to-end: collection → queryable → Where(computed property) → ToListAsync
         var results = await MongoQueryable.ToListAsync(
             wrapper.AsQueryable()
                 .Where(o => o.Price > 50)

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/ExpressiveMongoQueryProviderTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/ExpressiveMongoQueryProviderTests.cs
@@ -8,21 +8,15 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies that <see cref="ExpressiveMongoQueryProvider"/> correctly
-/// expands <c>[Expressive]</c> members before MongoDB's LINQ provider processes the query.
-/// </summary>
 [TestClass]
 public class ExpressiveMongoQueryProviderTests : MongoTestBase
 {
     [TestMethod]
     public async Task Select_ExpressiveMember_ExpandsBeforeMongoTranslation()
     {
-        // Total is [Expressive] => Price * Quantity
-        // Provider should expand before MongoDB sees it.
-        // Use the collection-based AsExpressive so the ExpressiveMongoQueryProvider is
-        // in the chain — otherwise the core wrapper forwards to MongoDB's raw provider,
-        // which has no way to expand [Expressive] members on a lambda Select.
+        // Use collection-based AsExpressive so ExpressiveMongoQueryProvider is in the
+        // chain — otherwise the core wrapper forwards to MongoDB's raw provider, which
+        // can't expand [Expressive] members on a lambda Select.
         var results = await Orders.AsExpressive()
             .Select(o => o.Total)
             .ToListAsync();
@@ -83,7 +77,6 @@ public class ExpressiveMongoQueryProviderTests : MongoTestBase
     [TestMethod]
     public async Task NestedExpressive_ExpandsRecursively()
     {
-        // PricingUtils.Clamp is [ExpressiveFor], Total is [Expressive]
         Expression<Func<Order, double>> expr = o => PricingUtils.Clamp(o.Total, 0.0, 200.0);
         var expanded = (Expression<Func<Order, double>>)expr.ExpandExpressives();
 

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/ExpressiveMongoQueryableTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/ExpressiveMongoQueryableTests.cs
@@ -8,10 +8,6 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies that the <see cref="IExpressiveMongoQueryable{T}"/> wrapper correctly
-/// implements the expected interfaces and preserves MongoDB capabilities.
-/// </summary>
 [TestClass]
 public class ExpressiveMongoQueryableTests : MongoTestBase
 {
@@ -43,14 +39,12 @@ public class ExpressiveMongoQueryableTests : MongoTestBase
         var baseline = Orders.AsQueryable();
         var expressive = Orders.AsExpressive();
 
-        // Both should have the same root expression (ConstantExpression pointing to the collection)
         Assert.AreEqual(baseline.Expression.NodeType, expressive.Expression.NodeType);
     }
 
     [TestMethod]
     public async Task ChainedOperations_MaintainWrapperType()
     {
-        // After Where/Select, the result should still go through our provider
         var filtered = Query.Where(o => o.Price > 50);
         Assert.IsInstanceOfType<ExpressiveMongoQueryProvider>(filtered.Provider);
 
@@ -61,7 +55,6 @@ public class ExpressiveMongoQueryableTests : MongoTestBase
     [TestMethod]
     public async Task ToCursorAsync_WorksThroughWrapper()
     {
-        // MongoDB-specific: ToCursorAsync should work through the wrapper
         using var cursor = await MongoQueryable.ToCursorAsync(Query);
         var results = new List<Order>();
         while (await cursor.MoveNextAsync())

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/PolyfillInterceptorTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/PolyfillInterceptorTests.cs
@@ -6,16 +6,9 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies that delegate-based lambdas with modern C# syntax are rewritten to
-/// expression trees by the source generator and correctly forwarded through
-/// the MongoDB provider. These features would normally fail in raw expression trees.
-/// </summary>
 [TestClass]
 public class PolyfillInterceptorTests : MongoTestBase
 {
-    // ── Null-conditional (?.) ───────────────────────────────────────────
-
     [TestMethod]
     public async Task NullConditional_PropertyAccess()
     {
@@ -69,8 +62,6 @@ public class PolyfillInterceptorTests : MongoTestBase
         CollectionAssert.AreEquivalent(new[] { 1 }, results);
     }
 
-    // ── Null-coalescing (??) ────────────────────────────────────────────
-
     [TestMethod]
     public async Task NullCoalescing_WithFallback()
     {
@@ -92,8 +83,6 @@ public class PolyfillInterceptorTests : MongoTestBase
 
         CollectionAssert.AreEqual(new[] { "Alice", "Bob", "Unknown", "Unknown" }, results);
     }
-
-    // ── Switch expressions ──────────────────────────────────────────────
 
     [TestMethod]
     public async Task SwitchExpression_OnEnum()
@@ -129,8 +118,6 @@ public class PolyfillInterceptorTests : MongoTestBase
         CollectionAssert.AreEqual(new[] { "Premium", "Standard", "Budget", "Standard" }, results);
     }
 
-    // ── Pattern matching ────────────────────────────────────────────────
-
     [TestMethod]
     public async Task PatternMatching_IsNotNull()
     {
@@ -154,8 +141,6 @@ public class PolyfillInterceptorTests : MongoTestBase
         CollectionAssert.AreEquivalent(new[] { 3 }, results);
     }
 
-    // ── Conditional (ternary) ───────────────────────────────────────────
-
     [TestMethod]
     public async Task Ternary_InSelect()
     {
@@ -169,12 +154,9 @@ public class PolyfillInterceptorTests : MongoTestBase
             new[] { "Expensive", "Expensive", "Affordable", "Affordable" }, results);
     }
 
-    // ── Compound queries ────────────────────────────────────────────────
-
     [TestMethod]
     public async Task Compound_NullConditional_WithCoalescing_InWhere()
     {
-        // Filter orders where the customer's country is unknown (null) then default
         var results = await Query
             .Where(o => (o.Customer?.Address?.Country ?? "Unknown") == "Unknown")
             .OrderBy(o => o.Id)

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/SynthesizedMongoIgnoreTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/SynthesizedMongoIgnoreTests.cs
@@ -8,11 +8,6 @@ using MongoDB.Driver;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies that <c>[ExpressiveProperty]</c> stubs are unmapped from BSON
-/// serialization by the <c>ExpressiveMongoIgnoreConvention</c>, and that the formula is
-/// correctly rewritten when referenced inside LINQ queries against the MongoDB provider.
-/// </summary>
 [TestClass]
 public class SynthesizedMongoIgnoreTests
 {
@@ -86,7 +81,6 @@ public class SynthesizedMongoIgnoreTests
     }
 }
 
-/// <summary>Self-contained document for synthesized-property Mongo tests.</summary>
 public partial class SynthesizedMongoDocument
 {
     public int Id { get; set; }

--- a/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/TransformerPipelineTests.cs
+++ b/tests/ExpressiveSharp.MongoDB.IntegrationTests/Tests/TransformerPipelineTests.cs
@@ -8,18 +8,14 @@ using MongoDB.Driver.Linq;
 
 namespace ExpressiveSharp.MongoDB.IntegrationTests.Tests;
 
-/// <summary>
-/// Verifies the default transformer pipeline produces expressions that
-/// MongoDB's LINQ provider can translate.
-/// </summary>
 [TestClass]
 public class TransformerPipelineTests : MongoTestBase
 {
     [TestMethod]
     public async Task NullConditionalPatterns_FlattenedForMongo()
     {
-        // CustomerName is [Expressive] => Customer?.Name
-        // RemoveNullConditionalPatterns should flatten the null-conditional pattern
+        // CustomerName is [Expressive] => Customer?.Name; RemoveNullConditionalPatterns
+        // must flatten the null-conditional pattern.
         Expression<Func<Order, string?>> expr = o => o.CustomerName;
         var expanded = (Expression<Func<Order, string?>>)expr.ExpandExpressives();
 
@@ -37,7 +33,6 @@ public class TransformerPipelineTests : MongoTestBase
     [TestMethod]
     public async Task BlockExpressions_Flattened()
     {
-        // GetCategory is [Expressive(AllowBlockBody = true)] with if/else
         Expression<Func<Order, string>> expr = o => o.GetCategory();
         var expanded = (Expression<Func<Order, string>>)expr.ExpandExpressives();
 
@@ -57,7 +52,7 @@ public class TransformerPipelineTests : MongoTestBase
     [TestMethod]
     public async Task ThrowExpressions_ReplacedWithDefault()
     {
-        // SafeTag => Tag ?? throw ... — ReplaceThrowWithDefault should replace throw with default
+        // SafeTag => Tag ?? throw ...; ReplaceThrowWithDefault swaps throw for default.
         Expression<Func<Order, string>> expr = o => o.SafeTag;
         var expanded = (Expression<Func<Order, string>>)expr.ExpandExpressives();
 
@@ -75,12 +70,10 @@ public class TransformerPipelineTests : MongoTestBase
     [TestMethod]
     public async Task CustomOptions_OverrideDefaults()
     {
-        // Use custom options with no transformers — raw expansion only
         var customOptions = new ExpressiveOptions();
         var customQuery = MongoDB.Extensions.MongoExpressiveExtensions.AsExpressive(
             Orders, customOptions);
 
-        // Simple query should still work (no transformers needed for basic arithmetic)
         var results = await customQuery
             .Select(o => o.Price * 2)
             .ToListAsync();

--- a/tests/ExpressiveSharp.Tests/Services/ExpressiveReplacerTests.cs
+++ b/tests/ExpressiveSharp.Tests/Services/ExpressiveReplacerTests.cs
@@ -134,8 +134,6 @@ public class ExpressiveReplacerTests
         var replacer = new ExpressiveReplacer(resolver);
         var param = Expression.Parameter(typeof(Product), "p");
 
-        // Simulate: ((object)p).Price — a convert that doesn't match an [Expressive] member
-        // More realistically: test that non-expressive access through cast passes through
         var propertyAccess = Expression.Property(param, nameof(Product.Price));
         var result = replacer.Replace(propertyAccess);
 

--- a/tests/ExpressiveSharp.Tests/Services/ExpressiveResolverTests.cs
+++ b/tests/ExpressiveSharp.Tests/Services/ExpressiveResolverTests.cs
@@ -85,8 +85,6 @@ public class ExpressiveResolverTests
             "Expected Product.Total expression to contain a Multiply node");
     }
 
-    // ── [ExpressiveProperty] ─────────────────────────────────────────────────
-    //
     // The most load-bearing correctness point: the generator must register the formula lambda
     // under the synthesized property's getter MethodHandle. If the registry were keyed off the
     // stub member (e.g. FullNameExpression), `ExpressiveReplacer` would never find a match at

--- a/tests/ExpressiveSharp.Tests/Transformers/ConvertLoopsToLinqTests.cs
+++ b/tests/ExpressiveSharp.Tests/Transformers/ConvertLoopsToLinqTests.cs
@@ -76,7 +76,6 @@ public class ConvertLoopsToLinqTests
 
         var result = _sut.Transform(loopExpr);
 
-        // Should be a MethodCallExpression to Enumerable.Sum
         Assert.IsInstanceOfType<MethodCallExpression>(result);
         var call = (MethodCallExpression)result;
         Assert.AreEqual("Sum", call.Method.Name);
@@ -152,7 +151,6 @@ public class ConvertLoopsToLinqTests
 
         var result = _sut.Transform(loopExpr);
 
-        // Should be Sum(Where(...))
         Assert.IsInstanceOfType<MethodCallExpression>(result);
         var sumCall = (MethodCallExpression)result;
         Assert.AreEqual("Sum", sumCall.Method.Name);
@@ -178,7 +176,6 @@ public class ConvertLoopsToLinqTests
     [TestMethod]
     public void ForEach_Sum_ExecutesCorrectly()
     {
-        // End-to-end: build loop, transform, compile, execute
         var items = Expression.Parameter(typeof(List<int>), "items");
         var sum = Expression.Variable(typeof(int), "sum");
 
@@ -250,7 +247,6 @@ public class ConvertLoopsToLinqTests
 
         var result = _sut.Transform(loopExpr);
 
-        // Should be ToList(Select(...))
         Assert.IsInstanceOfType<MethodCallExpression>(result);
         var toListCall = (MethodCallExpression)result;
         Assert.AreEqual("ToList", toListCall.Method.Name);

--- a/tests/ExpressiveSharp.Tests/Transformers/FlattenConcatArrayCallsTests.cs
+++ b/tests/ExpressiveSharp.Tests/Transformers/FlattenConcatArrayCallsTests.cs
@@ -147,7 +147,6 @@ public class FlattenConcatArrayCallsTests
 
         var result = _sut.Transform(call);
 
-        // Compile and invoke to verify the result is correct
         var lambda = Expression.Lambda<Func<string>>(result);
         var compiled = lambda.Compile();
         Assert.AreEqual("Hello world! How are you?", compiled());


### PR DESCRIPTION
Trim verbose XML doc summaries, redundant section-header banners (e.g. `// ── Helpers ──`), and inline commentary that restated what the code already said. No behavioral changes — generator output, runtime semantics, and tests are unaffected.