### PR TITLE
Add NotExpressive attribute and related analyzer

### DIFF
--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -38,6 +38,7 @@ See [Troubleshooting](./troubleshooting) for symptom-oriented guidance -- find t
 | [EXP0033](#exp0033) | Error | `[ExpressiveProperty]` requires an expression-bodied property stub | -- |
 | [EXP0034](#exp0034) | Error | `[ExpressiveProperty]` requires an instance stub | -- |
 | [EXP0035](#exp0035) | Error | `[ExpressiveProperty]` target shadows inherited member | -- |
+| [EXP0036](#exp0036) | Info | `IExpressiveQueryable<T>` chain dropped to plain `IQueryable<T>` | -- |
 | [EXP1001](#exp1001) | Warning | Replace `[Projectable]` with `[Expressive]` | [Replace attribute](#exp1001-fix) |
 | [EXP1002](#exp1002) | Warning | Replace `UseProjectables()` with `UseExpressives()` | [Replace method call](#exp1002-fix) |
 | [EXP1003](#exp1003) | Warning | Replace Projectables namespace | [Replace namespace](#exp1003-fix) |
@@ -642,6 +643,57 @@ on an override
 **Cause:** The target name matches a member inherited from a base class. Synthesizing a hidden member would silently shadow the base declaration, which is surprising and error-prone.
 
 **Fix:** Either pick a different target name, or drop `[ExpressiveProperty]` and make the computed value an `override` decorated with plain `[Expressive]`.
+
+---
+
+### EXP0036 -- `IExpressiveQueryable<T>` chain dropped to plain `IQueryable<T>` {#exp0036}
+
+**Severity:** Info
+**Category:** Usage
+
+**Message:**
+```
+'{0}' returns IQueryable<T> from an IExpressiveQueryable<T> receiver, dropping the expressive
+chain. Downstream LINQ skips ExpressiveSharp rewriting and [Expressive] members may evaluate
+on the client. Add an IExpressiveQueryable<T>-typed overload of '{0}', wrap the result with
+.AsExpressive(), or mark the method [NotExpressive] if the dropout is intentional.
+```
+
+**Cause:** A method invocation is being made on a receiver that implements `IExpressiveQueryable<T>`, but the method's return type is plain `IQueryable<T>` (or some derivative that is not also expressive). The chain loses its expressive type at this call site, and every downstream LINQ operation on the result skips ExpressiveSharp's rewrite step — `[Expressive]` members in subsequent `Where` / `Select` / `Include` / etc. fall back to runtime delegate invocation, which most providers cannot translate and will evaluate on the client.
+
+The diagnostic fires once, at the dropout point itself, regardless of how many further calls follow.
+
+**Common dropout shapes:**
+
+```csharp
+// User-defined helper typed on plain IQueryable<T> — drops the chain.
+public static IQueryable<T> Filter<T>(this IQueryable<T> source) => source.Where(...);
+
+db.Orders.AsExpressiveDbSet().Filter()  // ⚠ EXP0036 fires on .Filter()
+    .Include(o => o.Customer)           // chain is plain from here on
+    .ToList();
+```
+
+**Fix (preferred):** Add a sibling overload typed on `IExpressiveQueryable<T>` that returns `IExpressiveQueryable<T>`:
+
+```csharp
+public static IExpressiveQueryable<T> Filter<T>(this IExpressiveQueryable<T> source)
+    => source.Where(...);
+```
+
+**Fix (when the helper can't be modified):** wrap the result with `.AsExpressive()` to restore the chain:
+
+```csharp
+db.Orders.AsExpressiveDbSet()
+    .ThirdPartyHelper()      // returns plain IQueryable<Order>
+    .AsExpressive()          // re-wrap
+    .Include(o => o.Customer);
+```
+
+**Exemptions:**
+
+- `.AsQueryable()` — the standard explicit downcast — is sanctioned and never reported.
+- Marking the offending method with `[NotExpressive]` suppresses the diagnostic at every call site, for cases where the dropout is intentional (the helper performs work that genuinely needs to run on the client).
 
 ---
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -32,6 +32,7 @@ See [Troubleshooting](./troubleshooting) for symptom-oriented guidance -- find t
 | [EXP0017](#exp0017) | Error | `[ExpressiveFor]` return type mismatch | -- |
 | [EXP0019](#exp0019) | Error | `[ExpressiveFor]` conflicts with `[Expressive]` | -- |
 | [EXP0020](#exp0020) | Error | Duplicate `[ExpressiveFor]` mapping | -- |
+| [EXP0027](#exp0027) | Info | Plain `IQueryable` chain references an `[Expressive]` member without `.AsExpressive()` | [Wrap with `.AsExpressive()`](#exp0027-fix) |
 | [EXP0031](#exp0031) | Error | `[ExpressiveProperty]` target name is already defined | -- |
 | [EXP0032](#exp0032) | Error | `[ExpressiveProperty]` requires a partial containing type | -- |
 | [EXP0033](#exp0033) | Error | `[ExpressiveProperty]` requires an expression-bodied property stub | -- |
@@ -475,12 +476,45 @@ Duplicate [ExpressiveFor] mapping for member '{0}' on type '{1}'; only one stub 
 
 ---
 
+### EXP0027 -- Plain `IQueryable` chain references an `[Expressive]` member without `.AsExpressive()` {#exp0027}
+
+**Severity:** Info
+**Category:** Usage
+
+**Message:**
+```
+LINQ method '{0}' on a plain IQueryable<T> references the [Expressive] member '{1}'.
+Without .AsExpressive(), the member's body will not be inlined into the expression tree;
+the provider may evaluate the call in memory or fail to translate it. Wrap the source
+with .AsExpressive().
+```
+
+**Cause:** A LINQ method on a plain `IQueryable<T>` receiver (one that is not `IExpressiveQueryable<T>`) is invoked with a lambda whose body references an `[Expressive]` member. Because the chain is not expressive-aware, the source generator does not rewrite the lambda into an expression tree that inlines the member's body — the underlying query provider receives a call to the runtime delegate. Most providers cannot translate this and will either evaluate the call client-side (silent overfetch) or throw at execution time.
+
+**Fix:** Wrap the chain root with `.AsExpressive()` so that subsequent LINQ methods flow through the ExpressiveSharp delegate-based overloads, which inline `[Expressive]` member bodies at compile time.
+
+```csharp
+// Before — IsAdult is silently evaluated on the client.
+var adults = users.Where(u => u.IsAdult).ToList();
+
+// After — IsAdult is inlined into the expression tree before the provider sees it.
+var adults = users.AsExpressive().Where(u => u.IsAdult).ToList();
+```
+
+When you intentionally want to evaluate a member at runtime (e.g., it captures process state), mark the member with `[NotExpressive]` to suppress the diagnostic at every call site.
+
+#### Code Fix: Wrap source with `.AsExpressive()` {#exp0027-fix}
+
+The IDE offers a single code action: **Wrap source with `.AsExpressive()`**. It walks the LINQ chain to the leftmost non-LINQ expression, wraps it with `.AsExpressive()`, and inserts `using ExpressiveSharp;` if it is not already imported.
+
+---
+
 ## `[ExpressiveProperty]` Diagnostics (EXP0031--EXP0035)
 
 These diagnostics apply to `[ExpressiveProperty]` stubs, which ask the generator to emit a new property on the stub's containing partial type. See [`[ExpressiveProperty]` Attribute](./expressive-property) for the full feature reference.
 
 ::: info Replacing `[Expressive(Projectable = true)]`
-`[ExpressiveProperty]` replaces the now-removed `[Expressive(Projectable = true)]`. Diagnostic codes `EXP0021`--`EXP0030` were retired along with that feature and are not reused. The migration recipe is in [Migration from Projectables](../guide/migration-from-projectables#migrating-usememberbody).
+`[ExpressiveProperty]` replaces the now-removed `[Expressive(Projectable = true)]`. Diagnostic codes `EXP0021`--`EXP0026` and `EXP0028`--`EXP0030` were retired along with that feature and are not reused. (EXP0027 has been reassigned to the [plain-IQueryable analyzer](#exp0027).) The migration recipe is in [Migration from Projectables](../guide/migration-from-projectables#migrating-usememberbody).
 :::
 
 ### EXP0031 -- Target name is already defined {#exp0031}

--- a/docs/reference/expressive-attribute.md
+++ b/docs/reference/expressive-attribute.md
@@ -136,6 +136,27 @@ ExpressiveOptions.Default.AddTransformers(new RemoveNullConditionalPatterns());
 expr.ExpandExpressives(); // RemoveNullConditionalPatterns applied automatically
 ```
 
+## Opting Out: `[NotExpressive]`
+
+Use `[NotExpressive]` to mark a member that *looks* expressive-eligible (it has an expression body that the source generator could lift) but should intentionally remain runtime-evaluated. The attribute suppresses the analyzer suggestions:
+
+- [EXP0013](./diagnostics#exp0013) — "Member could benefit from `[Expressive]`"
+- [EXP0027](./diagnostics#exp0027) — "Plain `IQueryable` chain references an `[Expressive]` member without `.AsExpressive()`"
+
+```csharp
+public class Order
+{
+    public Guid Id { get; set; }
+
+    // Always evaluated in-memory — captures process-local state that would not
+    // survive translation. Suppress the "could be [Expressive]" suggestion.
+    [NotExpressive]
+    public string DebugLabel => $"{Id} (pid {System.Environment.ProcessId})";
+}
+```
+
+`[NotExpressive]` cannot be combined with `[Expressive]` on the same member.
+
 ## Complete Example
 
 ::: expressive-sample

--- a/src/ExpressiveSharp.Abstractions/NotExpressiveAttribute.cs
+++ b/src/ExpressiveSharp.Abstractions/NotExpressiveAttribute.cs
@@ -1,0 +1,17 @@
+namespace ExpressiveSharp;
+
+/// <summary>
+/// Suppresses ExpressiveSharp diagnostics that suggest decorating this member with
+/// <see cref="ExpressiveAttribute"/> or wrapping a query in <c>.AsExpressive()</c>.
+/// </summary>
+/// <remarks>
+/// Use this attribute on members whose bodies look expandable but should intentionally
+/// remain runtime-evaluated — for example, when the body relies on side effects, captures
+/// state that would not survive translation, or is deliberately client-side.
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor,
+    Inherited = true, AllowMultiple = false)]
+public sealed class NotExpressiveAttribute : Attribute
+{
+}

--- a/src/ExpressiveSharp.CodeFixers/ExpressiveQueryableDropoutAnalyzer.cs
+++ b/src/ExpressiveSharp.CodeFixers/ExpressiveQueryableDropoutAnalyzer.cs
@@ -1,0 +1,108 @@
+using System.Collections.Immutable;
+using ExpressiveSharp.CodeFixers.Internal;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ExpressiveSharp.CodeFixers;
+
+/// <summary>
+/// Reports EXP0036 at the *dropout call* itself: a method invocation whose receiver implements
+/// <c>IExpressiveQueryable&lt;T&gt;</c> but whose return type is plain <c>IQueryable&lt;T&gt;</c>.
+/// The chain stops being expressive at this call; downstream LINQ skips ExpressiveSharp rewriting.
+/// </summary>
+/// <remarks>
+/// Exemptions:
+/// <list type="bullet">
+///   <item><description><c>AsQueryable()</c> — sanctioned explicit downcast.</description></item>
+///   <item><description>Methods marked <c>[NotExpressive]</c> — opt-out for intentional dropouts.</description></item>
+/// </list>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ExpressiveQueryableDropoutAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor ExpressiveQueryableDropout = new(
+        id: "EXP0036",
+        title: "IExpressiveQueryable<T> chain dropped to plain IQueryable<T>",
+        messageFormat: "'{0}' returns IQueryable<T> from an IExpressiveQueryable<T> receiver, dropping the expressive chain. Downstream LINQ skips ExpressiveSharp rewriting and [Expressive] members may evaluate on the client. Add an IExpressiveQueryable<T>-typed overload of '{0}', wrap the result with .AsExpressive(), or mark the method [NotExpressive] if the dropout is intentional.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Once an IExpressiveQueryable<T> chain is upcast back to plain IQueryable<T>, the ExpressiveSharp rewrite layer is no longer applied to subsequent calls. User-defined helpers that take and return IQueryable<T> are the most common cause; sibling overloads typed on IExpressiveQueryable<T> preserve the chain.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(ExpressiveQueryableDropout);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        var calledName = memberAccess.Name.Identifier.Text;
+
+        // Sanctioned explicit downcast — user knows exactly what they're doing.
+        if (calledName == "AsQueryable")
+            return;
+
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+        if (symbolInfo.Symbol is not IMethodSymbol method)
+            return;
+
+        // Method-level opt-out. Honored same as EXP0027 honors it on referenced members.
+        if (ExpressiveSymbolHelpers.HasNotExpressiveAttribute(method))
+            return;
+
+        var receiverType = context.SemanticModel.GetTypeInfo(
+            memberAccess.Expression, context.CancellationToken).Type;
+        if (receiverType is null)
+            return;
+        if (!ExpressiveSymbolHelpers.IsOrImplementsExpressiveQueryable(receiverType))
+            return;
+
+        var resultType = context.SemanticModel.GetTypeInfo(invocation, context.CancellationToken).Type;
+        if (resultType is null)
+            return;
+
+        // Terminating calls (.ToList, .Count, scalars, void) don't continue the chain — no dropout.
+        if (!ImplementsIQueryable(resultType))
+            return;
+
+        // Still expressive — chain preserved, no dropout.
+        if (ExpressiveSymbolHelpers.IsOrImplementsExpressiveQueryable(resultType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            ExpressiveQueryableDropout,
+            memberAccess.Name.GetLocation(),
+            properties: null,
+            calledName));
+    }
+
+    private static bool ImplementsIQueryable(ITypeSymbol type)
+    {
+        if (IsIQueryable(type))
+            return true;
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (IsIQueryable(iface))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsIQueryable(ITypeSymbol type) =>
+        type.Name == "IQueryable" &&
+        type.ContainingNamespace?.ToDisplayString() == "System.Linq";
+}

--- a/src/ExpressiveSharp.CodeFixers/Internal/ExpressiveSymbolHelpers.cs
+++ b/src/ExpressiveSharp.CodeFixers/Internal/ExpressiveSymbolHelpers.cs
@@ -1,0 +1,87 @@
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ExpressiveSharp.CodeFixers.Internal;
+
+/// <summary>
+/// Shared classification helpers used by the diagnostics that reason about
+/// <c>[Expressive]</c>-eligible members and Expressive query chains.
+/// </summary>
+internal static class ExpressiveSymbolHelpers
+{
+    public static bool HasExpressiveAttribute(ISymbol symbol)
+        => HasAttribute(symbol, "ExpressiveAttribute");
+
+    public static bool HasNotExpressiveAttribute(ISymbol symbol)
+        => HasAttribute(symbol, "NotExpressiveAttribute");
+
+    private static bool HasAttribute(ISymbol symbol, string attributeTypeName)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            var attrClass = attr.AttributeClass;
+            if (attrClass is null)
+                continue;
+            if (attrClass.Name == attributeTypeName &&
+                attrClass.ContainingNamespace?.ToDisplayString() == "ExpressiveSharp")
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true when the symbol declares an inspectable body (expression-bodied or block-bodied)
+    /// that the source generator could lift into an expression tree if <c>[Expressive]</c> were applied.
+    /// </summary>
+    public static bool HasExpandableBody(ISymbol symbol, CancellationToken ct)
+    {
+        foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax(ct);
+
+            if (syntax is MethodDeclarationSyntax methodDecl)
+            {
+                if (methodDecl.ExpressionBody is not null || methodDecl.Body is not null)
+                    return true;
+            }
+            else if (syntax is PropertyDeclarationSyntax propDecl)
+            {
+                if (propDecl.ExpressionBody is not null)
+                    return true;
+
+                if (propDecl.AccessorList is not null)
+                {
+                    foreach (var accessor in propDecl.AccessorList.Accessors)
+                    {
+                        if (accessor.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.GetAccessorDeclaration) &&
+                            (accessor.ExpressionBody is not null || accessor.Body is not null))
+                            return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true when the type is or implements <c>ExpressiveSharp.IExpressiveQueryable&lt;T&gt;</c>.
+    /// </summary>
+    public static bool IsOrImplementsExpressiveQueryable(ITypeSymbol type)
+    {
+        if (IsExpressiveQueryableType(type))
+            return true;
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (IsExpressiveQueryableType(iface))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsExpressiveQueryableType(ITypeSymbol type) =>
+        type.Name == "IExpressiveQueryable" &&
+        type.ContainingNamespace?.ToDisplayString() == "ExpressiveSharp";
+}

--- a/src/ExpressiveSharp.CodeFixers/MissingExpressiveAnalyzer.cs
+++ b/src/ExpressiveSharp.CodeFixers/MissingExpressiveAnalyzer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using ExpressiveSharp.CodeFixers.Internal;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -47,7 +48,7 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         var memberDecl = (MemberDeclarationSyntax)context.Node;
 
         var symbol = context.SemanticModel.GetDeclaredSymbol(memberDecl, context.CancellationToken);
-        if (symbol is null || !HasExpressiveAttribute(symbol))
+        if (symbol is null || !ExpressiveSymbolHelpers.HasExpressiveAttribute(symbol))
             return;
 
         AnalyzeDescendants(context, memberDecl);
@@ -101,22 +102,7 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool IsOrImplementsExpressiveQueryable(ITypeSymbol type)
-    {
-        if (IsExpressiveQueryableType(type))
-            return true;
-
-        foreach (var iface in type.AllInterfaces)
-        {
-            if (IsExpressiveQueryableType(iface))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsExpressiveQueryableType(ITypeSymbol type) =>
-        type.Name == "IExpressiveQueryable" &&
-        type.ContainingNamespace?.ToDisplayString() == "ExpressiveSharp";
+        => ExpressiveSymbolHelpers.IsOrImplementsExpressiveQueryable(type);
 
     private static void AnalyzeDescendants(SyntaxNodeAnalysisContext context, SyntaxNode scope)
     {
@@ -218,7 +204,10 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         if (symbol.IsAbstract || symbol.IsExtern)
             return;
 
-        if (HasExpressiveAttribute(symbol))
+        if (ExpressiveSymbolHelpers.HasExpressiveAttribute(symbol))
+            return;
+
+        if (ExpressiveSymbolHelpers.HasNotExpressiveAttribute(symbol))
             return;
 
         // A sibling stub with [ExpressiveProperty("X")] or [ExpressiveFor(... "X")]
@@ -226,7 +215,7 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         if (HasSiblingMappingTargetingMember(symbol))
             return;
 
-        if (!HasExpandableBody(symbol, context.CancellationToken))
+        if (!ExpressiveSymbolHelpers.HasExpandableBody(symbol, context.CancellationToken))
             return;
 
         var declLocation = symbol.DeclaringSyntaxReferences[0]
@@ -303,48 +292,4 @@ public sealed class MissingExpressiveAnalyzer : DiagnosticAnalyzer
         attr.ConstructorArguments.Length > index
             ? attr.ConstructorArguments[index].Value as string
             : null;
-
-    private static bool HasExpressiveAttribute(ISymbol symbol)
-    {
-        foreach (var attr in symbol.GetAttributes())
-        {
-            var attrClass = attr.AttributeClass;
-            if (attrClass is null)
-                continue;
-            if (attrClass.Name == "ExpressiveAttribute" &&
-                attrClass.ContainingNamespace?.ToDisplayString() == "ExpressiveSharp")
-                return true;
-        }
-        return false;
-    }
-
-    private static bool HasExpandableBody(ISymbol symbol, System.Threading.CancellationToken ct)
-    {
-        foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
-        {
-            var syntax = syntaxRef.GetSyntax(ct);
-
-            if (syntax is MethodDeclarationSyntax methodDecl)
-            {
-                if (methodDecl.ExpressionBody is not null || methodDecl.Body is not null)
-                    return true;
-            }
-            else if (syntax is PropertyDeclarationSyntax propDecl)
-            {
-                if (propDecl.ExpressionBody is not null)
-                    return true;
-
-                if (propDecl.AccessorList is not null)
-                {
-                    foreach (var accessor in propDecl.AccessorList.Accessors)
-                    {
-                        if (accessor.IsKind(SyntaxKind.GetAccessorDeclaration) &&
-                            (accessor.ExpressionBody is not null || accessor.Body is not null))
-                            return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
 }

--- a/src/ExpressiveSharp.CodeFixers/PlainQueryableMissingAsExpressiveAnalyzer.cs
+++ b/src/ExpressiveSharp.CodeFixers/PlainQueryableMissingAsExpressiveAnalyzer.cs
@@ -1,0 +1,174 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using ExpressiveSharp.CodeFixers.Internal;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ExpressiveSharp.CodeFixers;
+
+/// <summary>
+/// Reports EXP0027 when a LINQ method on a plain <see cref="System.Linq.IQueryable{T}"/> receiver
+/// (not <c>IExpressiveQueryable&lt;T&gt;</c>) is invoked with a lambda whose body references an
+/// <c>[Expressive]</c> member. Without <c>.AsExpressive()</c>, the body of the referenced member
+/// is not expanded into the query tree and the provider may silently fall back to client-side
+/// evaluation or fail to translate the call.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PlainQueryableMissingAsExpressiveAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor PlainQueryableMissingAsExpressive = new(
+        id: "EXP0027",
+        title: "Plain IQueryable chain references an [Expressive] member without .AsExpressive()",
+        messageFormat: "LINQ method '{0}' on a plain IQueryable<T> references the [Expressive] member '{1}'. Without .AsExpressive(), the member's body will not be inlined into the expression tree; the provider may evaluate the call in memory or fail to translate it. Wrap the source with .AsExpressive().",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Marking a member [Expressive] only takes effect when the query chain is wrapped with .AsExpressive() (or runs through a provider with .UseExpressives() configured). Plain IQueryable chains skip the rewrite step, so [Expressive] member bodies fall back to runtime delegate invocation.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(PlainQueryableMissingAsExpressive);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+        if (symbolInfo.Symbol is not IMethodSymbol method)
+            return;
+
+        // Only LINQ extension methods on Queryable count — Enumerable methods are LINQ-to-Objects
+        // and gain nothing from .AsExpressive().
+        if (!IsQueryableMethod(method))
+            return;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        var receiverType = context.SemanticModel.GetTypeInfo(
+            memberAccess.Expression, context.CancellationToken).Type;
+        if (receiverType is null)
+            return;
+
+        if (!ImplementsIQueryable(receiverType))
+            return;
+
+        // If the chain is already an IExpressiveQueryable, the existing EXP0013 / EXP0021
+        // diagnostics cover it.
+        if (ExpressiveSymbolHelpers.IsOrImplementsExpressiveQueryable(receiverType))
+            return;
+
+        // Walk every lambda argument and look for a reference to an [Expressive] member.
+        foreach (var arg in invocation.ArgumentList.Arguments)
+        {
+            if (arg.Expression is not LambdaExpressionSyntax lambda)
+                continue;
+
+            var (referencedSymbol, location) = FindExpressiveReference(
+                context.SemanticModel, lambda, context.CancellationToken);
+
+            if (referencedSymbol is null || location is null)
+                continue;
+
+            var diagnosticLocation = memberAccess.Name.GetLocation();
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                PlainQueryableMissingAsExpressive,
+                diagnosticLocation,
+                additionalLocations: new[] { location },
+                properties: null,
+                method.Name,
+                referencedSymbol.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
+
+            // Only one report per invocation — additional matches would just be noise.
+            return;
+        }
+    }
+
+    private static (ISymbol? Symbol, Location? Location) FindExpressiveReference(
+        SemanticModel semanticModel, LambdaExpressionSyntax lambda, CancellationToken ct)
+    {
+        foreach (var node in lambda.DescendantNodes())
+        {
+            ISymbol? candidate = null;
+            Location? location = null;
+
+            if (node is InvocationExpressionSyntax inv)
+            {
+                var info = semanticModel.GetSymbolInfo(inv, ct);
+                if (info.Symbol is IMethodSymbol invokedMethod)
+                {
+                    candidate = invokedMethod;
+                    location = inv.Expression is MemberAccessExpressionSyntax m
+                        ? m.Name.GetLocation()
+                        : inv.Expression.GetLocation();
+                }
+            }
+            else if (node is MemberAccessExpressionSyntax memberAccess &&
+                     memberAccess.Parent is not InvocationExpressionSyntax)
+            {
+                var info = semanticModel.GetSymbolInfo(memberAccess, ct);
+                if (info.Symbol is IPropertySymbol)
+                {
+                    candidate = info.Symbol;
+                    location = memberAccess.Name.GetLocation();
+                }
+            }
+            else if (node is IdentifierNameSyntax identifier &&
+                     identifier.Parent is not MemberAccessExpressionSyntax &&
+                     identifier.Parent is not InvocationExpressionSyntax)
+            {
+                var info = semanticModel.GetSymbolInfo(identifier, ct);
+                if (info.Symbol is IPropertySymbol)
+                {
+                    candidate = info.Symbol;
+                    location = identifier.GetLocation();
+                }
+            }
+
+            if (candidate is null || location is null)
+                continue;
+
+            if (ExpressiveSymbolHelpers.HasNotExpressiveAttribute(candidate))
+                continue;
+
+            if (!ExpressiveSymbolHelpers.HasExpressiveAttribute(candidate))
+                continue;
+
+            return (candidate, location);
+        }
+
+        return (null, null);
+    }
+
+    private static bool IsQueryableMethod(IMethodSymbol method) =>
+        method.ContainingType?.Name == "Queryable" &&
+        method.ContainingType.ContainingNamespace?.ToDisplayString() == "System.Linq";
+
+    private static bool ImplementsIQueryable(ITypeSymbol type)
+    {
+        if (IsIQueryable(type))
+            return true;
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (IsIQueryable(iface))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsIQueryable(ITypeSymbol type) =>
+        type.Name == "IQueryable" &&
+        type.ContainingNamespace?.ToDisplayString() == "System.Linq";
+}

--- a/src/ExpressiveSharp.CodeFixers/WrapInAsExpressiveCodeFixProvider.cs
+++ b/src/ExpressiveSharp.CodeFixers/WrapInAsExpressiveCodeFixProvider.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ExpressiveSharp.CodeFixers;
+
+/// <summary>
+/// Provides a code fix for EXP0027 that wraps the chain root with <c>.AsExpressive()</c>
+/// (and adds <c>using ExpressiveSharp;</c> if needed) so that subsequent LINQ methods
+/// flow through the ExpressiveSharp delegate-based overloads.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(WrapInAsExpressiveCodeFixProvider))]
+[Shared]
+public sealed class WrapInAsExpressiveCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create("EXP0027");
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document
+            .GetSyntaxRootAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+            if (invocation is null)
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Wrap source with .AsExpressive()",
+                    createChangedDocument: ct => WrapWithAsExpressiveAsync(context.Document, invocation, ct),
+                    equivalenceKey: "EXP0027_WrapAsExpressive"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> WrapWithAsExpressiveAsync(
+        Document document,
+        InvocationExpressionSyntax diagnosticInvocation,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var chainRoot = FindChainRoot(diagnosticInvocation);
+        if (chainRoot is null)
+            return document;
+
+        var wrapped = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                chainRoot.WithoutTrailingTrivia(),
+                SyntaxFactory.IdentifierName("AsExpressive")))
+            .WithTriviaFrom(chainRoot);
+
+        var newRoot = root.ReplaceNode(chainRoot, wrapped);
+        newRoot = EnsureUsingDirective(newRoot);
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    /// <summary>
+    /// Walks back through chained <c>X.Method(...).Method(...)</c> invocations to find the leftmost
+    /// non-invocation expression — the source of the LINQ chain.
+    /// </summary>
+    private static ExpressionSyntax? FindChainRoot(InvocationExpressionSyntax invocation)
+    {
+        ExpressionSyntax current = invocation;
+
+        while (true)
+        {
+            if (current is InvocationExpressionSyntax inv)
+            {
+                if (inv.Expression is MemberAccessExpressionSyntax memberAccess)
+                {
+                    current = memberAccess.Expression;
+                    continue;
+                }
+
+                // Cannot walk further (e.g., delegate invocation, not a fluent chain).
+                return null;
+            }
+
+            return current;
+        }
+    }
+
+    private static SyntaxNode EnsureUsingDirective(SyntaxNode root)
+    {
+        const string requiredNamespace = "ExpressiveSharp";
+
+        if (root is CompilationUnitSyntax compilationUnit)
+        {
+            if (compilationUnit.Usings.Any(u => u.Name?.ToString() == requiredNamespace))
+                return root;
+
+            var newUsing = SyntaxFactory.UsingDirective(
+                SyntaxFactory.ParseName(requiredNamespace))
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+
+            return compilationUnit.WithUsings(compilationUnit.Usings.Add(newUsing));
+        }
+
+        return root;
+    }
+}

--- a/tests/ExpressiveSharp.Generator.Tests/CodeFixers/ExpressiveQueryableDropoutAnalyzerTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/CodeFixers/ExpressiveQueryableDropoutAnalyzerTests.cs
@@ -1,0 +1,282 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ExpressiveSharp.CodeFixers;
+using ExpressiveSharp.Generator.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ExpressiveSharp.Generator.Tests.CodeFixers;
+
+[TestClass]
+public sealed class ExpressiveQueryableDropoutAnalyzerTests : GeneratorTestBase
+{
+    /// <summary>
+    /// Stubs for the EF Core types and the ExpressiveSharp.EntityFrameworkCore shadow extensions —
+    /// just enough surface for the analyzer's symbol checks to bind without pulling in the real
+    /// packages as references.
+    /// </summary>
+    private const string Stubs = """
+        namespace Microsoft.EntityFrameworkCore
+        {
+            public interface IIncludableQueryable<out TEntity, out TProperty>
+                : System.Linq.IQueryable<TEntity> { }
+
+            public static class EntityFrameworkQueryableExtensions
+            {
+                public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
+                    this System.Linq.IQueryable<TEntity> source,
+                    System.Linq.Expressions.Expression<System.Func<TEntity, TProperty>> path)
+                    where TEntity : class
+                    => null!;
+            }
+        }
+
+        namespace ExpressiveSharp.EntityFrameworkCore
+        {
+            public static class ExpressiveQueryableEfCoreExtensions
+            {
+                public static ExpressiveSharp.IExpressiveQueryable<TEntity> AsNoTracking<TEntity>(
+                    this ExpressiveSharp.IExpressiveQueryable<TEntity> source)
+                    where TEntity : class
+                    => source;
+            }
+        }
+
+        namespace Test
+        {
+            public static class UserHelpers
+            {
+                // Drops the chain: takes IQueryable<T>, returns IQueryable<T>.
+                public static System.Linq.IQueryable<T> Filter<T>(this System.Linq.IQueryable<T> q)
+                    => q;
+
+                [ExpressiveSharp.NotExpressive]
+                public static System.Linq.IQueryable<T> Sanitize<T>(this System.Linq.IQueryable<T> q)
+                    => q;
+            }
+        }
+        """;
+
+    [TestMethod]
+    public async Task ExpressiveReceiver_PlainHelper_ReportsEXP0036()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            using Test;
+            namespace Test
+            {
+                public class Order { public int Id { get; set; } }
+
+                class C
+                {
+                    void M(IQueryable<Order> orders)
+                    {
+                        orders.AsExpressive().Filter();
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Id == "EXP0036"),
+            "Expected EXP0036 when a plain-IQueryable helper is called on an expressive receiver");
+    }
+
+    [TestMethod]
+    public async Task ExpressiveReceiver_AsQueryable_NoEXP0036()
+    {
+        // .AsQueryable() is a sanctioned explicit downcast — we treat it as user intent.
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                public class Order { public int Id { get; set; } }
+
+                class C
+                {
+                    void M(IQueryable<Order> orders)
+                    {
+                        orders.AsExpressive().AsQueryable();
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0036"),
+            "EXP0036 should not fire on an explicit .AsQueryable() — it is the sanctioned downcast");
+    }
+
+    [TestMethod]
+    public async Task ExpressiveReceiver_PlainHelper_FiresOnceEvenWithDownstreamCalls()
+    {
+        // The whole point of the generalized analyzer: surface the dropout point itself, not every
+        // downstream call after it. Even with a long chain after .Filter(), only one diagnostic.
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            using Microsoft.EntityFrameworkCore;
+            using Test;
+            namespace Test
+            {
+                public class Order
+                {
+                    public int Id { get; set; }
+                    public Customer? Customer { get; set; }
+                }
+                public class Customer { public string Name { get; set; } = ""; }
+
+                class C
+                {
+                    void M(IQueryable<Order> orders)
+                    {
+                        orders.AsExpressive().Filter().Include(o => o.Customer);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        var hits = diagnostics.Count(d => d.Id == "EXP0036");
+        Assert.AreEqual(1, hits,
+            "EXP0036 should fire once at the dropout point, not at downstream Include/Where/etc.");
+    }
+
+    [TestMethod]
+    public async Task ExpressiveReceiver_ExpressiveShadow_NoEXP0036()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            using ExpressiveSharp.EntityFrameworkCore;
+            namespace Test
+            {
+                public class Order { public int Id { get; set; } }
+
+                class C
+                {
+                    void M(IQueryable<Order> orders)
+                    {
+                        orders.AsExpressive().AsNoTracking();
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0036"),
+            "EXP0036 should not fire when the called method preserves IExpressiveQueryable<T>");
+    }
+
+    [TestMethod]
+    public async Task PlainReceiver_NoEXP0036()
+    {
+        const string source = """
+            using System.Linq;
+            using Test;
+            namespace Test
+            {
+                public class Order { public int Id { get; set; } }
+
+                class C
+                {
+                    void M(IQueryable<Order> orders)
+                    {
+                        orders.Filter();
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0036"),
+            "EXP0036 should not fire when the chain was never expressive to begin with");
+    }
+
+    [TestMethod]
+    public async Task ExpressiveReceiver_NotExpressiveMethod_NoEXP0036()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            using Test;
+            namespace Test
+            {
+                public class Order { public int Id { get; set; } }
+
+                class C
+                {
+                    void M(IQueryable<Order> orders)
+                    {
+                        orders.AsExpressive().Sanitize();
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0036"),
+            "[NotExpressive] on the offending method should suppress EXP0036");
+    }
+
+    [TestMethod]
+    public async Task ExpressiveReceiver_TerminatingCall_NoEXP0036()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                public class Order { public int Id { get; set; } }
+
+                class C
+                {
+                    void M(IQueryable<Order> orders)
+                    {
+                        List<Order> result = orders.AsExpressive().ToList();
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0036"),
+            "EXP0036 should not fire on terminating calls whose result is not IQueryable<T>");
+    }
+
+    private async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    {
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+        var trees = new[]
+        {
+            CSharpSyntaxTree.ParseText(Stubs, parseOptions, "Stubs.cs"),
+            CSharpSyntaxTree.ParseText(source, parseOptions, "TestFile.cs"),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            "TestProject",
+            trees,
+            GetDefaultReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new ExpressiveQueryableDropoutAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(CancellationToken.None);
+    }
+}

--- a/tests/ExpressiveSharp.Generator.Tests/CodeFixers/NotExpressiveOptOutTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/CodeFixers/NotExpressiveOptOutTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ExpressiveSharp.CodeFixers;
+using ExpressiveSharp.Generator.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ExpressiveSharp.Generator.Tests.CodeFixers;
+
+[TestClass]
+public sealed class NotExpressiveOptOutTests : GeneratorTestBase
+{
+    [TestMethod]
+    public async Task NotExpressive_OnReferencedMember_SuppressesEXP0013()
+    {
+        const string source = """
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class C
+                {
+                    [NotExpressive]
+                    public static int Helper(int x) => x * x;
+
+                    [Expressive]
+                    public int Computed => Helper(42);
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0013"),
+            "[NotExpressive] should suppress EXP0013 on the referenced member");
+    }
+
+    [TestMethod]
+    public async Task NoOptOut_StillReportsEXP0013()
+    {
+        const string source = """
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class C
+                {
+                    public static int Helper(int x) => x * x;
+
+                    [Expressive]
+                    public int Computed => Helper(42);
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Id == "EXP0013"),
+            "EXP0013 should still fire when [NotExpressive] is absent");
+    }
+
+    private async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    {
+        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            "TestProject",
+            "TestProject",
+            LanguageNames.CSharp,
+            compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            parseOptions: parseOptions,
+            metadataReferences: GetDefaultReferences());
+
+        var project = workspace.AddProject(projectInfo);
+        var document = workspace.AddDocument(project.Id, "TestFile.cs", SourceText.From(source));
+        project = document.Project;
+
+        var compilation = await project.GetCompilationAsync()
+            ?? throw new System.Exception("Failed to get compilation");
+
+        var analyzer = new MissingExpressiveAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(CancellationToken.None);
+    }
+}

--- a/tests/ExpressiveSharp.Generator.Tests/CodeFixers/PlainQueryableMissingAsExpressiveAnalyzerTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/CodeFixers/PlainQueryableMissingAsExpressiveAnalyzerTests.cs
@@ -1,0 +1,270 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ExpressiveSharp.CodeFixers;
+using ExpressiveSharp.Generator.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ExpressiveSharp.Generator.Tests.CodeFixers;
+
+[TestClass]
+public sealed class PlainQueryableMissingAsExpressiveAnalyzerTests : GeneratorTestBase
+{
+    [TestMethod]
+    public async Task PlainQueryable_WithExpressiveProperty_ReportsEXP0027()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [Expressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Id == "EXP0027"),
+            "Expected EXP0027 when plain IQueryable lambda references an [Expressive] member");
+    }
+
+    [TestMethod]
+    public async Task ExpressiveQueryable_NoEXP0027()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [Expressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IExpressiveQueryable<User> users)
+                    {
+                        users.Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0027"),
+            "EXP0027 should not fire when the receiver is already IExpressiveQueryable");
+    }
+
+    [TestMethod]
+    public async Task PlainQueryable_NonExpressiveMember_NoEXP0027()
+    {
+        const string source = """
+            using System.Linq;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.Where(u => u.Age >= 18);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0027"),
+            "EXP0027 should not fire when no [Expressive] member is referenced");
+    }
+
+    [TestMethod]
+    public async Task PlainEnumerable_NoEXP0027()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [Expressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IEnumerable<User> users)
+                    {
+                        users.Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0027"),
+            "EXP0027 should not fire on IEnumerable (LINQ-to-Objects) chains");
+    }
+
+    [TestMethod]
+    public async Task PlainQueryable_WithNotExpressiveMember_NoEXP0027()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [NotExpressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0027"),
+            "[NotExpressive] should suppress EXP0027");
+    }
+
+    [TestMethod]
+    public async Task PlainQueryable_AfterAsExpressive_NoEXP0027()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [Expressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.AsExpressive().Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Id == "EXP0027"),
+            "EXP0027 should not fire when the chain is already wrapped with .AsExpressive()");
+    }
+
+    [TestMethod]
+    public async Task PlainQueryable_ExpressiveMethodInLambda_ReportsEXP0027()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [Expressive]
+                    public bool IsOver(int min) => Age >= min;
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.Where(u => u.IsOver(21));
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Id == "EXP0027"),
+            "Expected EXP0027 when plain IQueryable lambda references an [Expressive] method");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    {
+        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            "TestProject",
+            "TestProject",
+            LanguageNames.CSharp,
+            compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            parseOptions: parseOptions,
+            metadataReferences: GetDefaultReferences());
+
+        var project = workspace.AddProject(projectInfo);
+        var document = workspace.AddDocument(project.Id, "TestFile.cs", SourceText.From(source));
+        project = document.Project;
+
+        var compilation = await project.GetCompilationAsync()
+            ?? throw new System.Exception("Failed to get compilation");
+
+        var analyzer = new PlainQueryableMissingAsExpressiveAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(CancellationToken.None);
+    }
+}

--- a/tests/ExpressiveSharp.Generator.Tests/CodeFixers/WrapInAsExpressiveCodeFixProviderTests.cs
+++ b/tests/ExpressiveSharp.Generator.Tests/CodeFixers/WrapInAsExpressiveCodeFixProviderTests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ExpressiveSharp.CodeFixers;
+using ExpressiveSharp.Generator.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ExpressiveSharp.Generator.Tests.CodeFixers;
+
+[TestClass]
+public sealed class WrapInAsExpressiveCodeFixProviderTests : GeneratorTestBase
+{
+    [TestMethod]
+    public async Task WrapsRoot_OnSingleLinqCall()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [Expressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await ApplyCodeFixAsync(source);
+
+        Assert.IsTrue(fixedSource.Contains("users.AsExpressive().Where(u => u.IsAdult)"),
+            $"Expected '.AsExpressive()' inserted before '.Where', got:\n{fixedSource}");
+    }
+
+    [TestMethod]
+    public async Task WrapsRoot_OnChainedLinqCalls()
+    {
+        const string source = """
+            using System.Linq;
+            using ExpressiveSharp;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [Expressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.OrderBy(u => u.Age).Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await ApplyCodeFixAsync(source);
+
+        Assert.IsTrue(fixedSource.Contains("users.AsExpressive().OrderBy(u => u.Age).Where(u => u.IsAdult)"),
+            $"Expected '.AsExpressive()' inserted at chain root, got:\n{fixedSource}");
+    }
+
+    [TestMethod]
+    public async Task AddsUsingDirective_WhenMissing()
+    {
+        const string source = """
+            using System.Linq;
+            namespace Test
+            {
+                class User
+                {
+                    public int Age { get; set; }
+
+                    [ExpressiveSharp.Expressive]
+                    public bool IsAdult => Age >= 18;
+                }
+
+                class C
+                {
+                    void M(IQueryable<User> users)
+                    {
+                        users.Where(u => u.IsAdult);
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await ApplyCodeFixAsync(source);
+
+        Assert.IsTrue(fixedSource.Contains("using ExpressiveSharp;"),
+            $"Expected 'using ExpressiveSharp;' added, got:\n{fixedSource}");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<string> ApplyCodeFixAsync(string source)
+    {
+        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+            projectId,
+            VersionStamp.Create(),
+            "TestProject",
+            "TestProject",
+            LanguageNames.CSharp,
+            compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            parseOptions: parseOptions,
+            metadataReferences: GetDefaultReferences());
+
+        var project = workspace.AddProject(projectInfo);
+        var document = workspace.AddDocument(project.Id, "TestFile.cs", SourceText.From(source));
+        project = document.Project;
+
+        var compilation = await project.GetCompilationAsync()
+            ?? throw new System.Exception("Failed to get compilation");
+
+        var analyzer = new PlainQueryableMissingAsExpressiveAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var analyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(CancellationToken.None);
+        var diagnostic = analyzerDiagnostics.FirstOrDefault(d => d.Id == "EXP0027");
+        Assert.IsNotNull(diagnostic, "Expected EXP0027 diagnostic to be emitted");
+
+        var docInSolution = project.Solution.GetDocument(diagnostic.Location.SourceTree)
+            ?? throw new System.Exception("Failed to locate document for diagnostic");
+
+        var codeFix = new WrapInAsExpressiveCodeFixProvider();
+        var actions = new List<CodeAction>();
+        var context = new CodeFixContext(
+            docInSolution,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await codeFix.RegisterCodeFixesAsync(context);
+        Assert.IsTrue(actions.Count > 0, "Expected at least one code fix action");
+
+        var operations = await actions[0].GetOperationsAsync(CancellationToken.None);
+        var applyOperation = operations.OfType<ApplyChangesOperation>().First();
+        var fixedDoc = applyOperation.ChangedSolution.GetDocument(docInSolution.Id)
+            ?? throw new System.Exception("Failed to locate fixed document");
+
+        return (await fixedDoc.GetTextAsync()).ToString();
+    }
+}


### PR DESCRIPTION
Introduce the `[NotExpressive]` attribute to suppress analyzer suggestions for members that should remain runtime-evaluated. Implement the `ExpressiveQueryableDropoutAnalyzer` to flag instances where an `IExpressiveQueryable<T>` chain drops to a plain `IQueryable<T>`, helping to identify potential issues in query chains. Include tests to verify the functionality of the new attribute and analyzer.