### PR TITLE
Add telemetry support for diagnostics

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -64,6 +64,7 @@ const sidebar: DefaultTheme.Sidebar = {
         { text: 'Switch Expressions', link: '/reference/switch-expressions' },
         { text: 'Expression Transformers', link: '/reference/expression-transformers' },
         { text: 'Diagnostics & Code Fixes', link: '/reference/diagnostics' },
+        { text: 'Telemetry', link: '/reference/telemetry' },
         { text: 'Troubleshooting', link: '/reference/troubleshooting' },
       ]
     }

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -6,7 +6,7 @@ Every instrument is **zero-cost when no listener is attached**: counters and act
 
 ## Activity (Distributed Tracing)
 
-A single span is emitted from `ExpressiveSharp.ActivitySource`:
+A single span is emitted from the `ExpressiveSharp` `ActivitySource` (the source's name is also exposed as the constant `ExpressiveDiagnostics.SourceName`):
 
 | Span | Emitted from | Tags |
 |------|--------------|------|

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -1,0 +1,88 @@
+# Telemetry
+
+ExpressiveSharp emits runtime telemetry through the standard .NET diagnostics primitives — `ActivitySource` for distributed traces, `Meter` for metrics, and `EventSource` for previously-silent failure paths. All three share the source name `ExpressiveSharp` (also exposed as the constant `ExpressiveDiagnostics.SourceName`).
+
+Every instrument is **zero-cost when no listener is attached**: counters and activities short-circuit on the no-listener path, and the more expensive observations (node-counting, `MemberInfo.ToString()` for tags) are guarded explicitly.
+
+## Activity (Distributed Tracing)
+
+A single span is emitted from `ExpressiveSharp.ActivitySource`:
+
+| Span | Emitted from | Tags |
+|------|--------------|------|
+| `Expressive.Expand` | `expression.ExpandExpressives()` (and the EF Core / MongoDB query compiler decorators that call into it) | `transformer.count`, `expansion.node_count`, `expansion.duration_ms` |
+
+Because the span runs synchronously inside the EF Core query pipeline, it nests cleanly under EF Core's `Microsoft.EntityFrameworkCore` activity. Trace viewers will show:
+
+```
+EF query  →  Expressive.Expand  →  SQL execution
+```
+
+### OpenTelemetry
+
+```csharp
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource("ExpressiveSharp")
+    .AddSource("Microsoft.EntityFrameworkCore") // optional — nests Expressive.Expand under EF activities
+    .AddOtlpExporter()
+    .Build();
+```
+
+::: tip
+The `expansion.duration_ms` tag is recorded redundantly with the activity's intrinsic duration so consumers that only run a metrics pipeline (no tracer) still get the timing.
+:::
+
+## Meter (Metrics)
+
+Five instruments on `Meter("ExpressiveSharp")`:
+
+| Instrument | Type | Unit | Tags | What it tells you |
+|------------|------|------|------|-------------------|
+| `expressive.cache.hits` | Counter&lt;long&gt; | — | — | The runtime resolver cache served the lookup without computing it again. |
+| `expressive.cache.misses` | Counter&lt;long&gt; | — | — | The resolver had to compute the lambda for a member it hadn't seen before. |
+| `expressive.reflection_fallback.count` | Counter&lt;long&gt; | — | `member` | The slow reflection-based fallback ran. Used for open-generic class members and generic methods not in the static registry. **Sustained activity here is a perf bug.** |
+| `expressive.expansion.node_count` | Histogram&lt;int&gt; | nodes | — | Total expression-tree node count after expansion + transformers. Surfaces members that explode into massive trees and bloat SQL. |
+| `expressive.expansion.duration_ms` | Histogram&lt;double&gt; | ms | — | Wall-clock cost of one `ExpandExpressives()` call. |
+
+### Live monitoring with `dotnet-counters`
+
+```sh
+dotnet-counters monitor -n MyApp ExpressiveSharp
+```
+
+### OpenTelemetry
+
+```csharp
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .AddMeter("ExpressiveSharp")
+    .AddOtlpExporter()
+    .Build();
+```
+
+::: info
+A healthy steady-state has **`cache.hits` ≫ `cache.misses`** after warmup, and **`reflection_fallback.count` should be flat** unless your code uses open-generic `[Expressive]` members. A non-trivial slope on `reflection_fallback.count` means the runtime is paying reflection costs that the static registry could have served — please file an issue with a reproducer.
+:::
+
+## EventSource (Failure Diagnostics)
+
+Three events on `EventSource("ExpressiveSharp")`. They surface failure paths that ExpressiveSharp deliberately recovers from but that historically left users debugging by rubber duck.
+
+| Event ID | Name | Level | Payload | When it fires |
+|----------|------|-------|---------|---------------|
+| `1` | `RegistryInitializationFailed` | Error | `assemblyName`, `exceptionType`, `message` | An assembly's generated `ExpressionRegistry` static constructor threw. The registry is marked inert (no `[ExpressiveFor]` lookups will succeed against it) but the process keeps running. |
+| `2` | `HotReloadResetFailed` | Warning | `assemblyName`, `exceptionType`, `message` | A hot-reload edit-and-continue update arrived but invalidating the assembly's expression registry threw. The stale registry stays cached, so the next lookup may return pre-edit lambdas. |
+| `3` | `MultipleExpressiveForMappings` | Error | `memberInfoString`, `firstAssembly`, `secondAssembly` | Two different assemblies both registered an `[ExpressiveFor]` mapping for the same member. An `InvalidOperationException` is thrown immediately after; the event fires first so it survives even if the exception is later caught. |
+
+### Collecting with `dotnet-trace`
+
+The most common path. No code changes, no app restart:
+
+```sh
+dotnet-trace collect -n MyApp --providers ExpressiveSharp::Verbose
+```
+
+Open the resulting `.nettrace` file in [PerfView](https://github.com/microsoft/perfview) or Visual Studio's diagnostic tools to inspect the events.
+
+## Stability
+
+The source name `ExpressiveSharp`, the instrument names, and the EventSource event IDs are part of the public API surface and follow the same stability rules as the rest of ExpressiveSharp. Tags carried on activities and counters may be extended (new tags added) but existing tags will not be renamed within a major version.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -322,6 +322,18 @@ public double Total => Price * Quantity;
 public double TotalWithTax => Total * (1 + TaxRate);  // Total is inlined
 ```
 
+### How do I see what ExpressiveSharp is doing at runtime?
+
+Subscribe to the `ExpressiveSharp` `ActivitySource`, `Meter`, or `EventSource`. The metrics surface cache hit/miss ratios and per-expansion timings; the EventSource surfaces failure paths that ExpressiveSharp recovers from silently — registry static-ctor failures, hot-reload reset failures, and `[ExpressiveFor]` collisions.
+
+The fastest path is `dotnet-trace`, which needs no code changes:
+
+```sh
+dotnet-trace collect -n MyApp --providers ExpressiveSharp::Verbose
+```
+
+See [Telemetry](./telemetry) for the full instrument and event reference.
+
 ### Is ExpressiveSharp EF Core specific?
 
 No. The core `ExpressiveSharp` package works with any LINQ provider or standalone expression tree use case. See [ExpressionPolyfill.Create](../guide/expression-polyfill) and [IExpressiveQueryable](../guide/expressive-queryable) for non-EF-Core usage.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -324,12 +324,17 @@ public double TotalWithTax => Total * (1 + TaxRate);  // Total is inlined
 
 ### How do I see what ExpressiveSharp is doing at runtime?
 
-Subscribe to the `ExpressiveSharp` `ActivitySource`, `Meter`, or `EventSource`. The metrics surface cache hit/miss ratios and per-expansion timings; the EventSource surfaces failure paths that ExpressiveSharp recovers from silently — registry static-ctor failures, hot-reload reset failures, and `[ExpressiveFor]` collisions.
-
-The fastest path is `dotnet-trace`, which needs no code changes:
+ExpressiveSharp emits three independent signals on the `ExpressiveSharp` source name — each requires a different out-of-process tool:
 
 ```sh
+# Failure events (registry static-ctor failures, hot-reload reset failures, [ExpressiveFor] collisions)
 dotnet-trace collect -n MyApp --providers ExpressiveSharp::Verbose
+
+# Metrics (cache hit/miss ratios, expansion timings, reflection-fallback rate)
+dotnet-counters monitor -n MyApp ExpressiveSharp
+
+# Distributed tracing (the Expressive.Expand activity span) — wire via OpenTelemetry,
+# see the Telemetry reference for the AddSource("ExpressiveSharp") snippet.
 ```
 
 See [Telemetry](./telemetry) for the full instrument and event reference.

--- a/src/ExpressiveSharp/Diagnostics/ExpressiveDiagnostics.cs
+++ b/src/ExpressiveSharp/Diagnostics/ExpressiveDiagnostics.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace ExpressiveSharp.Diagnostics;
+
+public static class ExpressiveDiagnostics
+{
+    public const string SourceName = "ExpressiveSharp";
+
+    internal static readonly ActivitySource ActivitySource = new(SourceName);
+    internal static readonly Meter Meter = new(SourceName);
+
+    internal static readonly Counter<long> CacheHits =
+        Meter.CreateCounter<long>("expressive.cache.hits");
+
+    internal static readonly Counter<long> CacheMisses =
+        Meter.CreateCounter<long>("expressive.cache.misses");
+
+    internal static readonly Counter<long> ReflectionFallback =
+        Meter.CreateCounter<long>("expressive.reflection_fallback.count");
+
+    internal static readonly Histogram<int> ExpansionNodeCount =
+        Meter.CreateHistogram<int>("expressive.expansion.node_count");
+
+    internal static readonly Histogram<double> ExpansionDurationMs =
+        Meter.CreateHistogram<double>("expressive.expansion.duration_ms", unit: "ms");
+}

--- a/src/ExpressiveSharp/Diagnostics/ExpressiveEventSource.cs
+++ b/src/ExpressiveSharp/Diagnostics/ExpressiveEventSource.cs
@@ -20,10 +20,14 @@ internal sealed class ExpressiveEventSource : EventSource
     public void RegistryInitializationFailed(Assembly assembly, Exception exception)
     {
         if (!IsEnabled()) return;
+        // The caller catches TypeInitializationException, but the actionable cause is the
+        // static-ctor exception nested inside it — unwrap so consumers see the real failure.
+        var actual = exception is TypeInitializationException && exception.InnerException is { } inner
+            ? inner : exception;
         RegistryInitializationFailed(
             assembly.GetName().Name ?? "<unknown>",
-            exception.GetType().FullName ?? exception.GetType().Name,
-            exception.Message);
+            actual.GetType().FullName ?? actual.GetType().Name,
+            actual.Message);
     }
 
     [Event(2, Level = EventLevel.Warning,

--- a/src/ExpressiveSharp/Diagnostics/ExpressiveEventSource.cs
+++ b/src/ExpressiveSharp/Diagnostics/ExpressiveEventSource.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Diagnostics.Tracing;
+using System.Reflection;
+
+namespace ExpressiveSharp.Diagnostics;
+
+[EventSource(Name = ExpressiveDiagnostics.SourceName)]
+internal sealed class ExpressiveEventSource : EventSource
+{
+    public static readonly ExpressiveEventSource Log = new();
+
+    private ExpressiveEventSource() { }
+
+    [Event(1, Level = EventLevel.Error,
+        Message = "ExpressiveSharp registry initialization failed for assembly '{0}': {1}: {2}")]
+    public void RegistryInitializationFailed(string assemblyName, string exceptionType, string message)
+        => WriteEvent(1, assemblyName, exceptionType, message);
+
+    [NonEvent]
+    public void RegistryInitializationFailed(Assembly assembly, Exception exception)
+    {
+        if (!IsEnabled()) return;
+        RegistryInitializationFailed(
+            assembly.GetName().Name ?? "<unknown>",
+            exception.GetType().FullName ?? exception.GetType().Name,
+            exception.Message);
+    }
+
+    [Event(2, Level = EventLevel.Warning,
+        Message = "ExpressiveSharp hot-reload registry reset failed for assembly '{0}': {1}: {2}")]
+    public void HotReloadResetFailed(string assemblyName, string exceptionType, string message)
+        => WriteEvent(2, assemblyName, exceptionType, message);
+
+    [NonEvent]
+    public void HotReloadResetFailed(Assembly assembly, Exception exception)
+    {
+        if (!IsEnabled()) return;
+        HotReloadResetFailed(
+            assembly.GetName().Name ?? "<unknown>",
+            exception.GetType().FullName ?? exception.GetType().Name,
+            exception.Message);
+    }
+
+    [Event(3, Level = EventLevel.Error,
+        Message = "Multiple [ExpressiveFor] mappings found for '{0}' in assemblies '{1}' and '{2}'")]
+    public void MultipleExpressiveForMappings(string memberInfoString, string firstAssembly, string secondAssembly)
+        => WriteEvent(3, memberInfoString, firstAssembly, secondAssembly);
+
+    [NonEvent]
+    public void MultipleExpressiveForMappings(MemberInfo memberInfo, Assembly first, Assembly second)
+    {
+        if (!IsEnabled()) return;
+        MultipleExpressiveForMappings(
+            memberInfo.ToString() ?? memberInfo.Name,
+            first.GetName().Name ?? "<unknown>",
+            second.GetName().Name ?? "<unknown>");
+    }
+}

--- a/src/ExpressiveSharp/Extensions/ExpressionExtensions.cs
+++ b/src/ExpressiveSharp/Extensions/ExpressionExtensions.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Linq.Expressions;
+using ExpressiveSharp.Diagnostics;
 using ExpressiveSharp.Services;
 
 namespace ExpressiveSharp;
@@ -16,15 +18,7 @@ public static class ExpressionExtensions
     /// Like <see cref="ExpandExpressives(Expression)"/> but uses transformers from the given options.
     /// </summary>
     public static Expression ExpandExpressives(this Expression expression, ExpressiveOptions options)
-    {
-        var expanded = new ExpressiveReplacer(new ExpressiveResolver()).Replace(expression);
-        var transformers = options.GetTransformers();
-        foreach (var transformer in transformers)
-        {
-            expanded = transformer.Transform(expanded);
-        }
-        return expanded;
-    }
+        => ExpandExpressivesCore(expression, options.GetTransformers());
 
     /// <summary>
     /// Like <see cref="ExpandExpressives(Expression)"/> but uses the explicitly supplied transformers.
@@ -32,12 +26,62 @@ public static class ExpressionExtensions
     public static Expression ExpandExpressives(
         this Expression expression,
         params IExpressionTreeTransformer[] transformers)
+        => ExpandExpressivesCore(expression, transformers);
+
+    private static Expression ExpandExpressivesCore(
+        Expression expression,
+        IReadOnlyList<IExpressionTreeTransformer> transformers)
     {
+        using var activity = ExpressiveDiagnostics.ActivitySource.StartActivity("Expressive.Expand");
+
+        var measureDuration = activity is not null || ExpressiveDiagnostics.ExpansionDurationMs.Enabled;
+        var startTimestamp = measureDuration ? Stopwatch.GetTimestamp() : 0L;
+
         var expanded = new ExpressiveReplacer(new ExpressiveResolver()).Replace(expression);
-        foreach (var transformer in transformers)
+        for (var i = 0; i < transformers.Count; i++)
         {
-            expanded = transformer.Transform(expanded);
+            expanded = transformers[i].Transform(expanded);
         }
+
+        if (activity is not null)
+        {
+            activity.SetTag("transformer.count", transformers.Count);
+        }
+
+        if (activity is not null || ExpressiveDiagnostics.ExpansionNodeCount.Enabled)
+        {
+            var nodeCount = ExpansionNodeCounter.Count(expanded);
+            ExpressiveDiagnostics.ExpansionNodeCount.Record(nodeCount);
+            activity?.SetTag("expansion.node_count", nodeCount);
+        }
+
+        if (measureDuration)
+        {
+            var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+            ExpressiveDiagnostics.ExpansionDurationMs.Record(elapsedMs);
+            activity?.SetTag("expansion.duration_ms", elapsedMs);
+        }
+
         return expanded;
+    }
+
+    private sealed class ExpansionNodeCounter : ExpressionVisitor
+    {
+        private int _count;
+
+        public static int Count(Expression? expression)
+        {
+            if (expression is null) return 0;
+            var counter = new ExpansionNodeCounter();
+            counter.Visit(expression);
+            return counter._count;
+        }
+
+        public override Expression? Visit(Expression? node)
+        {
+            if (node is null) return null;
+            _count++;
+            return base.Visit(node);
+        }
     }
 }

--- a/src/ExpressiveSharp/Services/ExpressiveHotReloadHandler.cs
+++ b/src/ExpressiveSharp/Services/ExpressiveHotReloadHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Metadata;
+using ExpressiveSharp.Diagnostics;
 
 [assembly: MetadataUpdateHandler(typeof(ExpressiveSharp.Services.ExpressiveHotReloadHandler))]
 
@@ -56,8 +57,17 @@ internal static class ExpressiveHotReloadHandler
             var reset = registryType?.GetMethod("ResetMap", BindingFlags.Static | BindingFlags.NonPublic);
             if (reset is null) continue;
 
-            try { reset.Invoke(null, null); }
-            catch { /* best-effort; stale registry stays stale */ }
+            try
+            {
+                reset.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                // Best-effort; stale registry stays stale. Surface via EventSource so
+                // a hot-reload edit-and-continue failure is no longer silent.
+                var inner = (ex as TargetInvocationException)?.InnerException ?? ex;
+                ExpressiveEventSource.Log.HotReloadResetFailed(assembly, inner);
+            }
         }
     }
 }

--- a/src/ExpressiveSharp/Services/ExpressiveResolver.cs
+++ b/src/ExpressiveSharp/Services/ExpressiveResolver.cs
@@ -106,18 +106,23 @@ namespace ExpressiveSharp.Services
         public LambdaExpression FindGeneratedExpression(MemberInfo expressiveMemberInfo,
             ExpressiveAttribute? expressiveAttribute = null)
         {
-            if (ExpressiveDiagnostics.CacheHits.Enabled || ExpressiveDiagnostics.CacheMisses.Enabled)
+            // Hits are counted on the fast path; misses are counted inside the factory so that
+            // concurrent racing TryGetValue calls don't both pre-increment when only one factory
+            // actually runs. ConcurrentDictionary may still invoke the factory multiple times
+            // under contention, which can over-count by a tiny margin — acceptable for an
+            // observability counter.
+            if (ExpressiveDiagnostics.CacheHits.Enabled
+                && _expressionCache.TryGetValue(expressiveMemberInfo, out var cached))
             {
-                if (_expressionCache.TryGetValue(expressiveMemberInfo, out var cached))
-                {
-                    ExpressiveDiagnostics.CacheHits.Add(1);
-                    return cached;
-                }
-                ExpressiveDiagnostics.CacheMisses.Add(1);
+                ExpressiveDiagnostics.CacheHits.Add(1);
+                return cached;
             }
 
-            return _expressionCache.GetOrAdd(expressiveMemberInfo,
-                static (mi, _) => ResolveExpressionCore(mi), (object?)null);
+            return _expressionCache.GetOrAdd(expressiveMemberInfo, static (mi, _) =>
+            {
+                ExpressiveDiagnostics.CacheMisses.Add(1);
+                return ResolveExpressionCore(mi);
+            }, (object?)null);
         }
 
         /// <inheritdoc/>
@@ -256,6 +261,10 @@ namespace ExpressiveSharp.Services
         /// </summary>
         public static LambdaExpression? FindGeneratedExpressionViaReflection(MemberInfo expressiveMemberInfo)
         {
+            // ConcurrentDictionary.GetOrAdd may invoke the factory more than once under
+            // contention, which can over-count the counter by a small margin on cold concurrent
+            // lookups. Acceptable for an observability signal — the alternative (Lazy<T> wrapper)
+            // adds allocation on every lookup.
             var result = _reflectionCache.GetOrAdd(expressiveMemberInfo, static mi =>
             {
                 var built = BuildReflectionExpression(mi);

--- a/src/ExpressiveSharp/Services/ExpressiveResolver.cs
+++ b/src/ExpressiveSharp/Services/ExpressiveResolver.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using ExpressiveSharp.Diagnostics;
 using ExpressiveSharp.Extensions;
 
 namespace ExpressiveSharp.Services
@@ -104,8 +105,20 @@ namespace ExpressiveSharp.Services
 
         public LambdaExpression FindGeneratedExpression(MemberInfo expressiveMemberInfo,
             ExpressiveAttribute? expressiveAttribute = null)
-            => _expressionCache.GetOrAdd(expressiveMemberInfo, static (mi, _) => ResolveExpressionCore(mi),
-                (object?)null);
+        {
+            if (ExpressiveDiagnostics.CacheHits.Enabled || ExpressiveDiagnostics.CacheMisses.Enabled)
+            {
+                if (_expressionCache.TryGetValue(expressiveMemberInfo, out var cached))
+                {
+                    ExpressiveDiagnostics.CacheHits.Add(1);
+                    return cached;
+                }
+                ExpressiveDiagnostics.CacheMisses.Add(1);
+            }
+
+            return _expressionCache.GetOrAdd(expressiveMemberInfo,
+                static (mi, _) => ResolveExpressionCore(mi), (object?)null);
+        }
 
         /// <inheritdoc/>
         public LambdaExpression? FindExternalExpression(MemberInfo memberInfo)
@@ -127,9 +140,10 @@ namespace ExpressiveSharp.Services
                 {
                     result = kvp.Value(memberInfo);
                 }
-                catch (TypeInitializationException)
+                catch (TypeInitializationException ex)
                 {
                     // Registry's static ctor failed — mark inert so we don't re-throw on every lookup.
+                    ExpressiveEventSource.Log.RegistryInitializationFailed(kvp.Key, ex);
                     _assemblyRegistries[kvp.Key] = _nullRegistry;
                     continue;
                 }
@@ -138,9 +152,12 @@ namespace ExpressiveSharp.Services
                     continue;
 
                 if (found is not null)
+                {
+                    ExpressiveEventSource.Log.MultipleExpressiveForMappings(memberInfo, foundAssembly!, kvp.Key);
                     throw new InvalidOperationException(
                         $"Multiple [ExpressiveFor] mappings found for '{memberInfo}' " +
                         $"in assemblies '{foundAssembly!.GetName().Name}' and '{kvp.Key.GetName().Name}'.");
+                }
 
                 found = result;
                 foundAssembly = kvp.Key;
@@ -239,8 +256,16 @@ namespace ExpressiveSharp.Services
         /// </summary>
         public static LambdaExpression? FindGeneratedExpressionViaReflection(MemberInfo expressiveMemberInfo)
         {
-            var result = _reflectionCache.GetOrAdd(expressiveMemberInfo,
-                static mi => BuildReflectionExpression(mi) ?? _reflectionNullSentinel);
+            var result = _reflectionCache.GetOrAdd(expressiveMemberInfo, static mi =>
+            {
+                var built = BuildReflectionExpression(mi);
+                if (ExpressiveDiagnostics.ReflectionFallback.Enabled)
+                {
+                    ExpressiveDiagnostics.ReflectionFallback.Add(1,
+                        new KeyValuePair<string, object?>("member", mi.ToString()));
+                }
+                return built ?? _reflectionNullSentinel;
+            });
             return ReferenceEquals(result, _reflectionNullSentinel) ? null : result;
         }
 

--- a/tests/ExpressiveSharp.Tests/Diagnostics/ExpressiveDiagnosticsTests.cs
+++ b/tests/ExpressiveSharp.Tests/Diagnostics/ExpressiveDiagnosticsTests.cs
@@ -1,0 +1,156 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using System.Linq.Expressions;
+using ExpressiveSharp.Diagnostics;
+using ExpressiveSharp.Services;
+using ExpressiveSharp.Tests.TestFixtures;
+
+namespace ExpressiveSharp.Tests.Diagnostics;
+
+[TestClass]
+public class ExpressiveDiagnosticsTests
+{
+    [TestInitialize]
+    public void ResetCaches() => ExpressiveResolver.ResetAllCaches();
+
+    [TestMethod]
+    public void ExpandExpressives_WithActivityListener_RecordsActivityWithTags()
+    {
+        var stopped = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == ExpressiveDiagnostics.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = stopped.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        Expression<Func<Product, double>> expr = p => p.Total;
+        _ = expr.ExpandExpressives();
+
+        Assert.AreEqual(1, stopped.Count);
+        Assert.AreEqual("Expressive.Expand", stopped[0].OperationName);
+        Assert.IsNotNull(stopped[0].GetTagItem("transformer.count"));
+        Assert.IsNotNull(stopped[0].GetTagItem("expansion.node_count"));
+        Assert.IsNotNull(stopped[0].GetTagItem("expansion.duration_ms"));
+    }
+
+    [TestMethod]
+    public void FindGeneratedExpression_RepeatedLookup_RecordsHitAndMissCounters()
+    {
+        var hits = 0L;
+        var misses = 0L;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, ml) =>
+        {
+            if (instrument.Meter.Name != ExpressiveDiagnostics.SourceName) return;
+            if (instrument.Name is "expressive.cache.hits" or "expressive.cache.misses")
+                ml.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            if (instrument.Name == "expressive.cache.hits") Interlocked.Add(ref hits, measurement);
+            else if (instrument.Name == "expressive.cache.misses") Interlocked.Add(ref misses, measurement);
+        });
+        listener.Start();
+
+        var resolver = new ExpressiveResolver();
+        var member = typeof(Product).GetProperty(nameof(Product.Total))!;
+
+        _ = resolver.FindGeneratedExpression(member);
+        _ = resolver.FindGeneratedExpression(member);
+
+        Assert.AreEqual(1, misses, "First lookup should be a cache miss");
+        Assert.AreEqual(1, hits, "Second lookup should be a cache hit");
+    }
+
+    [TestMethod]
+    public void FindGeneratedExpressionViaReflection_RecordsFallbackCounter()
+    {
+        var fallbackCount = 0L;
+        var lastMemberTag = (string?)null;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, ml) =>
+        {
+            if (instrument.Meter.Name == ExpressiveDiagnostics.SourceName
+                && instrument.Name == "expressive.reflection_fallback.count")
+                ml.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            Interlocked.Add(ref fallbackCount, measurement);
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "member") lastMemberTag = tag.Value as string;
+            }
+        });
+        listener.Start();
+
+        var member = typeof(Product).GetProperty(nameof(Product.Total))!;
+        _ = ExpressiveResolver.FindGeneratedExpressionViaReflection(member);
+
+        Assert.AreEqual(1, fallbackCount);
+        Assert.IsNotNull(lastMemberTag);
+        StringAssert.Contains(lastMemberTag!, nameof(Product.Total));
+    }
+
+    [TestMethod]
+    public void EventSource_RegistryInitializationFailed_CapturedByListener()
+    {
+        using var listener = new CapturingEventListener();
+
+        var ex = new TypeInitializationException(typeof(Product).FullName, new InvalidOperationException("boom"));
+        ExpressiveEventSource.Log.RegistryInitializationFailed(typeof(Product).Assembly, ex);
+
+        var evt = listener.Events.SingleOrDefault(e => e.EventName == nameof(ExpressiveEventSource.RegistryInitializationFailed));
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(EventLevel.Error, evt.Level);
+        Assert.AreEqual(typeof(Product).Assembly.GetName().Name, evt.Payload![0]);
+    }
+
+    [TestMethod]
+    public void EventSource_HotReloadResetFailed_CapturedByListener()
+    {
+        using var listener = new CapturingEventListener();
+
+        ExpressiveEventSource.Log.HotReloadResetFailed(typeof(Product).Assembly, new InvalidOperationException("oops"));
+
+        var evt = listener.Events.SingleOrDefault(e => e.EventName == nameof(ExpressiveEventSource.HotReloadResetFailed));
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(EventLevel.Warning, evt.Level);
+    }
+
+    [TestMethod]
+    public void EventSource_MultipleExpressiveForMappings_CapturedByListener()
+    {
+        using var listener = new CapturingEventListener();
+
+        var member = typeof(Product).GetProperty(nameof(Product.Total))!;
+        ExpressiveEventSource.Log.MultipleExpressiveForMappings(member, typeof(Product).Assembly, typeof(string).Assembly);
+
+        var evt = listener.Events.SingleOrDefault(e => e.EventName == nameof(ExpressiveEventSource.MultipleExpressiveForMappings));
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(EventLevel.Error, evt.Level);
+    }
+
+    // Source name is hardcoded — EventListener's base constructor invokes OnEventSourceCreated
+    // for already-existing sources before our derived ctor body runs, so any instance field would
+    // still be null when the comparison happens.
+    private sealed class CapturingEventListener : EventListener
+    {
+        public List<EventWrittenEventArgs> Events { get; } = new();
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == ExpressiveDiagnostics.SourceName)
+                EnableEvents(eventSource, EventLevel.Verbose);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventSource.Name == ExpressiveDiagnostics.SourceName)
+                Events.Add(eventData);
+        }
+    }
+}


### PR DESCRIPTION
Introduce telemetry capabilities using `ActivitySource`, `Meter`, and `EventSource` to enhance diagnostics. This includes metrics for cache hits/misses and expansion timings, along with event logging for registry initialization failures and hot-reload issues. A new telemetry section is added to the documentation for user guidance.