### PR TITLE
remove unused constraints

### DIFF
--- a/src/ExpressiveSharp.EntityFrameworkCore/Extensions/ExpressiveQueryableEfCoreExtensions.cs
+++ b/src/ExpressiveSharp.EntityFrameworkCore/Extensions/ExpressiveQueryableEfCoreExtensions.cs
@@ -55,7 +55,6 @@ public static class ExpressiveQueryableEfCoreExtensions
     public static IExpressiveQueryable<TEntity> TagWith<TEntity>(
         this IExpressiveQueryable<TEntity> source,
         string tag)
-        where TEntity : class
         => EntityFrameworkQueryableExtensions.TagWith(source, tag).AsExpressive();
 
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -63,7 +62,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
         [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
-        where TEntity : class
         => EntityFrameworkQueryableExtensions.TagWithCallSite(source, filePath, lineNumber).AsExpressive();
 
     // Include / ThenInclude run at runtime, not intercepted.
@@ -108,7 +106,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -117,7 +114,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -126,7 +122,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -135,7 +130,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -144,7 +138,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -153,7 +146,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -162,7 +154,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -171,7 +162,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -180,7 +170,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -189,88 +178,87 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, bool> predicate,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<int> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<int> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<int?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<int?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<long> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<long> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<long?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<long?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<float> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<float> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<float?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<float?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<decimal> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<decimal> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<decimal?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<decimal?> SumAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, int?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, long?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<float> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<float> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<float?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<float?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, float?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<double?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<double?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, double?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<decimal> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<decimal> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static Task<decimal?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal?> selector, CancellationToken cancellationToken = default) where TEntity : class => throw new UnreachableException(InterceptedMessage);
+    public static Task<decimal?> AverageAsync<TEntity>(this IExpressiveQueryable<TEntity> source, Func<TEntity, decimal?> selector, CancellationToken cancellationToken = default) => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -278,7 +266,6 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, TResult> selector,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 
     [PolyfillTarget(typeof(EntityFrameworkQueryableExtensions))]
@@ -287,6 +274,5 @@ public static class ExpressiveQueryableEfCoreExtensions
         this IExpressiveQueryable<TEntity> source,
         Func<TEntity, TResult> selector,
         CancellationToken cancellationToken = default)
-        where TEntity : class
         => throw new UnreachableException(InterceptedMessage);
 }

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/AsyncQueryableTestBase.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Infrastructure/AsyncQueryableTestBase.cs
@@ -325,4 +325,25 @@ public abstract class AsyncQueryableTestBase : EFCoreRelationalTestBase
 
         Assert.IsNull(result);
     }
+
+    [TestMethod]
+    public async Task SumAsync_OverValueTypeProjection_WithModernSyntax_Executes()
+    {
+        var result = await Context.Orders.AsExpressiveDbSet()
+            .Select(o => o.Price)
+            .SumAsync(x => x switch { >= 50 => x, _ => 0.0 });
+
+        Assert.AreEqual(245.0, result);
+    }
+
+    [TestMethod]
+    public async Task FirstAsync_OverValueTypeProjection_Executes()
+    {
+        var result = await Context.Orders.AsExpressiveDbSet()
+            .Select(o => o.Id)
+            .OrderBy(x => x)
+            .FirstAsync(x => x > 2);
+
+        Assert.AreEqual(3, result);
+    }
 }

--- a/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/StubSignatureTests.cs
+++ b/tests/ExpressiveSharp.EntityFrameworkCore.IntegrationTests/Tests/StubSignatureTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ExpressiveSharp.EntityFrameworkCore.IntegrationTests.Tests;
+
+[TestClass]
+public class StubSignatureTests
+{
+    [TestMethod]
+    public void Stubs_TEntityClassConstraint_MatchesEfCoreTargets()
+    {
+        var efNamesWithClassConstraint = typeof(EntityFrameworkQueryableExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.IsGenericMethodDefinition)
+            .ToLookup(m => m.Name, HasClassConstraint);
+
+        var overConstrained = typeof(ExpressiveQueryableEfCoreExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.IsGenericMethodDefinition && efNamesWithClassConstraint.Contains(m.Name))
+            .Where(m => HasClassConstraint(m) && !efNamesWithClassConstraint[m.Name].Any(c => c))
+            .Select(m => m.ToString())
+            .ToList();
+
+        Assert.AreEqual(0, overConstrained.Count);
+    }
+
+    private static bool HasClassConstraint(MethodInfo method) =>
+        method.GetGenericArguments()[0].GenericParameterAttributes
+            .HasFlag(GenericParameterAttributes.ReferenceTypeConstraint);
+}


### PR DESCRIPTION
Before: expressive overloads would only bind to reference types. that was a bad copy/paste. Now it binds properly to value types as well