### PR TITLE
preserve visitor rewrites in window function SQL expressions

### DIFF
--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundSqlExpression.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFrameBoundSqlExpression.cs
@@ -30,7 +30,7 @@ internal sealed class WindowFrameBoundSqlExpression : SqlExpression
 #endif
 
     public override bool Equals(object? obj) =>
-        obj is WindowFrameBoundSqlExpression other && BoundInfo == other.BoundInfo;
+        obj is WindowFrameBoundSqlExpression other && base.Equals(other) && BoundInfo == other.BoundInfo;
 
-    public override int GetHashCode() => BoundInfo.GetHashCode();
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), BoundInfo);
 }

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpression.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpression.cs
@@ -10,9 +10,11 @@ namespace ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructur
 /// RANK, DENSE_RANK, NTILE, aggregates, and navigation functions (ROW_NUMBER uses the built-in
 /// <see cref="RowNumberExpression"/>).
 /// <para>
-/// Self-rendering: <see cref="VisitChildren"/> interleaves <see cref="SqlFragmentExpression"/>
-/// nodes with column/ordering expressions, producing correct SQL through any provider's
-/// <see cref="QuerySqlGenerator"/> — no custom generator replacement needed.
+/// Self-rendering: for <see cref="QuerySqlGenerator"/> visitors, <see cref="VisitChildren"/>
+/// interleaves <see cref="SqlFragmentExpression"/> nodes with column/ordering expressions,
+/// producing correct SQL through any provider's generator — no custom generator replacement
+/// needed. All other visitors rebuild children normally so rewrites (alias remapping, pushdown)
+/// are preserved.
 /// </para>
 /// <para>
 /// Function names and clause syntax are hardcoded as literal SQL fragments, relying on SQL:2003
@@ -53,10 +55,44 @@ internal sealed class WindowFunctionSqlExpression : SqlExpression
 
     protected override Expression VisitChildren(ExpressionVisitor visitor)
     {
-        EmitWindowFunction(
-            text => visitor.Visit(new SqlFragmentExpression(text)),
-            expr => visitor.Visit(expr));
-        return this;
+        if (visitor is QuerySqlGenerator)
+        {
+            EmitWindowFunction(
+                text => visitor.Visit(new SqlFragmentExpression(text)),
+                expr => visitor.Visit(expr));
+            return this;
+        }
+
+        // Every other visitor (projection pushdown, alias uniquification, ...) rewrites children;
+        // discarding its results would leave stale references in the generated SQL.
+        var changed = false;
+
+        var newArguments = new SqlExpression[Arguments.Count];
+        for (var i = 0; i < Arguments.Count; i++)
+        {
+            newArguments[i] = (SqlExpression)visitor.Visit(Arguments[i]);
+            changed |= newArguments[i] != Arguments[i];
+        }
+
+        var newPartitions = new SqlExpression[Partitions.Count];
+        for (var i = 0; i < Partitions.Count; i++)
+        {
+            newPartitions[i] = (SqlExpression)visitor.Visit(Partitions[i]);
+            changed |= newPartitions[i] != Partitions[i];
+        }
+
+        var newOrderings = new OrderingExpression[Orderings.Count];
+        for (var i = 0; i < Orderings.Count; i++)
+        {
+            newOrderings[i] = (OrderingExpression)visitor.Visit(Orderings[i]);
+            changed |= newOrderings[i] != Orderings[i];
+        }
+
+        return changed
+            ? new WindowFunctionSqlExpression(
+                FunctionName, newArguments, newPartitions, newOrderings, Type, TypeMapping,
+                FrameType, FrameStart, FrameEnd)
+            : this;
     }
 
     protected override void Print(ExpressionPrinter expressionPrinter) =>
@@ -119,6 +155,7 @@ internal sealed class WindowFunctionSqlExpression : SqlExpression
 
     public override bool Equals(object? obj) =>
         obj is WindowFunctionSqlExpression other
+        && base.Equals(other)
         && FunctionName == other.FunctionName
         && Arguments.SequenceEqual(other.Arguments)
         && Partitions.SequenceEqual(other.Partitions)
@@ -130,6 +167,7 @@ internal sealed class WindowFunctionSqlExpression : SqlExpression
     public override int GetHashCode()
     {
         var hash = new HashCode();
+        hash.Add(base.GetHashCode());
         hash.Add(FunctionName);
         foreach (var a in Arguments) hash.Add(a);
         foreach (var p in Partitions) hash.Add(p);

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpressionWrapper.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowFunctionSqlExpressionWrapper.cs
@@ -54,7 +54,7 @@ internal static class WindowFunctionSqlExpressionWrapper
         {
             if (node is SqlFragmentExpression fragment
                 && fragment.Sql.StartsWith(PlaceholderPrefix, StringComparison.Ordinal)
-                && _stash.Remove(fragment.Sql, out var original))
+                && _stash.TryGetValue(fragment.Sql, out var original))
             {
                 return original;
             }

--- a/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowSpecSqlExpression.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore.RelationalExtensions/Infrastructure/Internal/WindowSpecSqlExpression.cs
@@ -119,6 +119,7 @@ internal sealed class WindowSpecSqlExpression : SqlExpression
 
     public override bool Equals(object? obj) =>
         obj is WindowSpecSqlExpression other
+        && base.Equals(other)
         && Partitions.SequenceEqual(other.Partitions)
         && Orderings.SequenceEqual(other.Orderings)
         && FrameType == other.FrameType
@@ -128,6 +129,7 @@ internal sealed class WindowSpecSqlExpression : SqlExpression
     public override int GetHashCode()
     {
         var hash = new HashCode();
+        hash.Add(base.GetHashCode());
         foreach (var p in Partitions) hash.Add(p);
         foreach (var o in Orderings) hash.Add(o);
         hash.Add(FrameType);

--- a/tests/ExpressiveSharp.Tests/RelationalExtensions/WindowFunctionSqlExpressionTests.cs
+++ b/tests/ExpressiveSharp.Tests/RelationalExtensions/WindowFunctionSqlExpressionTests.cs
@@ -1,0 +1,75 @@
+#pragma warning disable EF1001
+
+using System.Linq.Expressions;
+using ExpressiveSharp.EntityFrameworkCore.RelationalExtensions.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ExpressiveSharp.Tests.RelationalExtensions;
+
+[TestClass]
+public class WindowFunctionSqlExpressionTests
+{
+    private static readonly SqlFragmentExpression ColPrice = new("[Price]");
+    private static readonly SqlFragmentExpression ColTotal = new("[Total]");
+    private static readonly SqlFragmentExpression ColCustomerId = new("[CustomerId]");
+
+    private static string Print(Expression expr)
+    {
+        var printer = new ExpressionPrinter();
+        printer.Visit(expr);
+        return printer.ToString();
+    }
+
+    private static WindowFunctionSqlExpression MakeSum(Type type) =>
+        new(
+            "SUM",
+            arguments: [ColPrice],
+            partitions: [ColCustomerId],
+            orderings: [new OrderingExpression(ColPrice, ascending: true)],
+            type: type,
+            typeMapping: null);
+
+    private sealed class ReplacingVisitor(Expression from, Expression to) : ExpressionVisitor
+    {
+        public override Expression? Visit(Expression? node)
+            => ReferenceEquals(node, from) ? to : base.Visit(node);
+    }
+
+    [TestMethod]
+    public void VisitChildren_ReplacedArgument_IsReflectedInTheResult()
+    {
+        var expr = MakeSum(typeof(double));
+
+        var visited = new ReplacingVisitor(ColPrice, ColTotal).Visit(expr)!;
+
+        var printed = Print(visited);
+        StringAssert.Contains(printed, "[Total]");
+    }
+
+    [TestMethod]
+    public void Equals_DifferingClrType_IsNotEqual()
+    {
+        var asDouble = MakeSum(typeof(double));
+        var asDecimal = MakeSum(typeof(decimal));
+
+        Assert.AreNotEqual(asDouble, asDecimal);
+    }
+
+    [TestMethod]
+    public void UnwrapAll_DuplicatedPlaceholder_RestoresBothOccurrences()
+    {
+        var windowFunction = MakeSum(typeof(double));
+
+        var wrapped = WindowFunctionSqlExpressionWrapper.WrapAll(windowFunction, out var stash);
+        Assert.AreEqual(1, stash.Count);
+
+        var duplicated = Expression.Block(wrapped, wrapped);
+
+        var unwrapped = (BlockExpression)WindowFunctionSqlExpressionWrapper.UnwrapAll(duplicated, stash);
+
+        Assert.IsInstanceOfType<WindowFunctionSqlExpression>(unwrapped.Expressions[0]);
+        Assert.IsInstanceOfType<WindowFunctionSqlExpression>(unwrapped.Expressions[1]);
+    }
+}


### PR DESCRIPTION
WindowFunctionSqlExpression.VisitChildren served two masters: rendering SQL for
QuerySqlGenerator and answering EF's rewrite passes — and it discarded the
latter's results, so alias remapping and pushdown silently lost their rewrites.
Now self-renders only for QuerySqlGenerator and rebuilds children for every
other visitor. Also chains SqlExpression's Type/TypeMapping into equality on
all three window expression types, and makes the nullability-wrapper unwrap
idempotent (duplicated placeholders no longer leak literal __wf_placeholder_N
into the SQL).
