### PR TITLE
Remove bad dependency and pin to stable version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="Testcontainers.MySql" Version="4.3.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.25" />
     <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
+    <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="Testcontainers.MongoDb" Version="4.3.0" />
     <!-- Blazor WebAssembly host for the docs playground. -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />

--- a/src/Docs/Prerenderer/ExpressiveSharp.Docs.Prerenderer.csproj
+++ b/src/Docs/Prerenderer/ExpressiveSharp.Docs.Prerenderer.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"
                       VersionOverride="10.0.5" />
     <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExpressiveSharp.MongoDB/ExpressiveSharp.MongoDB.csproj
+++ b/src/ExpressiveSharp.MongoDB/ExpressiveSharp.MongoDB.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>MongoDB Driver integration for ExpressiveSharp — automatically expands [Expressive] members in MongoDB LINQ queries</Description>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove an unstable dependency from the library project and pin the package to a stable version to ensure reliability.