### PR TITLE
fix null guard

### DIFF
--- a/src/ExpressiveSharp/Transformers/RemoveNullConditionalPatterns.cs
+++ b/src/ExpressiveSharp/Transformers/RemoveNullConditionalPatterns.cs
@@ -119,8 +119,6 @@ public sealed class RemoveNullConditionalPatterns : ExpressionVisitor, IExpressi
     private static bool ExpressionsEqual(Expression a, Expression b)
     {
         if (a == b) return true;
-        if (a is ParameterExpression pa && b is ParameterExpression pb)
-            return pa.Name == pb.Name && pa.Type == pb.Type;
         if (a is MemberExpression ma && b is MemberExpression mb)
             return ma.Member == mb.Member
                 && ma.Expression is not null && mb.Expression is not null

--- a/tests/ExpressiveSharp.Tests/Transformers/RemoveNullConditionalPatternsTests.cs
+++ b/tests/ExpressiveSharp.Tests/Transformers/RemoveNullConditionalPatternsTests.cs
@@ -243,4 +243,23 @@ public class RemoveNullConditionalPatternsTests
 
         Assert.AreSame(expr, result);
     }
+
+    [TestMethod]
+    public void DistinctParametersWithSameName_GuardIsKept()
+    {
+        var x1 = Expression.Parameter(typeof(NullTestInner), "x");
+        var x2 = Expression.Parameter(typeof(NullTestInner), "x");
+
+        var conditional = Expression.Condition(
+            Expression.NotEqual(x1, Expression.Constant(null, typeof(NullTestInner))),
+            Expression.Property(x2, nameof(NullTestInner.Value)),
+            Expression.Constant(null, typeof(string)));
+
+        var lambda = Expression.Lambda<Func<NullTestInner?, NullTestInner?, string?>>(conditional, x1, x2);
+
+        var transformed = (Expression<Func<NullTestInner?, NullTestInner?, string?>>)_sut.Transform(lambda);
+        var compiled = transformed.Compile();
+
+        Assert.IsNull(compiled(null, new NullTestInner { Value = "bob" }));
+    }
 }


### PR DESCRIPTION
bad code smell that allowed `(x1 != null ? x2.Foo : null)` to be reduced to x2.Foo. 